### PR TITLE
Test deployment scenarios

### DIFF
--- a/tests/integration/lib.rs
+++ b/tests/integration/lib.rs
@@ -15,6 +15,7 @@ mod test_advancing_time;
 mod test_balance;
 mod test_blocks_generation;
 mod test_call;
+mod test_deploy;
 mod test_dump_and_load;
 mod test_estimate_fee;
 mod test_estimate_message_fee;

--- a/tests/integration/test_deploy.rs
+++ b/tests/integration/test_deploy.rs
@@ -1,0 +1,77 @@
+use std::sync::Arc;
+
+use server::test_utils::assert_contains;
+use starknet_rs_accounts::{Account, ExecutionEncoding, SingleOwnerAccount};
+use starknet_rs_contract::ContractFactory;
+use starknet_rs_core::types::Felt;
+
+use crate::common::background_devnet::BackgroundDevnet;
+use crate::common::constants;
+use crate::common::utils::get_simple_contract_in_sierra_and_compiled_class_hash;
+
+#[tokio::test]
+async fn double_deployment_not_allowed() {
+    let devnet = BackgroundDevnet::spawn().await.unwrap();
+
+    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let account = SingleOwnerAccount::new(
+        &devnet.json_rpc_client,
+        signer,
+        account_address,
+        constants::CHAIN_ID,
+        ExecutionEncoding::New,
+    );
+
+    // declare
+    let (contract_class, casm_hash) = get_simple_contract_in_sierra_and_compiled_class_hash();
+    let declaration_result = account
+        .declare_v3(Arc::new(contract_class), casm_hash)
+        .gas(1e7 as u64)
+        .send()
+        .await
+        .unwrap();
+
+    // prepare deployment
+    let contract_factory = ContractFactory::new(declaration_result.class_hash, account.clone());
+    let ctor_args = vec![Felt::ZERO]; // initial value
+    let salt = Felt::from(10);
+    let unique = false;
+
+    // first deployment should be successful
+    contract_factory.deploy_v3(ctor_args.clone(), salt, unique).send().await.unwrap();
+
+    // second deployment should be unsuccessful
+    match contract_factory.deploy_v3(ctor_args, salt, unique).send().await {
+        Err(e) => assert_contains(&format!("{e:?}"), "unavailable for deployment"),
+        other => panic!("Unexpected result: {other:?}"),
+    };
+}
+
+#[tokio::test]
+async fn cannot_deploy_undeclared_class() {
+    let devnet = BackgroundDevnet::spawn().await.unwrap();
+
+    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let account = SingleOwnerAccount::new(
+        &devnet.json_rpc_client,
+        signer,
+        account_address,
+        constants::CHAIN_ID,
+        ExecutionEncoding::New,
+    );
+
+    // skip declaration
+    let (contract_class, _) = get_simple_contract_in_sierra_and_compiled_class_hash();
+
+    // prepare deployment
+    let contract_factory = ContractFactory::new(contract_class.class_hash(), account.clone());
+    let ctor_args = vec![Felt::ZERO]; // initial value
+    let salt = Felt::from(10);
+    let unique = false;
+
+    // second deployment should be unsuccessful
+    match contract_factory.deploy_v3(ctor_args, salt, unique).send().await {
+        Err(e) => assert_contains(&format!("{e:?}"), "not declared"),
+        other => panic!("Unexpected result: {other:?}"),
+    };
+}

--- a/tests/integration/test_deploy.rs
+++ b/tests/integration/test_deploy.rs
@@ -69,7 +69,7 @@ async fn cannot_deploy_undeclared_class() {
     let salt = Felt::from(10);
     let unique = false;
 
-    // second deployment should be unsuccessful
+    // deployment should fail
     match contract_factory.deploy_v3(ctor_args, salt, unique).send().await {
         Err(e) => assert_contains(&format!("{e:?}"), "not declared"),
         other => panic!("Unexpected result: {other:?}"),


### PR DESCRIPTION
## Usage related changes

None

## Development related changes

- Motivated by [this Slack thread](https://spaceshard.slack.com/archives/C03031Y0LKC/p1741881598201099)

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Introduced a new integration test suite to validate contract deployment behaviors.
	- Verified scenarios where redeploying a contract triggers an error.
	- Ensured that attempting to deploy an undeclared contract results in a failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->