### PR TITLE
bugfix for __postman_wrapper on init

### DIFF
--- a/starknet_devnet/postman_wrapper.py
+++ b/starknet_devnet/postman_wrapper.py
@@ -106,7 +106,7 @@ and that the Messaging Contract is deployed at the provided address ({contract_a
         """Handles all pending L1 <> L2 messages and sends them to the other layer."""
 
         if self.__postman_wrapper is None:
-            return ([],[])
+            return ([], [])
 
         postman = self.__postman_wrapper.postman
 

--- a/starknet_devnet/postman_wrapper.py
+++ b/starknet_devnet/postman_wrapper.py
@@ -106,7 +106,7 @@ and that the Messaging Contract is deployed at the provided address ({contract_a
         """Handles all pending L1 <> L2 messages and sends them to the other layer."""
 
         if self.__postman_wrapper is None:
-            return ([], [])
+            return ({}, [])
 
         postman = self.__postman_wrapper.postman
 

--- a/starknet_devnet/postman_wrapper.py
+++ b/starknet_devnet/postman_wrapper.py
@@ -106,7 +106,7 @@ and that the Messaging Contract is deployed at the provided address ({contract_a
         """Handles all pending L1 <> L2 messages and sends them to the other layer."""
 
         if self.__postman_wrapper is None:
-            return {}
+            return ([],[])
 
         postman = self.__postman_wrapper.postman
 

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -755,26 +755,28 @@ class StarknetWrapper:
         return transaction.hash_value
 
     async def postman_flush(self) -> dict:
-        """Handles all pending L1 <> L2 messages and sends them to the other layer."""
+        """Handles all pending L1 <> L2 messages if such exists and sends them to the other layer."""
 
         state = self.get_state()
         # Generate transactions in PostmanWrapper
         parsed_l1_l2_messages, transactions_to_execute = await self.l1l2.flush(state)
 
         # Execute transactions inside StarknetWrapper
-        tx_hashes = []
-        for transaction in transactions_to_execute:
-            tx_hashes.append(hex(transaction.hash_value))
-            async with self.__get_transaction_handler() as tx_handler:
-                tx_handler.internal_tx = transaction
-                tx_handler.execution_info = await state.execute_tx(
-                    tx_handler.internal_tx
-                )
-                tx_handler.internal_calls = (
-                    tx_handler.execution_info.call_info.internal_calls
-                )
+        if parsed_l1_l2_messages and transactions_to_execute:
+            tx_hashes = []
+            for transaction in transactions_to_execute:
+                tx_hashes.append(hex(transaction.hash_value))
+                async with self.__get_transaction_handler() as tx_handler:
+                    tx_handler.internal_tx = transaction
+                    tx_handler.execution_info = await state.execute_tx(
+                        tx_handler.internal_tx
+                    )
+                    tx_handler.internal_calls = (
+                        tx_handler.execution_info.call_info.internal_calls
+                    )
 
-        parsed_l1_l2_messages["generated_l2_transactions"] = tx_hashes
+            parsed_l1_l2_messages["generated_l2_transactions"] = tx_hashes
+
         return parsed_l1_l2_messages
 
     async def update_pending_block(self, state_update: BlockStateUpdate = None):

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -760,10 +760,10 @@ class StarknetWrapper:
         state = self.get_state()
         # Generate transactions in PostmanWrapper
         parsed_l1_l2_messages, transactions_to_execute = await self.l1l2.flush(state)
+        tx_hashes = []
 
         # Execute transactions inside StarknetWrapper
         if parsed_l1_l2_messages and transactions_to_execute:
-            tx_hashes = []
             for transaction in transactions_to_execute:
                 tx_hashes.append(hex(transaction.hash_value))
                 async with self.__get_transaction_handler() as tx_handler:
@@ -775,8 +775,7 @@ class StarknetWrapper:
                         tx_handler.execution_info.call_info.internal_calls
                     )
 
-            parsed_l1_l2_messages["generated_l2_transactions"] = tx_hashes
-
+        parsed_l1_l2_messages["generated_l2_transactions"] = tx_hashes
         return parsed_l1_l2_messages
 
     async def update_pending_block(self, state_update: BlockStateUpdate = None):

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -755,7 +755,7 @@ class StarknetWrapper:
         return transaction.hash_value
 
     async def postman_flush(self) -> dict:
-        """Handles all pending L1 <> L2 messages if such exists and sends them to the other layer."""
+        """Handles all pending L1 <> L2 messages and sends them to the other layer."""
 
         state = self.get_state()
         # Generate transactions in PostmanWrapper

--- a/test/test_postman.py
+++ b/test/test_postman.py
@@ -401,3 +401,10 @@ def test_invalid_starknet_function_call_load_l1_messaging_contract():
     msg = "L1 network or StarknetMessaging contract address not specified"
     assert resp.status_code == 400
     assert msg in json_error_message
+
+
+@devnet_in_background(*PREDEPLOY_ACCOUNT_CLI_ARGS)
+def test_postman_flush():
+    # Test flush without load l1 contract
+    flush_response = flush()
+    assert flush_response["generated_l2_transactions"] == []

--- a/test/test_postman.py
+++ b/test/test_postman.py
@@ -405,6 +405,6 @@ def test_invalid_starknet_function_call_load_l1_messaging_contract():
 
 @devnet_in_background(*PREDEPLOY_ACCOUNT_CLI_ARGS)
 def test_postman_flush():
-    # Test flush without load l1 contract
+    """Test flush without load l1 contract"""
     flush_response = flush()
     assert flush_response["generated_l2_transactions"] == []


### PR DESCRIPTION
## Usage related changes

- bugfix for `flush` endpoint call without previous call of `load_l1_messaging_contract`

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing - `./scripts/test.sh`
