### PR TITLE
Fix ByteArray handling in ERC20 predeployment

### DIFF
--- a/crates/starknet-devnet-core/src/starknet/predeployed.rs
+++ b/crates/starknet-devnet-core/src/starknet/predeployed.rs
@@ -3,6 +3,7 @@ use starknet_rs_core::types::Felt;
 use starknet_rs_core::utils::cairo_short_string_to_felt;
 use starknet_types::contract_address::ContractAddress;
 use starknet_types::felt::felt_from_prefixed_hex;
+use starknet_types_core::hash::Poseidon;
 
 use crate::constants::{
     CHARGEABLE_ACCOUNT_ADDRESS, UDC_CONTRACT, UDC_CONTRACT_ADDRESS, UDC_CONTRACT_CLASS_HASH,
@@ -22,6 +23,40 @@ pub(crate) fn create_erc20_at_address_extended(
     Ok(erc20_fee_contract)
 }
 
+fn store_short_string_as_byte_array(
+    state: &mut StarknetState,
+    contract_address: ContractAddress,
+    storage_var_name: &str,
+    short_str: &str,
+) -> DevnetResult<()> {
+    let storage_var_address = get_storage_var_address(storage_var_name, &[])?.try_into()?;
+
+    let felt_value =
+        cairo_short_string_to_felt(short_str).map_err(|_| Error::UnexpectedInternalError {
+            msg: format!("Cannot create a ByteArray from {short_str}"),
+        })?;
+
+    state.set_storage_at(
+        contract_address.try_into()?,
+        storage_var_address,
+        short_str.len().into(),
+    )?;
+
+    // That's how ByteArray is defined
+    let capacity_arg = cairo_short_string_to_felt("ByteArray")
+        .map_err(|e| Error::UnexpectedInternalError { msg: e.to_string() })?;
+
+    let chunk_index = Felt::ZERO;
+    let mut hashable = [storage_var_address.into(), chunk_index, capacity_arg];
+    Poseidon::hades_permutation(&mut hashable);
+    let chunk_base = starknet_api::state::StorageKey::try_from(hashable[0])?;
+
+    // no offset in chunk because the word is expected to be short
+    state.set_storage_at(contract_address.try_into()?, chunk_base, felt_value)?;
+
+    Ok(())
+}
+
 /// Set initial values of ERC20 contract storage
 pub(crate) fn initialize_erc20_at_address(
     state: &mut StarknetState,
@@ -31,17 +66,11 @@ pub(crate) fn initialize_erc20_at_address(
 ) -> DevnetResult<()> {
     let contract_address = ContractAddress::new(contract_address)?;
 
+    for (storage_var_name, string) in [("ERC20_name", erc20_name), ("ERC20_symbol", erc20_symbol)] {
+        store_short_string_as_byte_array(state, contract_address, storage_var_name, string)?;
+    }
+
     for (storage_var_name, storage_value) in [
-        (
-            "ERC20_name",
-            cairo_short_string_to_felt(erc20_name)
-                .map_err(|err| Error::UnexpectedInternalError { msg: err.to_string() })?,
-        ),
-        (
-            "ERC20_symbol",
-            cairo_short_string_to_felt(erc20_symbol)
-                .map_err(|err| Error::UnexpectedInternalError { msg: err.to_string() })?,
-        ),
         ("ERC20_decimals", 18.into()),
         // necessary to set - otherwise minting txs cannot be executed
         ("Ownable_owner", felt_from_prefixed_hex(CHARGEABLE_ACCOUNT_ADDRESS)?),

--- a/tests/integration/general_integration_tests.rs
+++ b/tests/integration/general_integration_tests.rs
@@ -2,9 +2,7 @@ use reqwest::StatusCode;
 use serde_json::json;
 use starknet_rs_core::codec::Decode;
 use starknet_rs_core::types::{BlockId, BlockTag, ByteArray, Felt, FunctionCall};
-use starknet_rs_core::utils::{
-    get_selector_from_name, get_storage_var_address, parse_cairo_short_string,
-};
+use starknet_rs_core::utils::{get_selector_from_name, get_storage_var_address};
 use starknet_rs_providers::Provider;
 
 use crate::common::background_devnet::BackgroundDevnet;
@@ -189,14 +187,14 @@ async fn test_config() {
     assert_eq!(fetched_config, expected_config);
 }
 
+/// Part of the responsibility of this test was transferred to test
+/// `predeployed_erc20_tokens_return_expected_values_from_property_getters`
 #[tokio::test]
 async fn predeployed_erc20_tokens_have_expected_storage() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
     for (token_address, var_name, expected_value) in [
-        (ETH_ERC20_CONTRACT_ADDRESS, "ERC20_name", "Ether"),
-        (ETH_ERC20_CONTRACT_ADDRESS, "ERC20_symbol", "ETH"),
-        (STRK_ERC20_CONTRACT_ADDRESS, "ERC20_name", "StarkNet Token"),
-        (STRK_ERC20_CONTRACT_ADDRESS, "ERC20_symbol", "STRK"),
+        (ETH_ERC20_CONTRACT_ADDRESS, "ERC20_decimals", Felt::from(18)),
+        (STRK_ERC20_CONTRACT_ADDRESS, "ERC20_decimals", Felt::from(18)),
     ] {
         let actual_value = devnet
             .json_rpc_client
@@ -208,7 +206,7 @@ async fn predeployed_erc20_tokens_have_expected_storage() {
             .await
             .unwrap();
 
-        assert_eq!(parse_cairo_short_string(&actual_value).unwrap().as_str(), expected_value);
+        assert_eq!(actual_value, expected_value);
     }
 }
 

--- a/tests/integration/general_integration_tests.rs
+++ b/tests/integration/general_integration_tests.rs
@@ -1,7 +1,10 @@
 use reqwest::StatusCode;
 use serde_json::json;
-use starknet_rs_core::types::{BlockId, BlockTag, Felt};
-use starknet_rs_core::utils::{get_storage_var_address, parse_cairo_short_string};
+use starknet_rs_core::codec::Decode;
+use starknet_rs_core::types::{BlockId, BlockTag, ByteArray, Felt, FunctionCall};
+use starknet_rs_core::utils::{
+    get_selector_from_name, get_storage_var_address, parse_cairo_short_string,
+};
 use starknet_rs_providers::Provider;
 
 use crate::common::background_devnet::BackgroundDevnet;
@@ -206,5 +209,33 @@ async fn predeployed_erc20_tokens_have_expected_storage() {
             .unwrap();
 
         assert_eq!(parse_cairo_short_string(&actual_value).unwrap().as_str(), expected_value);
+    }
+}
+
+#[tokio::test]
+async fn predeployed_erc20_tokens_return_expected_values_from_property_getters() {
+    let devnet = BackgroundDevnet::spawn().await.unwrap();
+    for (token_address, getter_name, expected_value) in [
+        (ETH_ERC20_CONTRACT_ADDRESS, "name", "Ether"),
+        (ETH_ERC20_CONTRACT_ADDRESS, "symbol", "ETH"),
+        (STRK_ERC20_CONTRACT_ADDRESS, "name", "StarkNet Token"),
+        (STRK_ERC20_CONTRACT_ADDRESS, "symbol", "STRK"),
+    ] {
+        let actual_felts = devnet
+            .json_rpc_client
+            .call(
+                FunctionCall {
+                    contract_address: token_address,
+                    entry_point_selector: get_selector_from_name(getter_name).unwrap(),
+                    calldata: vec![],
+                },
+                BlockId::Tag(BlockTag::Latest),
+            )
+            .await
+            .unwrap();
+
+        // We expect the felt vector to contain the encoded ByteArray, thus we decode it
+        let actual_string: String = ByteArray::decode(&actual_felts).unwrap().try_into().unwrap();
+        assert_eq!(&actual_string, expected_value);
     }
 }


### PR DESCRIPTION
## Usage related changes

- Close #739

## Development related changes

- Predeploy properties of type `ByteArray`

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an improved mechanism for converting and storing short text values, enhancing the initialization process for token contracts.
- **Tests**
	- Updated integration tests to verify proper storage and retrieval of token properties, ensuring greater consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->