### PR TITLE
Improve default cairo1 compiler error

### DIFF
--- a/starknet_devnet/compiler.py
+++ b/starknet_devnet/compiler.py
@@ -14,6 +14,7 @@ from starkware.starknet.services.api.contract_class.contract_class import (
 from starkware.starknet.services.api.contract_class.contract_class_utils import (
     compile_contract_class,
 )
+from starkware.starkware_utils.error_handling import StarkException
 
 from starknet_devnet.util import StarknetDevnetException
 
@@ -30,10 +31,22 @@ class DefaultContractClassCompiler(ContractClassCompiler):
     """Uses the default internal cairo-lang compiler"""
 
     def compile_contract_class(self, contract_class: ContractClass) -> CompiledClass:
-        return compile_contract_class(
-            contract_class,
-            compiler_args="--add-pythonic-hints --allowed-libfuncs-list-name experimental_v0.1.0",
-        )
+        custom_err_msg = "\nFailed compilation from Sierra to Casm! Read more about starting Devnet with `--cairo-compiler-manifest <PATH>`"
+
+        try:
+            return compile_contract_class(
+                contract_class,
+                compiler_args="--add-pythonic-hints --allowed-libfuncs-list-name experimental_v0.1.0",
+            )
+        except PermissionError as error:
+            raise StarknetDevnetException(
+                code=StarknetErrorCode.COMPILATION_FAILED, message=custom_err_msg
+            ) from error
+        except StarkException as stark_exception:
+            raise StarknetDevnetException(
+                code=stark_exception.code,
+                message=stark_exception.message + custom_err_msg,
+            ) from stark_exception
 
 
 class CustomContractClassCompiler(ContractClassCompiler):


### PR DESCRIPTION
## Usage related changes

- Several users have already run into getting errors like:
```
StarknetPluginError: Declaring contract failed: [Errno 13] Permission denied: '/home/maciejka/.cache/pypoetry/virtualenvs/starknet-dai-bridge-e9QJjikr-py3.9/lib/python3.9/site-packages/starkware/starknet/compiler/v1/bin/starknet-sierra-compile'
```
and
```
Compilation failed. Error: Invalid Sierra program.
```

This PR should improve the UX by providing a more meaningful error.

## Development related changes

- Didn't add a test because it would require declaring a contract that was compiled with an alternative compiler version.

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [ ] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [ ] Linked the issues which this PR resolves
- [ ] Updated the tests
- [ ] All tests are passing - `./scripts/test.sh`
