### PR TITLE
Install nightly-2025-02-20; apply fmt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           name: Install Rust
           command: |
             rustup install 1.85.0
-            rustup install nightly-2024-07-08
+            rustup install nightly-2025-02-20
       - run:
           name: Install foundry
           command: ./scripts/install_foundry.sh

--- a/crates/starknet-devnet-core/src/account.rs
+++ b/crates/starknet-devnet-core/src/account.rs
@@ -8,7 +8,7 @@ use starknet_rs_core::types::Felt;
 use starknet_types::contract_address::ContractAddress;
 use starknet_types::contract_class::ContractClass;
 use starknet_types::error::Error;
-use starknet_types::felt::{felt_from_prefixed_hex, join_felts, split_biguint, ClassHash, Key};
+use starknet_types::felt::{ClassHash, Key, felt_from_prefixed_hex, join_felts, split_biguint};
 use starknet_types::num_bigint::BigUint;
 use starknet_types::rpc::state::Balance;
 

--- a/crates/starknet-devnet-core/src/blocks/mod.rs
+++ b/crates/starknet-devnet-core/src/blocks/mod.rs
@@ -17,8 +17,8 @@ use starknet_types_core::hash::{Pedersen, StarkHash};
 
 use crate::constants::{DEVNET_DEFAULT_STARTING_BLOCK_NUMBER, STARKNET_VERSION};
 use crate::error::{DevnetResult, Error};
-use crate::state::state_diff::StateDiff;
 use crate::state::StarknetState;
