### PR TITLE
Fix starknet_getCompiledCasm

### DIFF
--- a/crates/starknet-devnet-core/src/starknet/get_class_impls.rs
+++ b/crates/starknet-devnet-core/src/starknet/get_class_impls.rs
@@ -62,7 +62,9 @@ pub fn get_compiled_casm_impl(
     let contract_class = get_class_impl(starknet, &BlockId::Tag(BlockTag::Latest), class_hash)?;
     match contract_class {
         ContractClass::Cairo1(sierra_contract_class) => {
-            Ok(compile_sierra_contract(&sierra_contract_class)?)
+            let mut casm = compile_sierra_contract(&sierra_contract_class)?;
+            casm.pythonic_hints = None; // removes the extra key from serialized form
+            Ok(casm)
         }
         ContractClass::Cairo0(_) => Err(Error::StateError(StateError::NoneCasmClass(class_hash))),
     }

--- a/tests/integration/test_get_class.rs
+++ b/tests/integration/test_get_class.rs
@@ -265,7 +265,7 @@ async fn test_getting_class_after_block_abortion() {
 }
 
 #[tokio::test]
-async fn test_getting_compiled_casm_for_cairo0_or_non_existing_hash_have_to_return_class_hash_not_found_error()
+async fn getting_compiled_casm_for_cairo0_or_non_existing_hash_should_return_class_hash_not_found_error()
  {
     let devnet = BackgroundDevnet::spawn_with_additional_args(&["--account-class", "cairo0"])
         .await
@@ -280,7 +280,7 @@ async fn test_getting_compiled_casm_for_cairo0_or_non_existing_hash_have_to_retu
 
     // Felt::ONE is non existing class hash
     for el in [class_hash, Felt::ONE] {
-        match get_compiled_casm(&devnet, block_id, el).await.unwrap_err() {
+        match get_compiled_casm(&devnet, el).await.unwrap_err() {
             StarknetError::ClassHashNotFound => {}
             other => panic!("Unexpected error {:?}", other),
         }
@@ -288,7 +288,7 @@ async fn test_getting_compiled_casm_for_cairo0_or_non_existing_hash_have_to_retu
 }
 
 #[tokio::test]
-async fn test_getting_compiled_casm_for_cairo_1_have_to_succeed() {
+async fn getting_compiled_casm_for_cairo_1_should_succeed() {
     let devnet = BackgroundDevnet::spawn_with_additional_args(&["--account-class", "cairo1"])
         .await
         .expect("Could not start Devnet");
@@ -303,25 +303,26 @@ async fn test_getting_compiled_casm_for_cairo_1_have_to_succeed() {
     let class_hash =
         devnet.json_rpc_client.get_class_hash_at(block_id, account_address).await.unwrap();
 
-    let casm = get_compiled_casm(&devnet, block_id, class_hash).await.unwrap();
+    let casm = get_compiled_casm(&devnet, class_hash).await.unwrap();
     assert_eq!(casm.compiled_class_hash(), expected_casm_hash);
 }
 
 async fn get_compiled_casm(
     devnet: &BackgroundDevnet,
-    block_id: BlockId,
     class_hash: Felt,
 ) -> Result<CasmContractClass, StarknetError> {
     devnet
         .send_custom_rpc(
             "starknet_getCompiledCasm",
-            serde_json::json!({
-                "block_id": block_id,
-                "class_hash": format!("{:#x}", class_hash),
-            }),
+            serde_json::json!({ "class_hash": class_hash }),
         )
         .await
-        .map(|json_value| serde_json::from_value::<CasmContractClass>(json_value).unwrap())
+        .map(|json_value| {
+            if json_value.get("pythonic_hints").is_some() {
+                panic!("Expected no pythonic_hints; found some!");
+            }
+            serde_json::from_value::<CasmContractClass>(json_value).unwrap()
+        })
         .map_err(|err| {
             let json_rpc_error =
                 JsonRpcError { code: err.code, message: err.message.to_string(), data: err.data };

--- a/tests/integration/test_get_class.rs
+++ b/tests/integration/test_get_class.rs
@@ -318,6 +318,7 @@ async fn get_compiled_casm(
         )
         .await
         .map(|json_value| {
+            // Check done because `CasmContractClass` does not perfectly correspond to RPC spec
             if json_value.get("pythonic_hints").is_some() {
                 panic!("Expected no pythonic_hints; found some!");
             }

--- a/tests/integration/test_get_class.rs
+++ b/tests/integration/test_get_class.rs
@@ -319,9 +319,7 @@ async fn get_compiled_casm(
         .await
         .map(|json_value| {
             // Check done because `CasmContractClass` does not perfectly correspond to RPC spec
-            if json_value.get("pythonic_hints").is_some() {
-                panic!("Expected no pythonic_hints; found some!");
-            }
+            assert!(json_value.get("pythonic_hints").is_none());
             serde_json::from_value::<CasmContractClass>(json_value).unwrap()
         })
         .map_err(|err| {


### PR DESCRIPTION
## Usage related changes

- Close #712 

## Development related changes

- There was also an issue in the tests were `block_id` was unnecessarily specified, although not mentioned in the specs.
- Simplify test names.
- Serialize class hash Felt by relying on its implementation.

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)
  - All that are expected to pass are passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Compiled contract responses now exclude unnecessary metadata, providing a cleaner and more consistent output.
  - The underlying API has been simplified by reducing redundant parameters, ensuring more straightforward interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->