### PR TITLE
Fix `rpc_declare_transaction` logic to also return DeclareV2

### DIFF
--- a/starknet_devnet/blueprints/rpc/structures/payloads.py
+++ b/starknet_devnet/blueprints/rpc/structures/payloads.py
@@ -7,7 +7,7 @@ RPC payload structures
 from __future__ import annotations
 
 from enum import Enum, auto
-from typing import Callable, Dict, List, Optional, Union, cast
+from typing import Callable, Dict, List, Optional, Union
 
 from marshmallow.exceptions import MarshmallowError
 from starkware.starknet.definitions.constants import QUERY_VERSION_BASE
@@ -227,6 +227,7 @@ class RpcDeclareTransaction(RpcTransactionCommon):
 
 
 class RpcDeclareV2Transaction(RpcDeclareTransaction):
+    """TypedDict for rpc declare transaction version 2"""
 
     compiled_class_hash: Felt
 
@@ -325,7 +326,7 @@ def rpc_declare_transaction(transaction: DeclareSpecificInfo) -> RpcDeclareTrans
     """
     Convert gateway declare transaction to rpc format
     """
-    txn = {
+    common_data = {
         "class_hash": rpc_felt(transaction.class_hash),
         "sender_address": rpc_felt(transaction.sender_address),
         "transaction_hash": rpc_felt(transaction.transaction_hash),
@@ -336,9 +337,13 @@ def rpc_declare_transaction(transaction: DeclareSpecificInfo) -> RpcDeclareTrans
         "type": rpc_txn_type(transaction.tx_type.name),
     }
     if transaction.compiled_class_hash is not None:
-        txn["compiled_class_hash"] = rpc_felt(transaction.compiled_class_hash)
-        return cast(RpcDeclareV2Transaction, txn)
-    return cast(RpcDeclareTransaction, txn)
+        txn: RpcDeclareV2Transaction = {
+            "compiled_class_hash": rpc_felt(transaction.compiled_class_hash),
+            **common_data,
+        }
+    else:
+        txn: RpcDeclareTransaction = {**common_data}
+    return txn
 
 
 def rpc_deploy_transaction(transaction: DeploySpecificInfo) -> RpcDeployTransaction:

--- a/starknet_devnet/blueprints/rpc/structures/payloads.py
+++ b/starknet_devnet/blueprints/rpc/structures/payloads.py
@@ -336,7 +336,7 @@ def rpc_declare_transaction(transaction: DeclareSpecificInfo) -> RpcDeclareTrans
         "nonce": rpc_felt(transaction.nonce),
         "type": rpc_txn_type(transaction.tx_type.name),
     }
-    if transaction.compiled_class_hash is not None:
+    if transaction.version == 2:
         txn: RpcDeclareV2Transaction = {
             "compiled_class_hash": rpc_felt(transaction.compiled_class_hash),
             **common_data,

--- a/test/rpc/test_rpc_transactions.py
+++ b/test/rpc/test_rpc_transactions.py
@@ -9,6 +9,7 @@ from test.account import (
     declare,
     declare_and_deploy_with_chargeable,
     get_nonce,
+    send_declare_v2,
 )
 from test.rpc.conftest import prepare_deploy_account_tx, rpc_deploy_account_from_gateway
 from test.rpc.rpc_utils import (
@@ -28,7 +29,7 @@ from test.shared import (
     STARKNET_CLI_ACCOUNT_ABI_PATH,
     SUPPORTED_RPC_TX_VERSION,
 )
-from test.test_declare_v2 import load_cairo1_contract
+from test.test_declare_v2 import assert_declare_v2_accepted, load_cairo1_contract
 from test.util import assert_tx_status, call, load_contract_class, mint, send_tx
 from typing import List
 
@@ -178,6 +179,46 @@ def test_get_transaction_by_hash_declare():
         "type": rpc_txn_type(block_tx["type"]),
         "sender_address": rpc_felt(PREDEPLOYED_ACCOUNT_ADDRESS),
         "class_hash": rpc_felt(block_tx["class_hash"]),
+    }
+
+
+@pytest.mark.usefixtures("devnet_with_account")
+def test_get_transaction_by_hash_declare_v2():
+    """
+    Get transaction by hash
+    """
+    contract_class, _, compiled_class_hash = load_cairo1_contract()
+
+    declaration_resp = send_declare_v2(
+        contract_class=contract_class,
+        compiled_class_hash=compiled_class_hash,
+        sender_address=PREDEPLOYED_ACCOUNT_ADDRESS,
+        sender_key=PREDEPLOYED_ACCOUNT_PRIVATE_KEY,
+    )
+    assert_declare_v2_accepted(declaration_resp)
+
+    declare_info = declaration_resp.json()
+    block = get_block_with_transaction(declare_info["tx_hash"])
+    block_tx = block["transactions"][0]
+    transaction_hash: str = declare_info["tx_hash"]
+    signature: Signature = [rpc_felt(sig) for sig in block_tx["signature"]]
+
+    resp = rpc_call(
+        "starknet_getTransactionByHash",
+        params={"transaction_hash": rpc_felt(transaction_hash)},
+    )
+    transaction = resp["result"]
+
+    assert transaction == {
+        "transaction_hash": rpc_felt(transaction_hash),
+        "max_fee": rpc_felt(block_tx["max_fee"]),
+        "version": hex(SUPPORTED_RPC_TX_VERSION),
+        "signature": signature,
+        "nonce": rpc_felt(0),
+        "type": rpc_txn_type(block_tx["type"]),
+        "sender_address": rpc_felt(PREDEPLOYED_ACCOUNT_ADDRESS),
+        "class_hash": rpc_felt(block_tx["class_hash"]),
+        "compiled_class_hash": rpc_felt(block_tx["compiled_class_hash"]),
     }
 
 


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

- `getBlockWithTxs`, `getBlockWithTxHashes` and `getTransactionByHash` now can return `DeclareV2` transaction

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

- changed `rpc_declare_transaction` function to match RPC spec

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [ ] Linked the issues which this PR resolves
- [x] Updated the tests
- [ ] All tests are passing - `./scripts/test.sh`
