### PR TITLE
Fix get_state_update when forking

### DIFF
--- a/starknet_devnet/blocks.py
+++ b/starknet_devnet/blocks.py
@@ -171,11 +171,14 @@ class DevnetBlocks:
         # now either an int or "latest"
         if block_number != LATEST_BLOCK_ID:
             self.__assert_block_number_in_range(block_number)
-            numeric_hash = self.__num2hash[block_number]
-            if numeric_hash in self.__state_updates:
-                return self.__state_updates[numeric_hash]
 
-            return await self.origin.get_state_update(block_hash=numeric_hash)
+            # if block_number not in mapping, poll origin
+            if block_number in self.__num2hash:
+                numeric_hash = self.__num2hash[block_number]
+                if numeric_hash in self.__state_updates:
+                    return self.__state_updates[numeric_hash]
+
+            return await self.origin.get_state_update(block_number=block_number)
 
         # now it's the latest
         return (

--- a/test/test_fork_feeder_gateway.py
+++ b/test/test_fork_feeder_gateway.py
@@ -429,3 +429,15 @@ def test_block_responses_by_hash():
     state_update_by_hash = get_block_traces({"blockHash": latest_block_hash})
     state_update_by_number = get_block_traces({"blockNumber": "latest"})
     assert state_update_by_hash == state_update_by_number
+
+
+@devnet_in_background(*TESTNET_FORK_PARAMS)
+def test_get_state_update():
+    """Test if get_state_update works on blocks not locally present"""
+
+    state_update = get_state_update(block_number=0)
+
+    # make sure we aren't receiving the block that devnet mines on startup
+    assert state_update["block_hash"].startswith("0x")
+    assert state_update["old_root"] == "0x0"
+    assert state_update["new_root"] != "0x0"


### PR DESCRIPTION
## Usage related changes

- When forking and getting state update of e.g. block with number 0, it would fail due to a bug. This is now fixed.
  - Bug reported [on Discord](https://discord.com/channels/793094838509764618/985824027950055434/threads/1148207412948516915).

## Development related changes

- Improve return type of `get_state_update` in `origin.py` (use `BlockStateUpdate` instead of `dict`).

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing - `./scripts/test.sh`
