### PR TITLE
Explicitly wait for new timestamp for time advancing tests

### DIFF
--- a/tests/integration/test_advancing_time.rs
+++ b/tests/integration/test_advancing_time.rs
@@ -21,8 +21,12 @@ const DUMMY_AMOUNT: u128 = 1;
 const BUFFER_TIME_SECONDS: u64 = 30;
 
 async fn sleep_until_new_timestamp() {
-    // Sometimes sleeping for 1 second isn't enough.
-    tokio::time::sleep(time::Duration::from_millis(1500)).await
+    let now = get_unix_timestamp_as_seconds();
+    tokio::time::sleep(time::Duration::from_millis(100)).await;
+
+    while now == get_unix_timestamp_as_seconds() {
+        tokio::time::sleep(time::Duration::from_millis(100)).await;
+    }
 }
 
 /// Set time and generate a new block


### PR DESCRIPTION
## Usage related changes

None

## Development related changes

Tries to resolve flakiness of time advancing tests, specified at #687.

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)
