### PR TITLE
Fix Typo in Test Function Name

### DIFF
--- a/crates/starknet-devnet-types/src/serde_helpers.rs
+++ b/crates/starknet-devnet-types/src/serde_helpers.rs
@@ -38,7 +38,7 @@ pub mod rpc_sierra_contract_class_to_sierra_contract_class {
         use crate::serde_helpers::rpc_sierra_contract_class_to_sierra_contract_class::deserialize_to_sierra_contract_class;
 
         #[test]
-        fn correct_deserialzation_from_sierra_contract_class_with_abi_field_as_string() {
+        fn correct_deserialization_from_sierra_contract_class_with_abi_field_as_string() {
             #[derive(Deserialize)]
             struct TestDeserialization(
                 #[allow(unused)]


### PR DESCRIPTION


## Description

This pull request corrects a typo in the test function name within the `serde_helpers.rs` file. The function `correct_deserialzation_from_sierra_contract_class_with_abi_field_as_string` had a misspelling in the word "deserialization" (missing the letter "i"). The corrected function name is now `correct_deserialization_from_sierra_contract_class_with_abi_field_as_string`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved test consistency by fixing a minor typographical error, ensuring clearer test naming without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->