### PR TITLE
Fix for missing __latest_state at the initialization of StarknetWrapper

### DIFF
--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -176,6 +176,7 @@ class StarknetWrapper:
 
             await self.__preserve_current_state(starknet.state.state)
             await self.__create_genesis_block()
+            self.__latest_state = self.get_state().copy()
             self.__initialized = True
 
     async def __create_genesis_block(self):


### PR DESCRIPTION
## Usage related changes

- bugfix for missing __latest_state at the initialization of StarknetWrapper

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [x] Linked the issues which this PR resolves
- [ ] Updated the tests
- [x] All tests are passing - `./scripts/test.sh`
