### PR TITLE
Renamed transaction param for rpc simulateTransactions

### DIFF
--- a/starknet_devnet/blueprints/rpc/rpc_trace_spec.py
+++ b/starknet_devnet/blueprints/rpc/rpc_trace_spec.py
@@ -59,8 +59,8 @@ RPC_SPECIFICATION_TRACE = r"""
                     }
                 },
                 {
-                    "name": "transaction",
-                    "description": "The transaction to simulate",
+                    "name": "transactions",
+                    "description": "The transactions to simulate",
                     "required": true,
                     "schema": {
                         "type": "array",

--- a/starknet_devnet/blueprints/rpc/transactions.py
+++ b/starknet_devnet/blueprints/rpc/transactions.py
@@ -228,7 +228,7 @@ async def simulate_transaction(
     SKIP_EXECUTE SimulationFlag is not supported.
     """
     await assert_block_id_is_valid(block_id)
-    transactions = list(map(make_transaction, transaction))
+    transactions = list(map(make_transaction, transactions))
     skip_validate = SimulationFlag.SKIP_VALIDATE.name in simulation_flags
     skip_execute = SimulationFlag.SKIP_EXECUTE.name in simulation_flags
     simulated_transactions = []

--- a/starknet_devnet/blueprints/rpc/transactions.py
+++ b/starknet_devnet/blueprints/rpc/transactions.py
@@ -220,7 +220,7 @@ async def estimate_fee(request: List[RpcBroadcastedTxn], block_id: BlockId) -> l
 @validate_schema("simulateTransaction")
 async def simulate_transaction(
     block_id: BlockId,
-    transaction: List[RpcTransaction],
+    transactions: List[RpcTransaction],
     simulation_flags: List[SimulationFlag],
 ) -> list:
     """

--- a/test/rpc/test_rpc_traces.py
+++ b/test/rpc/test_rpc_traces.py
@@ -58,7 +58,7 @@ def test_skip_execute_flag(deploy_account_details):
         "starknet_simulateTransaction",
         {
             "block_id": "latest",
-            "transaction": [rpc_deploy_account_tx],
+            "transactions": [rpc_deploy_account_tx],
             "simulation_flags": [SimulationFlag.SKIP_EXECUTE.name],
         },
     )
@@ -87,7 +87,7 @@ def test_simulate_transaction_invoke():
         "starknet_simulateTransaction",
         {
             "block_id": "latest",
-            "transaction": [invoke_transaction],
+            "transactions": [invoke_transaction],
             "simulation_flags": [],
         },
     )["result"][0]
@@ -95,7 +95,7 @@ def test_simulate_transaction_invoke():
         "starknet_simulateTransaction",
         {
             "block_id": "latest",
-            "transaction": [invoke_transaction],
+            "transactions": [invoke_transaction],
             "simulation_flags": [SimulationFlag.SKIP_VALIDATE.name],
         },
     )["result"][0]
@@ -157,7 +157,7 @@ def test_simulate_transaction_declare_v1(declare_content):
         "starknet_simulateTransaction",
         {
             "block_id": "latest",
-            "transaction": [declare_transaction],
+            "transactions": [declare_transaction],
             "simulation_flags": [],
         },
     )["result"][0]
@@ -165,7 +165,7 @@ def test_simulate_transaction_declare_v1(declare_content):
         "starknet_simulateTransaction",
         {
             "block_id": "latest",
-            "transaction": [declare_transaction],
+            "transactions": [declare_transaction],
             "simulation_flags": [SimulationFlag.SKIP_VALIDATE.name],
         },
     )["result"][0]
@@ -215,7 +215,7 @@ def test_simulate_transaction_declare_v2():
         "starknet_simulateTransaction",
         {
             "block_id": "latest",
-            "transaction": [declare_transaction],
+            "transactions": [declare_transaction],
             "simulation_flags": [],
         },
     )["result"][0]
@@ -223,7 +223,7 @@ def test_simulate_transaction_declare_v2():
         "starknet_simulateTransaction",
         {
             "block_id": "latest",
-            "transaction": [declare_transaction],
+            "transactions": [declare_transaction],
             "simulation_flags": [SimulationFlag.SKIP_VALIDATE.name],
         },
     )["result"][0]
@@ -251,7 +251,7 @@ def test_simulate_transaction_deploy_account(deploy_account_details):
         "starknet_simulateTransaction",
         {
             "block_id": "latest",
-            "transaction": [rpc_deploy_account_tx],
+            "transactions": [rpc_deploy_account_tx],
             "simulation_flags": [],
         },
     )["result"][0]
@@ -259,7 +259,7 @@ def test_simulate_transaction_deploy_account(deploy_account_details):
         "starknet_simulateTransaction",
         {
             "block_id": "latest",
-            "transaction": [rpc_deploy_account_tx],
+            "transactions": [rpc_deploy_account_tx],
             "simulation_flags": [SimulationFlag.SKIP_VALIDATE.name],
         },
     )["result"][0]


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

- Renamed `transaction` param to `transactions` for rpc simulateTransactions, because this name will change in the rpc spec

## Development related changes

N/A

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [ ] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing - `./scripts/test.sh`
