### PR TITLE
Fix starknet_getStorageProof dummy implementation

### DIFF
--- a/crates/starknet-devnet-server/src/api/json_rpc/models.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/models.rs
@@ -52,7 +52,7 @@ pub struct GetStorageProofInput {
     pub block_id: BlockId,
     pub class_hashes: Option<Vec<Felt>>,
     pub contract_addresses: Option<Vec<ContractAddress>>,
-    pub contract_storage_keys: Option<ContractStorage>,
+    pub contracts_storage_keys: Option<Vec<ContractStorage>>,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/tests/integration/general_rpc_tests.rs
+++ b/tests/integration/general_rpc_tests.rs
@@ -1,10 +1,13 @@
 use serde_json::json;
-use starknet_rs_core::types::BlockId;
+use starknet_rs_core::types::ConfirmedBlockId;
+use starknet_rs_providers::Provider;
+use starknet_rs_providers::jsonrpc::JsonRpcError;
 
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants::RPC_PATH;
 use crate::common::errors::RpcError;
 use crate::common::reqwest_client::PostReqwestSender;
+use crate::common::utils::{assert_json_rpc_errors_equal, extract_json_rpc_error};
 
 #[tokio::test]
 async fn rpc_at_root() {
@@ -55,13 +58,14 @@ async fn rpc_returns_invalid_params() {
 #[tokio::test]
 async fn storage_proof_request_should_always_return_error() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
-    devnet.create_block().await.unwrap();
+
+    let devnet_storage_proof_msg = "Devnet doesn't support storage proofs";
 
     for (req_params, expected_code, expected_msg) in [
         (json!({}), -32602, "missing field `block_id`"),
-        (json!({ "block_id": BlockId::Number(0) }), 42, "Devnet doesn't support storage proofs"),
-        (json!({ "block_id": "latest" }), 42, "Devnet doesn't support storage proofs"),
-        (json!({ "block_id": BlockId::Number(5) }), 24, "Block not found"),
+        (json!({ "block_id": ConfirmedBlockId::Number(0) }), 42, devnet_storage_proof_msg),
+        (json!({ "block_id": "latest" }), 42, devnet_storage_proof_msg),
+        (json!({ "block_id": ConfirmedBlockId::Number(5) }), 24, "Block not found"),
     ] {
         let error =
             devnet.send_custom_rpc("starknet_getStorageProof", req_params).await.unwrap_err();
@@ -69,5 +73,16 @@ async fn storage_proof_request_should_always_return_error() {
             error,
             RpcError { code: expected_code.into(), message: expected_msg.into(), data: None }
         );
+    }
+
+    // Test with starknet-rs
+    match devnet.json_rpc_client.get_storage_proof(ConfirmedBlockId::Latest, [], [], []).await {
+        // Replace when this is accepted: https://github.com/xJonathanLEI/starknet-rs/pull/714
+        // Err(ProviderError::StarknetError(StarknetError::StorageProofNotSupported)) => (),
+        Err(e) => assert_json_rpc_errors_equal(
+            extract_json_rpc_error(e).unwrap(),
+            JsonRpcError { code: 42, message: devnet_storage_proof_msg.into(), data: None },
+        ),
+        other => panic!("Unexpected result: {other:?}"),
     }
 }


### PR DESCRIPTION
## Usage related changes

- Close #747 

## Development related changes

- Doing custom RPC error deserialization until starknet-rs includes https://github.com/xJonathanLEI/starknet-rs/pull/714

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded storage proof requests to support multiple storage keys, allowing for greater flexibility in specifying input.

- **Bug Fixes**
	- Standardized error feedback for unsupported storage proofs, ensuring consistent and clear messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->