+use crate::state::state_diff::StateDiff;
 use crate::traits::HashIdentified;
 
 pub(crate) struct StarknetBlocks {

--- a/crates/starknet-devnet-core/src/error.rs
+++ b/crates/starknet-devnet-core/src/error.rs
@@ -1,5 +1,5 @@
 use blockifier::execution::stack_trace::{
-    gen_tx_execution_error_trace, ErrorStack, ErrorStackHeader, ErrorStackSegment, PreambleType,
+    ErrorStack, ErrorStackHeader, ErrorStackSegment, PreambleType, gen_tx_execution_error_trace,
 };
 use blockifier::fee::fee_checks::FeeCheckError;
 use blockifier::transaction::errors::{

--- a/crates/starknet-devnet-core/src/messaging/mod.rs
+++ b/crates/starknet-devnet-core/src/messaging/mod.rs
@@ -36,10 +36,10 @@ use ethers::types::H256;
 use starknet_rs_core::types::{BlockId, ExecutionResult, Felt, Hash256};
 use starknet_types::rpc::messaging::{MessageToL1, MessageToL2};
 
+use crate::StarknetBlock;
 use crate::error::{DevnetResult, Error, MessagingError};
 use crate::starknet::Starknet;
 use crate::traits::HashIdentified;
-use crate::StarknetBlock;
 
 pub mod ethereum;
 pub use ethereum::EthereumMessaging;

--- a/crates/starknet-devnet-core/src/predeployed_accounts.rs
+++ b/crates/starknet-devnet-core/src/predeployed_accounts.rs
@@ -80,7 +80,7 @@ impl AccountGenerator for PredeployedAccounts {
 
 #[cfg(test)]
 mod tests {
-    use rand::{thread_rng, Rng};
+    use rand::{Rng, thread_rng};
     use starknet_types::rpc::state::Balance;
 
     use crate::predeployed_accounts::PredeployedAccounts;

--- a/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
@@ -126,8 +126,8 @@ mod tests {
     use starknet_types::traits::HashProducer;
 
     use crate::error::{Error, TransactionValidationError};
-    use crate::starknet::tests::setup_starknet_with_no_signature_check_account;
     use crate::starknet::Starknet;
+    use crate::starknet::tests::setup_starknet_with_no_signature_check_account;
     use crate::state::{BlockNumberOrPending, CustomStateReader};
     use crate::traits::HashIdentifiedMut;
     use crate::utils::test_utils::{

--- a/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
@@ -81,7 +81,7 @@ mod tests {
         STRK_ERC20_CONTRACT_ADDRESS,
     };
     use crate::error::{Error, TransactionValidationError};
-    use crate::starknet::{predeployed, Starknet};
+    use crate::starknet::{Starknet, predeployed};
     use crate::state::CustomState;
     use crate::traits::{Deployed, HashIdentifiedMut};
     use crate::utils::get_storage_var_address;

--- a/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
@@ -93,7 +93,7 @@ mod tests {
         ETH_ERC20_CONTRACT_ADDRESS,
     };
     use crate::error::{Error, TransactionValidationError};
-    use crate::starknet::{predeployed, Starknet};
+    use crate::starknet::{Starknet, predeployed};
     use crate::state::CustomState;
     use crate::traits::{Accounted, Deployed, HashIdentifiedMut};
     use crate::utils::exported_test_utils::dummy_cairo_0_contract_class;

--- a/crates/starknet-devnet-core/src/starknet/add_l1_handler_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_l1_handler_transaction.rs
@@ -62,7 +62,7 @@ mod tests {
         ENTRYPOINT_NOT_FOUND_ERROR_ENCODED, ETH_ERC20_CONTRACT_ADDRESS,
         STRK_ERC20_CONTRACT_ADDRESS,
     };
-    use crate::starknet::{predeployed, Starknet};
+    use crate::starknet::{Starknet, predeployed};
     use crate::state::CustomState;
     use crate::traits::{Deployed, HashIdentifiedMut};
     use crate::utils::exported_test_utils::dummy_cairo_l1l2_contract;

--- a/crates/starknet-devnet-core/src/starknet/events.rs
+++ b/crates/starknet-devnet-core/src/starknet/events.rs
@@ -137,9 +137,9 @@ mod tests {
     use starknet_types::rpc::transactions::TransactionWithHash;
 
     use super::{check_if_filter_applies_for_event, get_events};
+    use crate::starknet::Starknet;
     use crate::starknet::events::check_if_filter_applies_for_event_keys;
     use crate::starknet::starknet_config::StarknetConfig;
-    use crate::starknet::Starknet;
     use crate::traits::HashIdentified;
     use crate::utils::test_utils::{dummy_contract_address, dummy_declare_transaction_v3};
 

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -30,7 +30,7 @@ use starknet_types::contract_address::ContractAddress;
 use starknet_types::contract_class::ContractClass;
 use starknet_types::emitted_event::EmittedEvent;
 use starknet_types::felt::{
-    felt_from_prefixed_hex, split_biguint, BlockHash, ClassHash, TransactionHash,
+    BlockHash, ClassHash, TransactionHash, felt_from_prefixed_hex, split_biguint,
 };
 use starknet_types::num_bigint::BigUint;
 use starknet_types::patricia_key::PatriciaKey;

--- a/crates/starknet-devnet-core/src/state/mod.rs
+++ b/crates/starknet-devnet-core/src/state/mod.rs
@@ -432,8 +432,8 @@ mod tests {
     use super::StarknetState;
     use crate::state::{BlockNumberOrPending, CustomState, CustomStateReader};
     use crate::utils::test_utils::{
-        dummy_cairo_1_contract_class, dummy_contract_address, dummy_felt,
-        DUMMY_CAIRO_1_COMPILED_CLASS_HASH,
+        DUMMY_CAIRO_1_COMPILED_CLASS_HASH, dummy_cairo_1_contract_class, dummy_contract_address,
+        dummy_felt,
     };
 
     pub(crate) fn dummy_contract_storage_key() -> (starknet_api::core::ContractAddress, StorageKey)

--- a/crates/starknet-devnet-core/src/state/state_diff.rs
+++ b/crates/starknet-devnet-core/src/state/state_diff.rs
@@ -189,21 +189,21 @@ mod tests {
     use starknet_types::contract_address::ContractAddress;
     use starknet_types::contract_class::ContractClass;
     use starknet_types::rpc::state::{Balance, ReplacedClasses};
+    use starknet_types::rpc::transactions::BroadcastedInvokeTransaction;
     use starknet_types::rpc::transactions::broadcasted_declare_transaction_v2::BroadcastedDeclareTransactionV2;
     use starknet_types::rpc::transactions::broadcasted_invoke_transaction_v1::BroadcastedInvokeTransactionV1;
-    use starknet_types::rpc::transactions::BroadcastedInvokeTransaction;
     use starknet_types::traits::HashProducer;
 
     use super::StateDiff;
     use crate::account::Account;
     use crate::constants::{ETH_ERC20_CONTRACT_ADDRESS, STRK_ERC20_CONTRACT_ADDRESS};
-    use crate::starknet::starknet_config::StarknetConfig;
     use crate::starknet::Starknet;
+    use crate::starknet::starknet_config::StarknetConfig;
     use crate::state::{CustomState, StarknetState};
     use crate::traits::Deployed;
     use crate::utils::test_utils::{
-        cairo_0_account_without_validations, dummy_cairo_1_contract_class, dummy_contract_address,
-        dummy_felt, DUMMY_CAIRO_1_COMPILED_CLASS_HASH,
+        DUMMY_CAIRO_1_COMPILED_CLASS_HASH, cairo_0_account_without_validations,
+        dummy_cairo_1_contract_class, dummy_contract_address, dummy_felt,
     };
 
     #[test]

--- a/crates/starknet-devnet-core/src/system_contract.rs
+++ b/crates/starknet-devnet-core/src/system_contract.rs
@@ -1,8 +1,8 @@
 use blockifier::state::state_api::StateReader;
 use starknet_rs_core::types::Felt;
 use starknet_types::contract_address::ContractAddress;
-use starknet_types::contract_class::deprecated::json_contract_class::Cairo0Json;
 use starknet_types::contract_class::ContractClass;
+use starknet_types::contract_class::deprecated::json_contract_class::Cairo0Json;
 use starknet_types::felt::ClassHash;
 use starknet_types::rpc::state::Balance;
 

--- a/crates/starknet-devnet-core/src/utils.rs
+++ b/crates/starknet-devnet-core/src/utils.rs
@@ -8,7 +8,7 @@ use starknet_types::patricia_key::{PatriciaKey, StorageKey};
 use crate::error::DevnetResult;
 
 pub mod random_number_generator {
-    use rand::{thread_rng, Rng, SeedableRng};
+    use rand::{Rng, SeedableRng, thread_rng};
     use rand_mt::Mt64;
 
     pub fn generate_u32_random_number() -> u32 {
@@ -222,8 +222,8 @@ pub(crate) mod test_utils {
 #[cfg(any(test, feature = "test_utils"))]
 #[allow(clippy::unwrap_used)]
 pub mod exported_test_utils {
-    use starknet_types::contract_class::deprecated::json_contract_class::Cairo0Json;
     use starknet_types::contract_class::Cairo0ContractClass;
+    use starknet_types::contract_class::deprecated::json_contract_class::Cairo0Json;
 
     pub fn dummy_cairo_l1l2_contract() -> Cairo0ContractClass {
         let json_str =

--- a/crates/starknet-devnet-server/src/api/http/endpoints/accounts.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/accounts.rs
@@ -1,5 +1,5 @@
-use axum::extract::{Query, State};
 use axum::Json;
+use axum::extract::{Query, State};
 use serde::Deserialize;
 use starknet_core::starknet::Starknet;
 use starknet_rs_core::types::{BlockTag, Felt};
@@ -7,12 +7,12 @@ use starknet_types::contract_address::ContractAddress;
 use starknet_types::rpc::transaction_receipt::FeeUnit;
 
 use super::mint_token::{get_balance, get_erc20_address};
+use crate::api::Api;
 use crate::api::http::error::HttpApiError;
 use crate::api::http::models::{
     AccountBalanceResponse, AccountBalancesResponse, SerializableAccount,
 };
 use crate::api::http::{HttpApiHandler, HttpApiResult};
-use crate::api::Api;
 
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]

--- a/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
@@ -1,11 +1,11 @@
-use axum::extract::State;
 use axum::Json;
+use axum::extract::State;
 
 use super::extract_optional_json_from_request;
+use crate::api::Api;
 use crate::api::http::error::HttpApiError;
 use crate::api::http::models::{DumpPath, DumpResponseBody};
 use crate::api::http::{HttpApiHandler, HttpApiResult};
-use crate::api::Api;
 use crate::dump_util::dump_events;
 
 pub async fn dump(

--- a/crates/starknet-devnet-server/src/api/http/endpoints/mint_token.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/mint_token.rs
@@ -7,10 +7,10 @@ use starknet_types::felt::join_felts;
 use starknet_types::num_bigint::BigUint;
 use starknet_types::rpc::transaction_receipt::FeeUnit;
 
-use crate::api::http::models::{MintTokensRequest, MintTokensResponse};
-use crate::api::json_rpc::error::{ApiError, StrictRpcResult};
-use crate::api::json_rpc::DevnetResponse;
 use crate::api::Api;
+use crate::api::http::models::{MintTokensRequest, MintTokensResponse};
+use crate::api::json_rpc::DevnetResponse;
+use crate::api::json_rpc::error::{ApiError, StrictRpcResult};
 
 /// get the balance of the `address`
 pub fn get_balance(

--- a/crates/starknet-devnet-server/src/api/http/endpoints/mod.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/mod.rs
@@ -1,5 +1,5 @@
-use axum::extract::State;
 use axum::Json;
+use axum::extract::State;
 use serde::Serialize;
 use starknet_core::starknet::starknet_config::StarknetConfig;
 

--- a/crates/starknet-devnet-server/src/api/http/endpoints/postman.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/postman.rs
@@ -1,7 +1,8 @@
-use starknet_types::felt::{felt_from_prefixed_hex, TransactionHash};
+use starknet_types::felt::{TransactionHash, felt_from_prefixed_hex};
 use starknet_types::rpc::messaging::{MessageToL1, MessageToL2};
 use starknet_types::rpc::transactions::l1_handler_transaction::L1HandlerTransaction;
 
+use crate::api::Api;
 use crate::api::http::models::{
     FlushParameters, FlushedMessages, MessageHash, MessagingLoadAddress,
     PostmanLoadL1MessagingContract,
@@ -9,7 +10,6 @@ use crate::api::http::models::{
 use crate::api::json_rpc::error::{ApiError, StrictRpcResult};
 use crate::api::json_rpc::models::TransactionHashOutput;
 use crate::api::json_rpc::{DevnetResponse, JsonRpcHandler};
-use crate::api::Api;
 use crate::rpc_core::error::RpcError;
 use crate::rpc_core::request::RpcMethodCall;
 use crate::rpc_core::response::ResponseResult;

--- a/crates/starknet-devnet-server/src/api/http/endpoints/time.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/time.rs
@@ -1,7 +1,7 @@
-use crate::api::http::models::{IncreaseTime, IncreaseTimeResponse, SetTime, SetTimeResponse};
-use crate::api::json_rpc::error::StrictRpcResult;
-use crate::api::json_rpc::DevnetResponse;
 use crate::api::Api;
+use crate::api::http::models::{IncreaseTime, IncreaseTimeResponse, SetTime, SetTimeResponse};
+use crate::api::json_rpc::DevnetResponse;
+use crate::api::json_rpc::error::StrictRpcResult;
 
 pub(crate) async fn set_time_impl(api: &Api, data: SetTime) -> StrictRpcResult {
     let mut starknet = api.starknet.lock().await;

--- a/crates/starknet-devnet-server/src/api/http/error.rs
+++ b/crates/starknet-devnet-server/src/api/http/error.rs
@@ -1,6 +1,6 @@
+use axum::Json;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::Json;
 use serde_json::json;
 use thiserror::Error;
 

--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
@@ -16,11 +16,11 @@ use super::error::{ApiError, StrictRpcResult};
 use super::models::{
     BlockHashAndNumberOutput, GetStorageProofInput, L1TransactionHashInput, SyncingOutput,
 };
-use super::{DevnetResponse, JsonRpcHandler, JsonRpcResponse, StarknetResponse, RPC_SPEC_VERSION};
-use crate::api::http::endpoints::accounts::{
-    get_account_balance_impl, get_predeployed_accounts_impl, BalanceQuery, PredeployedAccountsQuery,
-};
+use super::{DevnetResponse, JsonRpcHandler, JsonRpcResponse, RPC_SPEC_VERSION, StarknetResponse};
 use crate::api::http::endpoints::DevnetConfig;
+use crate::api::http::endpoints::accounts::{
+    BalanceQuery, PredeployedAccountsQuery, get_account_balance_impl, get_predeployed_accounts_impl,
+};
 
 const DEFAULT_CONTINUATION_TOKEN: &str = "0";
 

--- a/crates/starknet-devnet-server/src/api/json_rpc/error.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/error.rs
@@ -283,8 +283,8 @@ mod tests {
     use starknet_core::error::ContractExecutionError;
 
     use super::StrictRpcResult;
-    use crate::api::json_rpc::error::ApiError;
     use crate::api::json_rpc::ToRpcResponseResult;
+    use crate::api::json_rpc::error::ApiError;
 
     #[test]
     fn contract_not_found_error() {

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -51,8 +51,9 @@ use self::models::{
     SyncingOutput,
 };
 use self::origin_forwarder::OriginForwarder;
-use super::http::endpoints::accounts::{BalanceQuery, PredeployedAccountsQuery};
+use super::Api;
 use super::http::endpoints::DevnetConfig;
+use super::http::endpoints::accounts::{BalanceQuery, PredeployedAccountsQuery};
 use super::http::models::{
     AbortedBlocks, AbortingBlocks, AccountBalanceResponse, CreatedBlock, DumpPath,
     DumpResponseBody, FlushParameters, FlushedMessages, IncreaseTime, IncreaseTimeResponse,
@@ -60,7 +61,7 @@ use super::http::models::{
     PostmanLoadL1MessagingContract, RestartParameters, SerializableAccount, SetTime,
     SetTimeResponse,
 };
-use super::Api;
+use crate::ServerConfig;
 use crate::api::json_rpc::models::{
     BroadcastedDeclareTransactionEnumWrapper, BroadcastedDeployAccountTransactionEnumWrapper,
     BroadcastedInvokeTransactionEnumWrapper, SimulateTransactionsInput,
@@ -76,7 +77,6 @@ use crate::subscribe::{
     NewTransactionStatus, NotificationData, PendingTransactionNotification, SocketId,
     TransactionHashWrapper,
 };
-use crate::ServerConfig;
 
 /// Helper trait to easily convert results to rpc results
 pub trait ToRpcResponseResult {
@@ -1619,8 +1619,8 @@ mod requests_tests {
 
 #[cfg(test)]
 mod response_tests {
-    use crate::api::json_rpc::error::StrictRpcResult;
     use crate::api::json_rpc::ToRpcResponseResult;
+    use crate::api::json_rpc::error::StrictRpcResult;
 
     #[test]
     fn serializing_starknet_response_empty_variant_yields_empty_json_on_conversion_to_rpc_result() {

--- a/crates/starknet-devnet-server/src/api/json_rpc/spec_reader/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/spec_reader/mod.rs
@@ -164,14 +164,14 @@ fn generate_json_rpc_response(
 mod tests {
     use std::fs::File;
 
-    use serde::de::DeserializeOwned;
     use serde::Deserialize;
+    use serde::de::DeserializeOwned;
     use serde_json::Value;
 
-    use super::{generate_combined_schema, generate_json_rpc_response, ApiMethod, Spec};
+    use super::{ApiMethod, Spec, generate_combined_schema, generate_json_rpc_response};
     use crate::api::json_rpc::spec_reader::generate_json_rpc_request;
     use crate::api::json_rpc::{
-        JsonRpcRequest, JsonRpcSubscriptionRequest, StarknetResponse, RPC_SPEC_VERSION,
+        JsonRpcRequest, JsonRpcSubscriptionRequest, RPC_SPEC_VERSION, StarknetResponse,
     };
     use crate::subscribe::{SubscriptionConfirmation, SubscriptionResponse};
 

--- a/crates/starknet-devnet-server/src/restrictive_mode.rs
+++ b/crates/starknet-devnet-server/src/restrictive_mode.rs
@@ -101,7 +101,7 @@ mod tests {
 
     use super::DEFAULT_RESTRICTED_JSON_RPC_METHODS;
     use crate::restrictive_mode::{
-        is_json_rpc_method_restricted, is_uri_path_restricted, RPC_METHOD_TO_HTTP_URI,
+        RPC_METHOD_TO_HTTP_URI, is_json_rpc_method_restricted, is_uri_path_restricted,
     };
     lazy_static! {
         static ref DEFAULT_RESTRICTED_HTTP_URIS: Vec<String> = DEFAULT_RESTRICTED_JSON_RPC_METHODS

--- a/crates/starknet-devnet-server/src/rpc_handler.rs
+++ b/crates/starknet-devnet-server/src/rpc_handler.rs
@@ -1,11 +1,11 @@
 use std::fmt::{self};
 
+use axum::Json;
 use axum::extract::rejection::JsonRejection;
 use axum::extract::ws::WebSocket;
 use axum::extract::{State, WebSocketUpgrade};
 use axum::response::IntoResponse;
-use axum::Json;
-use futures::{future, FutureExt};
+use futures::{FutureExt, future};
 use serde::de::DeserializeOwned;
 use tracing::{trace, warn};
 

--- a/crates/starknet-devnet-server/src/server.rs
+++ b/crates/starknet-devnet-server/src/server.rs
@@ -1,27 +1,27 @@
 use std::time::Duration;
 
+use axum::Router;
 use axum::body::{Body, Bytes};
 use axum::extract::{DefaultBodyLimit, Request, State};
 use axum::http::{HeaderValue, StatusCode};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
-use axum::routing::{get, post, IntoMakeService, MethodRouter};
-use axum::Router;
+use axum::routing::{IntoMakeService, MethodRouter, get, post};
 use http_body_util::BodyExt;
 use lazy_static::lazy_static;
-use reqwest::{header, Method};
+use reqwest::{Method, header};
 use tokio::net::TcpListener;
 use tower_http::cors::CorsLayer;
 use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::TraceLayer;
 
-use crate::api::http::{endpoints as http, HttpApiHandler};
+use crate::api::http::{HttpApiHandler, endpoints as http};
 use crate::api::json_rpc::JsonRpcHandler;
 use crate::restrictive_mode::is_uri_path_restricted;
 use crate::rpc_core::error::RpcError;
 use crate::rpc_core::response::ResponseResult;
 use crate::rpc_handler::RpcHandler;
-use crate::{http_rpc_router, rpc_handler, ServerConfig};
+use crate::{ServerConfig, http_rpc_router, rpc_handler};
 pub type StarknetDevnetServer = axum::serve::Serve<IntoMakeService<Router>, Router>;
 
 lazy_static! {

--- a/crates/starknet-devnet-server/src/subscribe.rs
+++ b/crates/starknet-devnet-server/src/subscribe.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use axum::extract::ws::{Message, WebSocket};
-use futures::stream::SplitSink;
 use futures::SinkExt;
+use futures::stream::SplitSink;
 use serde::{self, Deserialize, Serialize};
 use starknet_core::starknet::events::check_if_filter_applies_for_event;
 use starknet_rs_core::types::Felt;

--- a/crates/starknet-devnet-types/src/rpc/contract_address.rs
+++ b/crates/starknet-devnet-types/src/rpc/contract_address.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use starknet_rs_core::types::Felt;
 
 use crate::error::{DevnetResult, Error};
-use crate::patricia_key::{PatriciaKey, PATRICIA_KEY_ZERO};
+use crate::patricia_key::{PATRICIA_KEY_ZERO, PatriciaKey};
 use crate::serde_helpers::hex_string::{
     deserialize_to_prefixed_contract_address, serialize_contract_address_to_prefixed_hex,
 };

--- a/crates/starknet-devnet-types/src/rpc/contract_class.rs
+++ b/crates/starknet-devnet-types/src/rpc/contract_class.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use blockifier::execution::contract_class::{
-    deserialize_program, CompiledClassV0, CompiledClassV0Inner, RunnableCompiledClass,
+    CompiledClassV0, CompiledClassV0Inner, RunnableCompiledClass, deserialize_program,
 };
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet_classes::contract_class::ContractClass as SierraContractClass;
@@ -380,7 +380,7 @@ mod tests {
     use crate::contract_class::deprecated::rpc_contract_class::{
         ContractClassAbiEntryWithType, DeprecatedContractClass,
     };
-    use crate::contract_class::{convert_sierra_to_codegen, ContractClass};
+    use crate::contract_class::{ContractClass, convert_sierra_to_codegen};
     use crate::felt::felt_from_prefixed_hex;
     use crate::serde_helpers::rpc_sierra_contract_class_to_sierra_contract_class::deserialize_to_sierra_contract_class;
     use crate::traits::HashProducer;

--- a/crates/starknet-devnet-types/src/rpc/contract_class/deprecated/json_contract_class.rs
+++ b/crates/starknet-devnet-types/src/rpc/contract_class/deprecated/json_contract_class.rs
@@ -1,10 +1,10 @@
 use core::fmt::{Debug, Display, Formatter};
 use std::collections::HashMap;
 
-use flate2::write::GzEncoder;
 use flate2::Compression;
+use flate2::write::GzEncoder;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Serializer as JsonSerializer, Value};
+use serde_json::{Serializer as JsonSerializer, Value, json};
 use starknet_api::contract_class::EntryPointType;
 use starknet_api::deprecated_contract_class::EntryPointV0;
 use starknet_rs_core::types::{CompressedLegacyContractClass, Felt};

--- a/crates/starknet-devnet-types/src/rpc/contract_class/deprecated/rpc_contract_class.rs
+++ b/crates/starknet-devnet-types/src/rpc/contract_class/deprecated/rpc_contract_class.rs
@@ -2,8 +2,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use starknet_rs_core::types::{CompressedLegacyContractClass, Felt, LegacyEntryPointsByType};
 
-use crate::contract_class::deprecated::abi_entry::{AbiEntry, AbiEntryType};
 use crate::contract_class::deprecated::Cairo0Json;
+use crate::contract_class::deprecated::abi_entry::{AbiEntry, AbiEntryType};
 use crate::error::{DevnetResult, Error, JsonError};
 use crate::serde_helpers::base_64_gzipped_json_string::{
     deserialize_to_serde_json_value_with_keys_ordered_in_alphabetical_order,

--- a/crates/starknet-devnet-types/src/rpc/messaging.rs
+++ b/crates/starknet-devnet-types/src/rpc/messaging.rs
@@ -3,7 +3,7 @@ use starknet_rs_core::types::{EthAddress, Felt, Hash256, MsgToL1, MsgToL2};
 
 use crate::contract_address::ContractAddress;
 use crate::error::{DevnetResult, Error};
-use crate::felt::{try_felt_to_num, Calldata, EntryPointSelector, Nonce};
+use crate::felt::{Calldata, EntryPointSelector, Nonce, try_felt_to_num};
 use crate::rpc::eth_address::EthAddressWrapper;
 
 /// An L1 to L2 message.

--- a/crates/starknet-devnet-types/src/rpc/transactions.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions.rs
@@ -16,7 +16,7 @@ use starknet_api::data_availability::DataAvailabilityMode;
 use starknet_api::transaction::fields::{
     AllResourceBounds, Fee, GasVectorComputationMode, Tip, ValidResourceBounds,
 };
-use starknet_api::transaction::{signed_tx_version, TransactionHasher, TransactionOptions};
+use starknet_api::transaction::{TransactionHasher, TransactionOptions, signed_tx_version};
 use starknet_rs_core::types::{
     BlockId, ExecutionResult, Felt, ResourceBounds, ResourceBoundsMapping,
     TransactionExecutionStatus, TransactionFinalityStatus,
@@ -37,7 +37,7 @@ use super::state::ThinStateDiff;
 use super::transaction_receipt::{ExecutionResources, FeeInUnits, TransactionReceipt};
 use crate::constants::QUERY_VERSION_OFFSET;
 use crate::contract_address::ContractAddress;
-use crate::contract_class::{compute_sierra_class_hash, ContractClass};
+use crate::contract_class::{ContractClass, compute_sierra_class_hash};
 use crate::emitted_event::{Event, OrderedEvent};
 use crate::error::{ConversionError, DevnetResult};
 use crate::felt::{

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v2.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v2.rs
@@ -52,8 +52,8 @@ mod tests {
     use crate::contract_address::ContractAddress;
     use crate::contract_class::ContractClass;
     use crate::felt::try_felt_to_num;
-    use crate::rpc::transactions::broadcasted_declare_transaction_v2::BroadcastedDeclareTransactionV2;
     use crate::rpc::transactions::BroadcastedDeclareTransaction;
+    use crate::rpc::transactions::broadcasted_declare_transaction_v2::BroadcastedDeclareTransactionV2;
     use crate::utils::test_utils::CAIRO_1_EVENTS_CONTRACT_PATH;
 
     #[derive(Deserialize)]

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_invoke_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_invoke_transaction_v1.rs
@@ -45,8 +45,8 @@ mod tests {
     use crate::chain_id::ChainId;
     use crate::contract_address::ContractAddress;
     use crate::felt::try_felt_to_num;
-    use crate::rpc::transactions::broadcasted_invoke_transaction_v1::BroadcastedInvokeTransactionV1;
     use crate::rpc::transactions::BroadcastedInvokeTransaction;
+    use crate::rpc::transactions::broadcasted_invoke_transaction_v1::BroadcastedInvokeTransactionV1;
 
     #[derive(Deserialize)]
     struct FeederGatewayInvokeTransaction {

--- a/crates/starknet-devnet-types/src/rpc/transactions/declare_transaction_v3.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/declare_transaction_v3.rs
@@ -3,8 +3,8 @@ use starknet_api::data_availability::DataAvailabilityMode;
 use starknet_api::transaction::fields::Tip;
 use starknet_types_core::felt::Felt;
 
-use super::broadcasted_declare_transaction_v3::BroadcastedDeclareTransactionV3;
 use super::ResourceBoundsWrapper;
+use super::broadcasted_declare_transaction_v3::BroadcastedDeclareTransactionV3;
 use crate::contract_address::ContractAddress;
 use crate::felt::{ClassHash, CompiledClassHash, Nonce, TransactionSignature, TransactionVersion};
 

--- a/crates/starknet-devnet-types/src/rpc/transactions/l1_handler_transaction.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/l1_handler_transaction.rs
@@ -17,7 +17,7 @@ use super::serialize_paid_fee_on_l1;
 use crate::constants::PREFIX_L1_HANDLER;
 use crate::contract_address::ContractAddress;
 use crate::error::{ConversionError, DevnetResult, Error};
-use crate::felt::{try_felt_to_num, Calldata, EntryPointSelector, Nonce, TransactionVersion};
+use crate::felt::{Calldata, EntryPointSelector, Nonce, TransactionVersion, try_felt_to_num};
 use crate::rpc::messaging::MessageToL2;
 
 #[derive(Debug, Clone, Default, Serialize, Eq, PartialEq)]

--- a/crates/starknet-devnet-types/src/serde_helpers.rs
+++ b/crates/starknet-devnet-types/src/serde_helpers.rs
@@ -253,8 +253,8 @@ pub mod dec_string {
 
 pub mod base_64_gzipped_json_string {
     use base64::Engine;
-    use flate2::write::GzEncoder;
     use flate2::Compression;
+    use flate2::write::GzEncoder;
     use serde::{Deserialize, Deserializer, Serializer};
     use serde_json::Value;
     use starknet_rs_core::serde::byte_array::base64 as base64Sir;

--- a/crates/starknet-devnet/src/cli.rs
+++ b/crates/starknet-devnet/src/cli.rs
@@ -2,10 +2,10 @@ use std::collections::HashSet;
 use std::num::NonZeroU128;
 
 use clap::Parser;
+use server::ServerConfig;
 use server::api::json_rpc::JsonRpcRequest;
 use server::restrictive_mode::DEFAULT_RESTRICTED_JSON_RPC_METHODS;
 use server::server::HTTP_API_ROUTES_WITHOUT_LEADING_SLASH;
-use server::ServerConfig;
 use starknet_core::constants::{
     ARGENT_CONTRACT_VERSION, ARGENT_MULTISIG_CONTRACT_VERSION, DEVNET_DEFAULT_L1_DATA_GAS_PRICE,
     DEVNET_DEFAULT_L1_GAS_PRICE, DEVNET_DEFAULT_L2_GAS_PRICE, DEVNET_DEFAULT_PORT,

--- a/crates/starknet-devnet/src/main.rs
+++ b/crates/starknet-devnet/src/main.rs
@@ -8,9 +8,9 @@ use cli::Args;
 use futures::future::join_all;
 use serde::de::IntoDeserializer;
 use serde_json::json;
+use server::api::Api;
 use server::api::http::HttpApiHandler;
 use server::api::json_rpc::{JsonRpcHandler, RPC_SPEC_VERSION};
-use server::api::Api;
 use server::dump_util::{dump_events, load_events};
 use server::server::serve_http_api_json_rpc;
 use starknet_core::account::Account;
@@ -18,10 +18,10 @@ use starknet_core::constants::{
     ARGENT_CONTRACT_CLASS_HASH, ARGENT_MULTISIG_CONTRACT_CLASS_HASH, ETH_ERC20_CONTRACT_ADDRESS,
     STRK_ERC20_CONTRACT_ADDRESS, UDC_CONTRACT_ADDRESS, UDC_CONTRACT_CLASS_HASH,
 };
+use starknet_core::starknet::Starknet;
 use starknet_core::starknet::starknet_config::{
     BlockGenerationOn, DumpOn, ForkConfig, StarknetConfig,
 };
-use starknet_core::starknet::Starknet;
 use starknet_rs_core::types::ContractClass::{Legacy, Sierra};
 use starknet_rs_core::types::{
     BlockId, BlockTag, Felt, MaybePendingBlockWithTxHashes, StarknetError,
@@ -33,7 +33,7 @@ use starknet_types::rpc::state::Balance;
 use starknet_types::serde_helpers::rpc_sierra_contract_class_to_sierra_contract_class::deserialize_to_sierra_contract_class;
 use tokio::net::TcpListener;
 #[cfg(unix)]
-use tokio::signal::unix::{signal, SignalKind};
+use tokio::signal::unix::{SignalKind, signal};
 #[cfg(windows)]
 use tokio::signal::windows::ctrl_c;
 use tokio::task::{self};

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -7,7 +7,7 @@ max_width = 100
 
 # Unstable features below
 unstable_features = true
-version = "Two"
+style_edition = "2024"
 comment_width = 100
 format_code_in_doc_comments = true
 format_macro_bodies = true

--- a/scripts/check_spelling.sh
+++ b/scripts/check_spelling.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-set -eu
+set -euo pipefail
 
 # should skip if already installed
-cargo +nightly-2024-07-08 install typos-cli
+cargo +nightly-2025-02-20 install typos-cli --version 1.31.0
 
-typos
+typos && echo "No spelling errors!"

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-cargo +nightly-2024-07-08 fmt --all
+cargo +nightly-2025-02-20 fmt --all
 
 # Format documentation
 npm --prefix website run format

--- a/scripts/format_check.sh
+++ b/scripts/format_check.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-cargo +nightly-2024-07-08 fmt --all --check
+cargo +nightly-2025-02-20 fmt --all --check
 
 # Format documentation
 npm --prefix website run format-check

--- a/tests/integration/common/background_devnet.rs
+++ b/tests/integration/common/background_devnet.rs
@@ -23,7 +23,7 @@ use super::constants::{
 };
 use super::errors::{RpcError, TestError};
 use super::reqwest_client::{PostReqwestSender, ReqwestClient};
-use super::utils::{to_hex_felt, FeeUnit, ImpersonationAction};
+use super::utils::{FeeUnit, ImpersonationAction, to_hex_felt};
 use crate::common::background_server::get_acquired_port;
 use crate::common::constants::{
     DEVNET_EXECUTABLE_BINARY_PATH, DEVNET_MANIFEST_PATH, STRK_ERC20_CONTRACT_ADDRESS,

--- a/tests/integration/common/reqwest_client.rs
+++ b/tests/integration/common/reqwest_client.rs
@@ -1,8 +1,8 @@
 use std::any::TypeId;
 
 use reqwest::Method;
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use serde_json::json;
 
 use super::errors::ReqwestError;

--- a/tests/integration/common/utils.rs
+++ b/tests/integration/common/utils.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use ethers::types::U256;
 use futures::{SinkExt, StreamExt, TryStreamExt};
-use rand::{thread_rng, Rng};
+use rand::{Rng, thread_rng};
 use serde_json::json;
 use server::test_utils::assert_contains;
 use starknet_rs_accounts::{
@@ -21,7 +21,7 @@ use starknet_rs_core::types::{
     InnerContractExecutionError, ResourceBounds, ResourceBoundsMapping,
 };
 use starknet_rs_core::utils::{
-    get_selector_from_name, get_udc_deployed_address, UdcUniqueSettings,
+    UdcUniqueSettings, get_selector_from_name, get_udc_deployed_address,
 };
 use starknet_rs_providers::jsonrpc::{
     HttpTransport, HttpTransportError, JsonRpcClientError, JsonRpcError,

--- a/tests/integration/general_integration_tests.rs
+++ b/tests/integration/general_integration_tests.rs
@@ -11,7 +11,7 @@ use crate::common::constants::{
 };
 use crate::common::errors::RpcError;
 use crate::common::reqwest_client::{HttpEmptyResponseBody, PostReqwestSender};
-use crate::common::utils::{to_hex_felt, UniqueAutoDeletableFile};
+use crate::common::utils::{UniqueAutoDeletableFile, to_hex_felt};
 
 #[tokio::test]
 /// Asserts that a background instance can be spawned

--- a/tests/integration/test_abort_blocks.rs
+++ b/tests/integration/test_abort_blocks.rs
@@ -4,7 +4,7 @@ use starknet_rs_core::types::{BlockId, BlockTag, Felt};
 
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::reqwest_client::PostReqwestSender;
-use crate::common::utils::{assert_tx_reverted, to_hex_felt, FeeUnit};
+use crate::common::utils::{FeeUnit, assert_tx_reverted, to_hex_felt};
 
 static DUMMY_ADDRESS: u128 = 1;
 static DUMMY_AMOUNT: u128 = 1;

--- a/tests/integration/test_account_impersonation.rs
+++ b/tests/integration/test_account_impersonation.rs
@@ -11,7 +11,7 @@ use starknet_rs_signers::{LocalWallet, SigningKey};
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants::STRK_ERC20_CONTRACT_ADDRESS;
 use crate::common::utils::{
-    get_simple_contract_in_sierra_and_compiled_class_hash, FeeUnit, ImpersonationAction,
+    FeeUnit, ImpersonationAction, get_simple_contract_in_sierra_and_compiled_class_hash,
 };
 
 const IMPERSONATED_ACCOUNT_PRIVATE_KEY: Felt = Felt::ONE;

--- a/tests/integration/test_account_selection.rs
+++ b/tests/integration/test_account_selection.rs
@@ -16,8 +16,8 @@ use crate::common::constants::{
 };
 use crate::common::reqwest_client::GetReqwestSender;
 use crate::common::utils::{
-    assert_tx_successful, deploy_argent_account, deploy_oz_account,
-    get_simple_contract_in_sierra_and_compiled_class_hash, FeeUnit,
+    FeeUnit, assert_tx_successful, deploy_argent_account, deploy_oz_account,
+    get_simple_contract_in_sierra_and_compiled_class_hash,
 };
 
 pub async fn get_predeployed_accounts(

--- a/tests/integration/test_advancing_time.rs
+++ b/tests/integration/test_advancing_time.rs
@@ -11,8 +11,8 @@ use starknet_rs_providers::Provider;
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants;
 use crate::common::utils::{
-    get_block_reader_contract_in_sierra_and_compiled_class_hash, get_unix_timestamp_as_seconds,
-    send_ctrl_c_signal_and_wait, UniqueAutoDeletableFile,
+    UniqueAutoDeletableFile, get_block_reader_contract_in_sierra_and_compiled_class_hash,
+    get_unix_timestamp_as_seconds, send_ctrl_c_signal_and_wait,
 };
 
 const DUMMY_ADDRESS: u128 = 1;

--- a/tests/integration/test_blocks_generation.rs
+++ b/tests/integration/test_blocks_generation.rs
@@ -17,10 +17,10 @@ use starknet_rs_signers::Signer;
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants::{self, CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH};
 use crate::common::utils::{
-    assert_equal_elements, assert_tx_successful, get_contract_balance,
-    get_contract_balance_by_block_id, get_events_contract_in_sierra_and_compiled_class_hash,
-    get_simple_contract_in_sierra_and_compiled_class_hash, send_ctrl_c_signal_and_wait, FeeUnit,
-    UniqueAutoDeletableFile,
+    FeeUnit, UniqueAutoDeletableFile, assert_equal_elements, assert_tx_successful,
+    get_contract_balance, get_contract_balance_by_block_id,
+    get_events_contract_in_sierra_and_compiled_class_hash,
+    get_simple_contract_in_sierra_and_compiled_class_hash, send_ctrl_c_signal_and_wait,
 };
 
 static DUMMY_ADDRESS: u128 = 1;

--- a/tests/integration/test_dump_and_load.rs
+++ b/tests/integration/test_dump_and_load.rs
@@ -7,7 +7,7 @@ use starknet_rs_providers::Provider;
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants;
 use crate::common::reqwest_client::PostReqwestSender;
-use crate::common::utils::{send_ctrl_c_signal_and_wait, FeeUnit, UniqueAutoDeletableFile};
+use crate::common::utils::{FeeUnit, UniqueAutoDeletableFile, send_ctrl_c_signal_and_wait};
 
 static DUMMY_ADDRESS: u128 = 1;
 static DUMMY_AMOUNT: u128 = 1;

--- a/tests/integration/test_estimate_fee.rs
+++ b/tests/integration/test_estimate_fee.rs
@@ -13,7 +13,7 @@ use starknet_rs_core::types::{
     ResourceBounds, ResourceBoundsMapping, StarknetError, TransactionExecutionErrorData,
 };
 use starknet_rs_core::utils::{
-    cairo_short_string_to_felt, get_selector_from_name, get_udc_deployed_address, UdcUniqueness,
+    UdcUniqueness, cairo_short_string_to_felt, get_selector_from_name, get_udc_deployed_address,
 };
 use starknet_rs_providers::jsonrpc::HttpTransport;
 use starknet_rs_providers::{JsonRpcClient, Provider, ProviderError};
@@ -26,9 +26,10 @@ use crate::common::constants::{
     QUERY_VERSION_OFFSET, UDC_CONTRACT_ADDRESS,
 };
 use crate::common::utils::{
-    assert_tx_reverted, assert_tx_successful, extract_message_error, extract_nested_error,
-    get_deployable_account_signer, get_flattened_sierra_contract_and_casm_hash,
-    get_simple_contract_in_sierra_and_compiled_class_hash, LocalFee,
+    LocalFee, assert_tx_reverted, assert_tx_successful, extract_message_error,
+    extract_nested_error, get_deployable_account_signer,
+    get_flattened_sierra_contract_and_casm_hash,
+    get_simple_contract_in_sierra_and_compiled_class_hash,
 };
 
 fn assert_fee_estimation(fee_estimation: &FeeEstimate) {

--- a/tests/integration/test_estimate_message_fee.rs
+++ b/tests/integration/test_estimate_message_fee.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use starknet_rs_accounts::{Account, ExecutionEncoding, SingleOwnerAccount};
 use starknet_rs_contract::ContractFactory;
 use starknet_rs_core::types::{BlockId, BlockTag, EthAddress, Felt, MsgFromL1, StarknetError};
-use starknet_rs_core::utils::{get_udc_deployed_address, UdcUniqueness};
+use starknet_rs_core::utils::{UdcUniqueness, get_udc_deployed_address};
 use starknet_rs_providers::{Provider, ProviderError};
 
 use crate::common::background_devnet::BackgroundDevnet;

--- a/tests/integration/test_fork.rs
+++ b/tests/integration/test_fork.rs
@@ -24,10 +24,10 @@ use crate::common::constants::{
     MAINNET_HTTPS_URL, MAINNET_URL,
 };
 use crate::common::utils::{
-    assert_cairo1_classes_equal, assert_json_rpc_errors_equal, assert_tx_successful,
+    FeeUnit, assert_cairo1_classes_equal, assert_json_rpc_errors_equal, assert_tx_successful,
     declare_v3_deploy_v3, extract_json_rpc_error,
     get_block_reader_contract_in_sierra_and_compiled_class_hash, get_contract_balance,
-    get_simple_contract_in_sierra_and_compiled_class_hash, send_ctrl_c_signal_and_wait, FeeUnit,
+    get_simple_contract_in_sierra_and_compiled_class_hash, send_ctrl_c_signal_and_wait,
 };
 
 #[tokio::test]

--- a/tests/integration/test_messaging.rs
+++ b/tests/integration/test_messaging.rs
@@ -11,7 +11,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use ethers::prelude::*;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use server::test_utils::assert_contains;
 use starknet_rs_accounts::{
     Account, AccountError, ConnectedAccount, ExecutionEncoding, SingleOwnerAccount,
@@ -22,7 +22,7 @@ use starknet_rs_core::types::{
     InvokeTransactionResult, TransactionExecutionStatus, TransactionReceipt,
     TransactionReceiptWithBlockInfo,
 };
-use starknet_rs_core::utils::{get_selector_from_name, get_udc_deployed_address, UdcUniqueness};
+use starknet_rs_core::utils::{UdcUniqueness, get_selector_from_name, get_udc_deployed_address};
 use starknet_rs_providers::jsonrpc::HttpTransport;
 use starknet_rs_providers::{JsonRpcClient, Provider};
 use starknet_rs_signers::LocalWallet;
@@ -35,9 +35,9 @@ use crate::common::constants::{
 };
 use crate::common::errors::RpcError;
 use crate::common::utils::{
-    assert_tx_successful, felt_to_u256, get_messaging_contract_in_sierra_and_compiled_class_hash,
+    UniqueAutoDeletableFile, assert_tx_successful, felt_to_u256,
+    get_messaging_contract_in_sierra_and_compiled_class_hash,
     get_messaging_lib_in_sierra_and_compiled_class_hash, send_ctrl_c_signal_and_wait,
-    UniqueAutoDeletableFile,
 };
 
 const DUMMY_L1_ADDRESS: Felt =

--- a/tests/integration/test_old_state.rs
+++ b/tests/integration/test_old_state.rs
@@ -20,9 +20,9 @@ use crate::common::constants::{
     UDC_CONTRACT_ADDRESS, UDC_CONTRACT_CLASS_HASH,
 };
 use crate::common::utils::{
-    assert_cairo1_classes_equal, extract_message_error, extract_nested_error,
+    FeeUnit, assert_cairo1_classes_equal, extract_message_error, extract_nested_error,
     get_events_contract_in_sierra_and_compiled_class_hash,
-    get_flattened_sierra_contract_and_casm_hash, FeeUnit,
+    get_flattened_sierra_contract_and_casm_hash,
 };
 
 #[tokio::test]

--- a/tests/integration/test_restart.rs
+++ b/tests/integration/test_restart.rs
@@ -13,9 +13,9 @@ use crate::common::constants::{
     self, CAIRO_0_ACCOUNT_CONTRACT_HASH, CHAIN_ID, STRK_ERC20_CONTRACT_ADDRESS,
 };
 use crate::common::utils::{
-    assert_tx_successful, get_deployable_account_signer,
+    FeeUnit, assert_tx_successful, get_deployable_account_signer,
     get_simple_contract_in_sierra_and_compiled_class_hash, remove_file,
-    send_ctrl_c_signal_and_wait, FeeUnit,
+    send_ctrl_c_signal_and_wait,
 };
 
 #[tokio::test]

--- a/tests/integration/test_simulate_transactions.rs
+++ b/tests/integration/test_simulate_transactions.rs
@@ -16,7 +16,7 @@ use starknet_rs_core::types::{
     SimulationFlag, StarknetError, TransactionExecutionErrorData, TransactionTrace,
 };
 use starknet_rs_core::utils::{
-    cairo_short_string_to_felt, get_selector_from_name, get_udc_deployed_address, UdcUniqueness,
+    UdcUniqueness, cairo_short_string_to_felt, get_selector_from_name, get_udc_deployed_address,
 };
 use starknet_rs_providers::{Provider, ProviderError};
 use starknet_rs_signers::{LocalWallet, Signer, SigningKey};
@@ -29,10 +29,10 @@ use crate::common::constants::{
 };
 use crate::common::fees::{assert_difference_if_validation, assert_fee_in_resp_at_least_equal};
 use crate::common::utils::{
-    declare_v3_deploy_v3, get_deployable_account_signer,
+    LocalFee, declare_v3_deploy_v3, get_deployable_account_signer,
     get_flattened_sierra_contract_and_casm_hash,
     get_simple_contract_in_sierra_and_compiled_class_hash, iter_to_hex_felt, to_hex_felt,
-    to_num_as_hex, LocalFee,
+    to_num_as_hex,
 };
 
 #[tokio::test]

--- a/tests/integration/test_subscription_to_blocks.rs
+++ b/tests/integration/test_subscription_to_blocks.rs
@@ -6,11 +6,11 @@ use starknet_core::constants::ETH_ERC20_CONTRACT_ADDRESS;
 use starknet_rs_core::types::{BlockId, BlockTag};
 use starknet_rs_providers::Provider;
 use tokio::net::TcpStream;
-use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
 
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::utils::{
-    assert_no_notifications, receive_notification, subscribe_new_heads, unsubscribe, SubscriptionId,
+    SubscriptionId, assert_no_notifications, receive_notification, subscribe_new_heads, unsubscribe,
 };
 
 async fn receive_block(

--- a/tests/integration/test_subscription_to_events.rs
+++ b/tests/integration/test_subscription_to_events.rs
@@ -5,17 +5,17 @@ use starknet_core::constants::{STRK_ERC20_CONTRACT_ADDRESS, UDC_CONTRACT_ADDRESS
 use starknet_rs_accounts::{Account, ExecutionEncoding, SingleOwnerAccount};
 use starknet_rs_core::types::{BlockId, BlockTag, Call, Felt, InvokeTransactionResult};
 use starknet_rs_core::utils::get_selector_from_name;
-use starknet_rs_providers::jsonrpc::HttpTransport;
 use starknet_rs_providers::JsonRpcClient;
+use starknet_rs_providers::jsonrpc::HttpTransport;
 use starknet_rs_signers::LocalWallet;
 use tokio::net::TcpStream;
-use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
 
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants;
 use crate::common::utils::{
-    assert_no_notifications, declare_deploy_events_contract, receive_notification,
-    receive_rpc_via_ws, subscribe, unsubscribe, SubscriptionId,
+    SubscriptionId, assert_no_notifications, declare_deploy_events_contract, receive_notification,
+    receive_rpc_via_ws, subscribe, unsubscribe,
 };
 
 async fn subscribe_events(

--- a/tests/integration/test_subscription_to_pending_txs.rs
+++ b/tests/integration/test_subscription_to_pending_txs.rs
@@ -5,13 +5,13 @@ use starknet_core::constants::CHARGEABLE_ACCOUNT_ADDRESS;
 use starknet_rs_accounts::{ExecutionEncoding, SingleOwnerAccount};
 use starknet_rs_core::types::{DeclareTransaction, Felt, InvokeTransaction, Transaction};
 use tokio::net::TcpStream;
-use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
 
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants;
 use crate::common::utils::{
-    assert_no_notifications, declare_deploy_simple_contract, receive_rpc_via_ws, subscribe,
-    unsubscribe, FeeUnit, SubscriptionId,
+    FeeUnit, SubscriptionId, assert_no_notifications, declare_deploy_simple_contract,
+    receive_rpc_via_ws, subscribe, unsubscribe,
 };
 
 async fn subscribe_pending_txs(

--- a/tests/integration/test_subscription_to_tx_status.rs
+++ b/tests/integration/test_subscription_to_tx_status.rs
@@ -1,12 +1,12 @@
 use serde_json::json;
 use starknet_rs_core::types::{BlockId, Felt};
 use tokio::net::TcpStream;
-use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
 
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::utils::{
-    assert_no_notifications, receive_rpc_via_ws, subscribe, subscribe_new_heads, unsubscribe,
-    SubscriptionId,
+    SubscriptionId, assert_no_notifications, receive_rpc_via_ws, subscribe, subscribe_new_heads,
+    unsubscribe,
 };
 
 async fn subscribe_tx_status(

--- a/tests/integration/test_trace.rs
+++ b/tests/integration/test_trace.rs
@@ -11,7 +11,7 @@ use starknet_rs_core::types::{
     BlockId, BlockTag, DeployedContractItem, ExecuteInvocation, Felt, InvokeTransactionTrace,
     StarknetError, TransactionTrace,
 };
-use starknet_rs_core::utils::{get_selector_from_name, get_udc_deployed_address, UdcUniqueness};
+use starknet_rs_core::utils::{UdcUniqueness, get_selector_from_name, get_udc_deployed_address};
 use starknet_rs_providers::{Provider, ProviderError};
 
 use crate::common::background_devnet::BackgroundDevnet;

--- a/tests/integration/test_v3_transactions.rs
+++ b/tests/integration/test_v3_transactions.rs
@@ -19,8 +19,8 @@ use crate::common::constants::{
     self, CAIRO_0_ACCOUNT_CONTRACT_HASH, STRK_ERC20_CONTRACT_ADDRESS, UDC_CONTRACT_ADDRESS,
 };
 use crate::common::utils::{
-    assert_tx_successful, get_deployable_account_signer,
-    get_simple_contract_in_sierra_and_compiled_class_hash, FeeUnit, LocalFee,
+    FeeUnit, LocalFee, assert_tx_successful, get_deployable_account_signer,
+    get_simple_contract_in_sierra_and_compiled_class_hash,
 };
 
 enum Action {

--- a/tests/integration/test_websocket.rs
+++ b/tests/integration/test_websocket.rs
@@ -4,7 +4,7 @@ use tokio_tungstenite::connect_async;
 
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::utils::{
-    assert_no_notifications, send_binary_rpc_via_ws, send_text_rpc_via_ws, subscribe, FeeUnit,
+    FeeUnit, assert_no_notifications, send_binary_rpc_via_ws, send_text_rpc_via_ws, subscribe,
 };
 
 #[tokio::test]


### PR DESCRIPTION
## Usage related changes

None

## Development related changes

- Use the nightly from the date when Rust 1.85 was released (2025-02-20)
  - I made a mistake in the branch and commit saying it's from 2020, it's **NOT**
  - Should reduce the discrepancy between vs-code's default formatting on save and the result of `scripts/format.sh`
- Of the Rust code lines, only imports are modified.
- Replace deprecated property in `rustfmt.toml`: version -> style_edition

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI configurations and utility scripts to use the latest nightly Rust toolchain (Feb 2025) for builds, formatting, and checks.
  
- **Refactor**
  - Reorganized internal code imports across modules and tests to enhance consistency and clarity without affecting functionality.
  
- **Style**
  - Adjusted formatting configuration to align with the updated Rust style edition (2024), ensuring uniform code style across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->