### PR TITLE
Added `call_type` param to rpc `FunctionInvocation`

### DIFF
--- a/starknet_devnet/blueprints/rpc/structures/payloads.py
+++ b/starknet_devnet/blueprints/rpc/structures/payloads.py
@@ -1020,6 +1020,7 @@ def gateway_to_rpc_invocation(
         "contract_address",
         "entry_point_selector",
         "calldata",
+        "call_type",
         "caller_address",
         "entry_point_type",
         "class_hash",


### PR DESCRIPTION
## Usage related changes
Added `call_type` param to rpc `FunctionInvocation`, as it's in the starknet-spec. (https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_trace_api_openrpc.json)

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [ ] Linked the issues which this PR resolves
- [ ] Updated the tests
- [x] All tests are passing - `./scripts/test.sh`
