### PR TITLE
Fix broken UDC docs link

### DIFF
--- a/website/versioned_docs/version-0.0.6/predeployed.md
+++ b/website/versioned_docs/version-0.0.6/predeployed.md
@@ -1,6 +1,6 @@
 # Predeployed contracts
 
-Devnet predeploys a [UDC](https://docs.openzeppelin.com/contracts-cairo/0.6.1/udc), an [ERC20 (fee token)](https://docs.openzeppelin.com/contracts-cairo/0.8.1/erc20) contract and a set of predeployed funded accounts.
+Devnet predeploys a [UDC](https://docs.openzeppelin.com/contracts-cairo/1.0.0/udc), an [ERC20 (fee token)](https://docs.openzeppelin.com/contracts-cairo/0.8.1/erc20) contract and a set of predeployed funded accounts.
 
 The set of accounts can be controlled via [CLI options](./running/cli): `--accounts <NUMBER_OF>`, `--initial-balance <WEI>`, `--seed <VALUE>`.
 


### PR DESCRIPTION
Updated outdated link pointing to UDC documentation version 0.6.1 (404) with the correct working version:
https://docs.openzeppelin.com/contracts-cairo/1.0.0/udc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the hyperlink for the Universal Decentralized Contract documentation to version 1.0.0, ensuring users access the latest version. The ERC20 documentation link remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->