### PR TITLE
starknet_devnet/compiler.py: fix error messages

### DIFF
--- a/starknet_devnet/compiler.py
+++ b/starknet_devnet/compiler.py
@@ -44,12 +44,12 @@ Failed compilation from Sierra to Casm! Read more about starting Devnet with --c
         except PermissionError as permission_error:
             raise StarknetDevnetException(
                 code=StarknetErrorCode.COMPILATION_FAILED,
-                message=permission_error + custom_err_msg,
+                message=str(permission_error) + custom_err_msg,
             ) from permission_error
         except StarkException as stark_exception:
             raise StarknetDevnetException(
-                code=stark_exception.code,
-                message=stark_exception.message + custom_err_msg,
+                code=StarknetErrorCode.COMPILATION_FAILED,
+                message=(stark_exception.message or "") + custom_err_msg,
             ) from stark_exception
 
 


### PR DESCRIPTION
## Usage related changes

this was discovered due to https://github.com/0xSpaceShard/starknet-devnet/issues/478

errors aren't displayed correctly due to typing errors when concatenating error messages:

```
AssertionError: StarknetPluginError: Declaring contract failed: unsupported operand type(s) for +: 'PermissionError' and 'str'
```

also fixed the following exception message in the `StarkException` clause because `message` is typed `Optional[str]`

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [ ] Linked the issues which this PR resolves
- [ ] Updated the tests
- [ ] All tests are passing - `./scripts/test.sh`
