### PR TITLE
Address alternative call failure

### DIFF
--- a/crates/starknet-devnet-core/src/stack_trace.rs
+++ b/crates/starknet-devnet-core/src/stack_trace.rs
@@ -1,6 +1,7 @@
 // Copied with minor modifications from blockifier/src/execution/stack_trace.rs.
 // Try removing once included in a blockifier release.
 
+use blockifier::execution::call_info::CallInfo;
 use blockifier::execution::deprecated_syscalls::hint_processor::DeprecatedSyscallExecutionError;
 use blockifier::execution::errors::{
     ConstructorEntryPointExecutionError, EntryPointExecutionError,
@@ -54,6 +55,24 @@ pub struct ErrorStack {
 impl ErrorStack {
     pub fn from_str_err(s: &str) -> Self {
         Self { stack: vec![Frame::StringFrame(s.into())] }
+    }
+
+    pub fn from_inner_calls(_calls: &[CallInfo]) -> Self {
+        unimplemented!("Figure out how to get preamble_type")
+        // Self {
+        //     stack: calls
+        //         .iter()
+        //         .map(|_call| {
+        //             Frame::EntryPoint(EntryPointErrorFrame {
+        //                 depth: todo!(),
+        //                 preamble_type: todo!(),
+        //                 storage_address: todo!(),
+        //                 class_hash: todo!(),
+        //                 selector: todo!(),
+        //             })
+        //         })
+        //         .collect(),
+        // }
     }
 
     pub fn push(&mut self, frame: Frame) {


### PR DESCRIPTION
## Usage related changes

- As discussed [on Slack](https://spaceshard.slack.com/archives/C03QN20522D/p1735547866439019), `ENTRYPOINT_NOT_FOUND` is not the only error to be handled. Others should result in a generic `CONTRACT_ERROR`.
- Currently marked as draft as I have yet to figure out how to convert internal calls into an error stack (and if it should even be done on the internal call infos).

## Development related changes

<!-- How these changes affect the developers of this project. E.g. changes in dev tools, testing, CI/CD... -->

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [ ] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] No spelling errors - `./scripts/check_spelling.sh`
- [ ] Performed code self-review
- [ ] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [ ] Updated the docs if needed - `./website/README.md`
- [ ] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)
