### PR TITLE
Support starknet_simulateTransactions

### DIFF
--- a/page/docs/guide/json-rpc-api.md
+++ b/page/docs/guide/json-rpc-api.md
@@ -34,7 +34,7 @@ Response:
 
 ## Trace API
 
-Out of [Starknet trace API RPC methods](https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_trace_api_openrpc.json), only `starknet_simulateTransaction` is supported.
+Out of [Starknet trace API RPC methods](https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_trace_api_openrpc.json), only `starknet_simulateTransaction` (and `starknet_simulateTransactions`) is supported.
 
 The official specification of `starknet_simulateTransaction` supports `simulation_flags` which can be `SKIP_VALIDATE` and `SKIP_EXECUTE`. At the moment, only `SKIP_VALIDATE` is supported. Dev info: `SKIP_EXECUTE` support is blocked by `InternalInvokeFunctionForSimulate.create_for_simulate` not supporting it. Return type `FUNCTION_INVOCATION` is modified according to suggestions by the Starkware team: `code_address` and `call_type` are replaced with `class_hash`.
 

--- a/starknet_devnet/blueprints/rpc/routes.py
+++ b/starknet_devnet/blueprints/rpc/routes.py
@@ -75,6 +75,7 @@ methods = {
     "addDeclareTransaction": add_declare_transaction,
     "addDeployAccountTransaction": add_deploy_account_transaction,
     "simulateTransaction": simulate_transaction,
+    "simulateTransactions": simulate_transaction,
 }
 
 rpc = Blueprint("rpc", __name__, url_prefix="/rpc")

--- a/test/rpc/conftest.py
+++ b/test/rpc/conftest.py
@@ -161,9 +161,7 @@ def fixture_latest_block_id(latest_block, request) -> dict:
     return _block_to_block_id(latest_block, request.param)
 
 
-@pytest.fixture(
-    name="deploy_account_details",
-)
+@pytest.fixture(name="deploy_account_details")
 def fixture_deploy_account_details() -> dict:
     """Deploy account transaction details"""
     return {


### PR DESCRIPTION
## Usage related changes

- Close #523 

## Development related changes

- Use parametrization in rpc simulation tests (parametrized simulation method)
- Add `dummy_consume_unused` to deal with unused background devnet fixture

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing - `./scripts/test.sh`
