### PR TITLE
Fix failing isinstance checks in syscalls with Rust VM

### DIFF
--- a/starknet_devnet/cairo_rs_py_patch.py
+++ b/starknet_devnet/cairo_rs_py_patch.py
@@ -592,7 +592,6 @@ def cairo_rs_py_validate_read_only_segments(self, runner: CairoRunner):
 
 
 def cairo_rs_py_get_felt_range(self, start_addr: Any, end_addr: Any) -> List[int]:
-    print(type(start_addr))
     assert isinstance(start_addr, RelocatableValue)
     assert isinstance(end_addr, RelocatableValue)
     assert start_addr.segment_index == end_addr.segment_index, (

--- a/starknet_devnet/cairo_rs_py_patch.py
+++ b/starknet_devnet/cairo_rs_py_patch.py
@@ -590,22 +590,23 @@ def cairo_rs_py_validate_read_only_segments(self, runner: CairoRunner):
         )
         runner.mark_as_accessed(address=segment_ptr, size=segment_size)
 
+
 def cairo_rs_py_get_felt_range(self, start_addr: Any, end_addr: Any) -> List[int]:
-        print(type(start_addr))
-        assert isinstance(start_addr, RelocatableValue)
-        assert isinstance(end_addr, RelocatableValue)
-        assert start_addr.segment_index == end_addr.segment_index, (
-            "Inconsistent start and end segment indices "
-            f"({start_addr.segment_index} != {end_addr.segment_index})."
-        )
+    print(type(start_addr))
+    assert isinstance(start_addr, RelocatableValue)
+    assert isinstance(end_addr, RelocatableValue)
+    assert start_addr.segment_index == end_addr.segment_index, (
+        "Inconsistent start and end segment indices "
+        f"({start_addr.segment_index} != {end_addr.segment_index})."
+    )
 
-        assert start_addr.offset <= end_addr.offset, (
-            "The start offset cannot be greater than the end offset"
-            f"({start_addr.offset} > {end_addr.offset})."
-        )
+    assert start_addr.offset <= end_addr.offset, (
+        "The start offset cannot be greater than the end offset"
+        f"({start_addr.offset} > {end_addr.offset})."
+    )
 
-        size = end_addr.offset - start_addr.offset
-        return self.segments.memory.get_range_as_ints(addr=start_addr, size=size)
+    size = end_addr.offset - start_addr.offset
+    return self.segments.memory.get_range_as_ints(addr=start_addr, size=size)
 
 
 def cairo_rs_py_monkeypatch():

--- a/starknet_devnet/cairo_rs_py_patch.py
+++ b/starknet_devnet/cairo_rs_py_patch.py
@@ -58,6 +58,7 @@ from starkware.starknet.core.os.contract_class.deprecated_class_hash import (
 from starkware.starknet.core.os.syscall_handler import (
     BusinessLogicSyscallHandler,
     DeprecatedBlSyscallHandler,
+    SyscallHandlerBase,
 )
 from starkware.starknet.definitions.error_codes import StarknetErrorCode
 from starkware.starknet.definitions.general_config import StarknetGeneralConfig
@@ -589,6 +590,23 @@ def cairo_rs_py_validate_read_only_segments(self, runner: CairoRunner):
         )
         runner.mark_as_accessed(address=segment_ptr, size=segment_size)
 
+def cairo_rs_py_get_felt_range(self, start_addr: Any, end_addr: Any) -> List[int]:
+        print(type(start_addr))
+        assert isinstance(start_addr, RelocatableValue)
+        assert isinstance(end_addr, RelocatableValue)
+        assert start_addr.segment_index == end_addr.segment_index, (
+            "Inconsistent start and end segment indices "
+            f"({start_addr.segment_index} != {end_addr.segment_index})."
+        )
+
+        assert start_addr.offset <= end_addr.offset, (
+            "The start offset cannot be greater than the end offset"
+            f"({start_addr.offset} > {end_addr.offset})."
+        )
+
+        size = end_addr.offset - start_addr.offset
+        return self.segments.memory.get_range_as_ints(addr=start_addr, size=size)
+
 
 def cairo_rs_py_monkeypatch():
     setattr(ExecuteEntryPoint, "_execute", cairo_rs_py_execute)
@@ -642,3 +660,4 @@ def cairo_rs_py_monkeypatch():
         cairo_rs_py_get_runtime_type,
     )
     setattr(syscall_utils.HandlerException, "__str__", handler_exception__str__)
+    setattr(SyscallHandlerBase, "_get_felt_range", cairo_rs_py_get_felt_range)

--- a/starknet_devnet/cairo_rs_py_patch.py
+++ b/starknet_devnet/cairo_rs_py_patch.py
@@ -598,12 +598,10 @@ def cairo_rs_py_get_felt_range(self, start_addr: Any, end_addr: Any) -> List[int
         "Inconsistent start and end segment indices "
         f"({start_addr.segment_index} != {end_addr.segment_index})."
     )
-
     assert start_addr.offset <= end_addr.offset, (
         "The start offset cannot be greater than the end offset"
         f"({start_addr.offset} > {end_addr.offset})."
     )
-
     size = end_addr.offset - start_addr.offset
     return self.segments.memory.get_range_as_ints(addr=start_addr, size=size)
 


### PR DESCRIPTION
Fixes a bug causing certain syscalls to fail when running with cairo_rs_py. This bug was first discovered by running a contract that emits an event. It is caused by an isinstance check in the method `SyscallHandlerBase._get_felt_range` that failed due to cairo_rs_py and cairo-lang using a similar but different `RelocatableValue` class.

In order to fix this, the method `SyscallHandlerBase._get_felt_range` was overriden in the patch so that it uses `cairo_rs_py.RelocatableValue` for its isinstance checks.

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [ ] Linked the issues which this PR resolves
- [ ] Updated the tests
- [x] All tests are passing - `./scripts/test.sh`
