### PR TITLE
Fix ResourcesBoundsExceedBalance error handling

### DIFF
--- a/crates/starknet-devnet-core/src/error.rs
+++ b/crates/starknet-devnet-core/src/error.rs
@@ -149,7 +149,7 @@ impl From<FeeCheckError> for Error {
 
 impl From<TransactionFeeError> for Error {
     fn from(value: TransactionFeeError) -> Self {
-        // TODO use clippy to force covering all cases explicitly
+        #[warn(clippy::wildcard_enum_match_arm)]
         match value {
             TransactionFeeError::FeeTransferError { .. }
             | TransactionFeeError::MaxFeeTooLow { .. }
@@ -162,7 +162,11 @@ impl From<TransactionFeeError> for Error {
             | TransactionFeeError::GasBoundsExceedBalance { .. } => {
                 TransactionValidationError::InsufficientAccountBalance.into()
             }
-            err => Error::TransactionFeeError(err),
+            err @ (TransactionFeeError::CairoResourcesNotContainedInFeeCosts
+            | TransactionFeeError::ExecuteFeeTransferError(_)
+            | TransactionFeeError::InsufficientFee { .. }
+            | TransactionFeeError::MissingL1GasBounds
+            | TransactionFeeError::StateError(_)) => Error::TransactionFeeError(err),
         }
     }
 }

--- a/crates/starknet-devnet-core/src/error.rs
+++ b/crates/starknet-devnet-core/src/error.rs
@@ -149,6 +149,7 @@ impl From<FeeCheckError> for Error {
 
 impl From<TransactionFeeError> for Error {
     fn from(value: TransactionFeeError) -> Self {
+        // TODO use clippy to force covering all cases explicitly
         match value {
             TransactionFeeError::FeeTransferError { .. }
             | TransactionFeeError::MaxFeeTooLow { .. }
@@ -157,6 +158,7 @@ impl From<TransactionFeeError> for Error {
                 TransactionValidationError::InsufficientResourcesForValidate.into()
             }
             TransactionFeeError::MaxFeeExceedsBalance { .. }
+            | TransactionFeeError::ResourcesBoundsExceedBalance { .. }
             | TransactionFeeError::GasBoundsExceedBalance { .. } => {
                 TransactionValidationError::InsufficientAccountBalance.into()
             }


### PR DESCRIPTION
## Usage related changes

- Fix the new error which arises when resource bounds not sufficient
  - Reported [on Slack](https://spaceshard.slack.com/archives/C03031Y0LKC/p1741950477837299?thread_ts=1741881598.201099&cid=C03031Y0LKC)

## Development related changes

- The assumption is that this would be discovered by existing tests if we tested with an adapted starknet-rs (under way).
- Added a clippy warning in case more enum variants are introduced to force us to cover them.

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)
