### PR TITLE
Fix get_code

### DIFF
--- a/starknet_devnet/__init__.py
+++ b/starknet_devnet/__init__.py
@@ -49,6 +49,9 @@ def _patch_poseidon_hash():
     starkware.cairo.common.poseidon_hash.poseidon_hash_many = getattr(
         poseidon_hash, "poseidon_hash_many"
     )
+    starkware.cairo.common.poseidon_hash.poseidon_hash_single = getattr(
+        poseidon_hash, "poseidon_hash_single"
+    )
     starkware.cairo.common.poseidon_hash.poseidon_perm = getattr(
         poseidon_hash, "poseidon_perm"
     )

--- a/test/test_declare_v2.py
+++ b/test/test_declare_v2.py
@@ -27,6 +27,7 @@ from .shared import (
 )
 from .test_state_update import get_state_update
 from .util import (
+    assert_contract_code_present,
     assert_hex_equal,
     assert_tx_status,
     assert_undeclared_class,
@@ -229,7 +230,7 @@ def test_v2_contract_interaction():
 
 @pytest.mark.declare
 @devnet_in_background(*PREDEPLOY_ACCOUNT_CLI_ARGS)
-def test_v2_get_full_contract():
+def test_getting_contract_artifacts():
     """Test for declare, deploy and get full contract"""
 
     contract_class, _, compiled_class_hash = load_cairo1_contract()
@@ -257,7 +258,11 @@ def test_v2_get_full_contract():
         tx_hash=deploy_info["tx_hash"], expected_tx_status="ACCEPTED_ON_L2"
     )
 
+    # get_full_contract
     full_contract = get_full_contract_raw(contract_address=deploy_info["address"])
     assert full_contract.status_code == 200
     sierra = ContractClass.load(full_contract.json())
     assert load_sierra(CONTRACT_1_PATH) == sierra
+
+    # get_code
+    assert_contract_code_present(deploy_info["address"])


### PR DESCRIPTION
## Usage related changes

- Close #458

## Development related changes

- Add one missing patch override from https://github.com/0xSpaceShard/starknet-devnet/pull/452

## Checklist:

- [x] Checked why tesnet's get_code is failing - it will be deprecated, but if anyone needs it in the next weeks, this PR presents a patch
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing - `./scripts/test.sh`
