### PR TITLE
Improve L1-L2 docs

### DIFF
--- a/website/docs/postman.md
+++ b/website/docs/postman.md
@@ -1,8 +1,18 @@
 # L1-L2 interaction via Postman
 
-Postman is a Starknet utility that allows testing L1-L2 interaction. It is **unrelated** to the [Postman API platform](https://www.postman.com/). Ensure you have an L1 node and a Devnet (L2 node) running, [load](#load) a messaging contract, and [flush](#flush) the queue to transmit the messages to their destinations. The functionality relies on two internal message queues: one for L1->L2 messages, another for L2->L1 messages.
+Postman is a Starknet utility that allows testing L1-L2 interaction. It is **unrelated** to the [Postman API platform](https://www.postman.com/). Ensure you have:
 
-You can use [**`starknet-devnet-js`**](https://github.com/0xSpaceShard/starknet-devnet-js) to perform these actions, as witnessed in [**this example**](https://github.com/0xSpaceShard/starknet-devnet-js/blob/master/test/l1-l2-postman.test.ts), or directly send requests to the endpoints specified below.
+- an L1 node (possibilities listed [below](#l1-network))
+- a Devnet instance (acting as L2 node)
+- a [loaded](#load) messaging contract
+  - this is an L1 contract for exchanging messages between L1 and L2
+  - you can deploy a new instance or specify the address of an old one
+- an L1 contract that can interact with the messaging contract
+- an L2 contract that can interact with the messaging contract
+
+There are two internal message queues: one for L1->L2 messages, another for L2->L1 messages. When there are messages in a queue, you will need to [flush](#flush) to transmit the messages to their destinations.
+
+You can use [**`starknet-devnet-js`**](https://github.com/0xSpaceShard/starknet-devnet-js) to assist you in the above listed actions. [**This example**](https://github.com/0xSpaceShard/starknet-devnet-js/blob/master/test/l1-l2-postman.test.ts), especially the `it("should exchange messages between L1 and L2")` test case should be of most help. The required contracts are configured and deployed in the `before` block. Alternatively, you can directly send requests to the endpoints specified below.
 
 ## Load
 
@@ -13,7 +23,7 @@ POST /postman/load_l1_messaging_contract
 ```json
 {
   "network_url": "http://localhost:8545",
-  "address": "0x123...def"
+  "address": "0x123...def" // optional
 }
 ```
 
@@ -32,7 +42,9 @@ JSON-RPC
 
 Loads a `MockStarknetMessaging` contract. The `address` parameter is optional; if provided, the `MockStarknetMessaging` contract will be fetched from that address, otherwise a new one will be deployed.
 
-`network_url` is the URL of the JSON-RPC API of the L1 node you've run locally or that already exists; possibilities include, and are not limited to:
+### L1 network
+
+The parameter `network_url` refers to the URL of the JSON-RPC API of the L1 node you've run locally or that already exists; possibilities include, and are not limited to:
 
 - [**Anvil**](https://github.com/foundry-rs/foundry/tree/master/crates/anvil)
 - [**Sepolia testnet**](https://sepolia.etherscan.io/)

--- a/website/docs/postman.md
+++ b/website/docs/postman.md
@@ -1,6 +1,6 @@
 # L1-L2 interaction via Postman
 
-Postman is a Starknet utility that allows testing L1-L2 interaction. It is **unrelated** to the [Postman API platform](https://www.postman.com/). Ensure you have:
+Postman is a Starknet utility that allows testing L1-L2 interaction. It is **unrelated** to the [Postman API platform](https://www.postman.com/). To use it, ensure you have:
 
 - an L1 node (possibilities listed [below](#l1-network))
 - a Devnet instance (acting as L2 node)
@@ -41,6 +41,15 @@ JSON-RPC
 ```
 
 Loads a `MockStarknetMessaging` contract. The `address` parameter is optional; if provided, the `MockStarknetMessaging` contract will be fetched from that address, otherwise a new one will be deployed.
+
+:::note L1-L2 with dockerized Devnet
+
+L1-L2 communication requires extra attention if Devnet is [run in a Docker container](./running/docker.md). The `network_url` argument must be on the same network as Devnet. E.g. if your L1 instance is run locally (i.e. using the host machine's network), then:
+
+- on Linux, it is enough to run the Devnet Docker container with `--network host`
+- on Mac and Windows, replace any `http://localhost` or `http://127.0.0.1` occurrence in the value of `network_url` with `http://host.docker.internal`.
+
+:::
 
 ### L1 network
 

--- a/website/docs/postman.md
+++ b/website/docs/postman.md
@@ -44,7 +44,7 @@ Loads a `MockStarknetMessaging` contract. The `address` parameter is optional; i
 
 ### L1 network
 
-The `network_url` parameter refers to the URL of the JSON-RPC API endpoint of the L1 node you've run locally or which is publicly accessible; possibilities include, but are not limited to:
+The `network_url` parameter refers to the URL of the JSON-RPC API endpoint of the L1 node you've run locally, or which is publicly accessible. Possibilities include, but are not limited to:
 
 - [**Anvil**](https://github.com/foundry-rs/foundry/tree/master#anvil)
 - [**Sepolia testnet**](https://sepolia.etherscan.io/)

--- a/website/docs/postman.md
+++ b/website/docs/postman.md
@@ -44,7 +44,7 @@ Loads a `MockStarknetMessaging` contract. The `address` parameter is optional; i
 
 ### L1 network
 
-The parameter `network_url` refers to the URL of the JSON-RPC API of the L1 node you've run locally or that already exists; possibilities include, and are not limited to:
+The `network_url` parameter refers to the URL of the JSON-RPC API endpoint of the L1 node you've run locally or which is publicly accessible; possibilities include, but are not limited to:
 
 - [**Anvil**](https://github.com/foundry-rs/foundry/tree/master#anvil)
 - [**Sepolia testnet**](https://sepolia.etherscan.io/)

--- a/website/docs/postman.md
+++ b/website/docs/postman.md
@@ -46,7 +46,7 @@ Loads a `MockStarknetMessaging` contract. The `address` parameter is optional; i
 
 The parameter `network_url` refers to the URL of the JSON-RPC API of the L1 node you've run locally or that already exists; possibilities include, and are not limited to:
 
-- [**Anvil**](https://github.com/foundry-rs/foundry/tree/master/crates/anvil)
+- [**Anvil**](https://github.com/foundry-rs/foundry/tree/master#anvil)
 - [**Sepolia testnet**](https://sepolia.etherscan.io/)
 - [**Ganache**](https://www.npmjs.com/package/ganache)
 - [**Geth**](https://github.com/ethereum/go-ethereum#docker-quick-start)


### PR DESCRIPTION
## Usage related changes

What the title says.

## Development related changes

N/A

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Revised the Postman utility guide for improved clarity and detail.
  - Structured prerequisites into a bulleted list outlining required components for L1-L2 interaction.
  - Expanded explanations for the `network_url` parameter and configurations for L1-L2 communication in Docker.
  - Highlighted the optional nature of the `address` parameter in the JSON request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->