### PR TITLE
Enable custom account in deploying L1-L2 messaging contract

### DIFF
--- a/crates/starknet-devnet-core/src/messaging/ethereum.rs
+++ b/crates/starknet-devnet-core/src/messaging/ethereum.rs
@@ -77,7 +77,7 @@ async fn assert_address_contains_any_code(
 
     if &messaging_contract_code.to_string() == "0x" || messaging_contract_code.len() <= 2 {
         return Err(Error::MessagingError(MessagingError::EthersError(format!(
-            "The specified address ({address}) contains no contract."
+            "The specified address ({address:#x}) contains no contract"
         ))));
     }
 

--- a/crates/starknet-devnet-core/src/messaging/ethereum.rs
+++ b/crates/starknet-devnet-core/src/messaging/ethereum.rs
@@ -84,12 +84,12 @@ impl EthereumMessaging {
     ///
     /// * `rpc_url` - The L1 node RPC URL.
     /// * `contract_address` - The messaging contract address deployed on L1 node.
-    /// * `funded_account_private_key` - The private key of the funded account on L1 node to perform
-    ///   the role of signer.
+    /// * `deployer_account_private_key` - The private key of the funded account on L1 node to
+    ///   perform the role of signer.
     pub async fn new(
         rpc_url: &str,
         contract_address: Option<&str>,
-        funded_account_private_key: Option<&str>,
+        deployer_account_private_key: Option<&str>,
     ) -> DevnetResult<EthereumMessaging> {
         let provider = Provider::<Http>::try_from(rpc_url).map_err(|e| {
             Error::MessagingError(MessagingError::EthersError(format!(
@@ -99,7 +99,7 @@ impl EthereumMessaging {
 
         let chain_id = provider.get_chainid().await?;
 
-        let private_key = match funded_account_private_key {
+        let private_key = match deployer_account_private_key {
             Some(private_key) => private_key,
             None => ETH_ACCOUNT_DEFAULT.private_key,
         };

--- a/crates/starknet-devnet-core/src/messaging/ethereum.rs
+++ b/crates/starknet-devnet-core/src/messaging/ethereum.rs
@@ -84,9 +84,12 @@ impl EthereumMessaging {
     ///
     /// * `rpc_url` - The L1 node RPC URL.
     /// * `contract_address` - The messaging contract address deployed on L1 node.
+    /// * `funded_account_private_key` - The private key of the funded account on L1 node to perform
+    ///   the role of signer.
     pub async fn new(
         rpc_url: &str,
         contract_address: Option<&str>,
+        funded_account_private_key: Option<&str>,
     ) -> DevnetResult<EthereumMessaging> {
         let provider = Provider::<Http>::try_from(rpc_url).map_err(|e| {
             Error::MessagingError(MessagingError::EthersError(format!(
@@ -96,7 +99,10 @@ impl EthereumMessaging {
 
         let chain_id = provider.get_chainid().await?;
 
-        let private_key = ETH_ACCOUNT_DEFAULT.private_key;
+        let private_key = match funded_account_private_key {
+            Some(private_key) => private_key,
+            None => ETH_ACCOUNT_DEFAULT.private_key,
+        };
 
         let wallet: LocalWallet =
             private_key.parse::<LocalWallet>()?.with_chain_id(chain_id.as_u32());

--- a/crates/starknet-devnet-core/src/messaging/ethereum.rs
+++ b/crates/starknet-devnet-core/src/messaging/ethereum.rs
@@ -75,7 +75,7 @@ async fn assert_address_contains_any_code(
         )))
     })?;
 
-    if &messaging_contract_code.to_string() == "0x" || messaging_contract_code.len() <= 2 {
+    if messaging_contract_code.is_empty() {
         return Err(Error::MessagingError(MessagingError::EthersError(format!(
             "The specified address ({address:#x}) contains no contract"
         ))));

--- a/crates/starknet-devnet-core/src/messaging/mod.rs
+++ b/crates/starknet-devnet-core/src/messaging/mod.rs
@@ -97,18 +97,18 @@ impl Starknet {
     ///
     /// * `rpc_url` - The L1 node RPC URL.
     /// * `contract_address` - The messaging contract address deployed on L1 node.
-    /// * `funded_account_private_key` - The private key of the funded account on L1 node to perform
-    ///   the role of signer.
+    /// * `deployer_account_private_key` - The private key of the funded account on L1 node to
+    ///   perform the role of signer.
     pub async fn configure_messaging(
         &mut self,
         rpc_url: &str,
         contract_address: Option<&str>,
-        funded_account_private_key: Option<&str>,
+        deployer_account_private_key: Option<&str>,
     ) -> DevnetResult<String> {
         tracing::trace!("Configuring messaging: {}", rpc_url);
 
         self.messaging.configure_ethereum(
-            EthereumMessaging::new(rpc_url, contract_address, funded_account_private_key).await?,
+            EthereumMessaging::new(rpc_url, contract_address, deployer_account_private_key).await?,
         );
 
         Ok(format!("0x{:x}", self.messaging.ethereum_ref()?.messaging_contract_address()))

--- a/crates/starknet-devnet-core/src/messaging/mod.rs
+++ b/crates/starknet-devnet-core/src/messaging/mod.rs
@@ -97,14 +97,19 @@ impl Starknet {
     ///
     /// * `rpc_url` - The L1 node RPC URL.
     /// * `contract_address` - The messaging contract address deployed on L1 node.
+    /// * `funded_account_private_key` - The private key of the funded account on L1 node to perform
+    ///   the role of signer.
     pub async fn configure_messaging(
         &mut self,
         rpc_url: &str,
         contract_address: Option<&str>,
+        funded_account_private_key: Option<&str>,
     ) -> DevnetResult<String> {
         tracing::trace!("Configuring messaging: {}", rpc_url);
 
-        self.messaging.configure_ethereum(EthereumMessaging::new(rpc_url, contract_address).await?);
+        self.messaging.configure_ethereum(
+            EthereumMessaging::new(rpc_url, contract_address, funded_account_private_key).await?,
+        );
 
         Ok(format!("0x{:x}", self.messaging.ethereum_ref()?.messaging_contract_address()))
     }

--- a/crates/starknet-devnet-server/src/api/http/endpoints/postman.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/postman.rs
@@ -23,8 +23,8 @@ pub(crate) async fn postman_load_impl(
     let messaging_contract_address = starknet
         .configure_messaging(
             &data.network_url,
-            data.address.as_deref(),
-            data.funded_account_private_key.as_deref(),
+            data.messaging_contract_address.as_deref(),
+            data.deployer_account_private_key.as_deref(),
         )
         .await?;
 

--- a/crates/starknet-devnet-server/src/api/http/endpoints/postman.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/postman.rs
@@ -20,8 +20,13 @@ pub(crate) async fn postman_load_impl(
     data: PostmanLoadL1MessagingContract,
 ) -> StrictRpcResult {
     let mut starknet = api.starknet.lock().await;
-    let messaging_contract_address =
-        starknet.configure_messaging(&data.network_url, data.address.as_deref()).await?;
+    let messaging_contract_address = starknet
+        .configure_messaging(
+            &data.network_url,
+            data.address.as_deref(),
+            data.funded_account_private_key.as_deref(),
+        )
+        .await?;
 
     Ok(DevnetResponse::MessagingContractAddress(MessagingLoadAddress {
         messaging_contract_address,

--- a/crates/starknet-devnet-server/src/api/http/models.rs
+++ b/crates/starknet-devnet-server/src/api/http/models.rs
@@ -32,6 +32,7 @@ pub struct LoadPath {
 pub struct PostmanLoadL1MessagingContract {
     pub network_url: String,
     pub address: Option<String>,
+    pub funded_account_private_key: Option<String>,
 }
 
 #[derive(Serialize)]

--- a/crates/starknet-devnet-server/src/api/http/models.rs
+++ b/crates/starknet-devnet-server/src/api/http/models.rs
@@ -31,8 +31,9 @@ pub struct LoadPath {
 #[cfg_attr(test, derive(Debug))]
 pub struct PostmanLoadL1MessagingContract {
     pub network_url: String,
-    pub address: Option<String>,
-    pub funded_account_private_key: Option<String>,
+    #[serde(alias = "address")]
+    pub messaging_contract_address: Option<String>,
+    pub deployer_account_private_key: Option<String>,
 }
 
 #[derive(Serialize)]

--- a/tests/integration/common/background_anvil.rs
+++ b/tests/integration/common/background_anvil.rs
@@ -76,7 +76,7 @@ impl BackgroundAnvil {
     }
 
     /// Spawns an instance at random port. Assumes CLI args in `args` don't contain `--port` or
-    /// mnemonic parameters. Uses the mnemonic seed defined in constants.
+    /// mnemonic parameters. Uses the mnemonic phrase defined in constants.
     pub(crate) async fn spawn_with_additional_args(args: &[&str]) -> Result<Self, TestError> {
         Self::spawn_with_additional_args_and_custom_signer(
             args,

--- a/tests/integration/common/background_devnet.rs
+++ b/tests/integration/common/background_devnet.rs
@@ -133,7 +133,7 @@ impl BackgroundDevnet {
 
         let process = Command::new(DEVNET_EXECUTABLE_BINARY_PATH)
             .args(Self::add_default_args(args))
-            .stdout(Stdio::piped()) // comment this out for complete devnet stdout
+            // .stdout(Stdio::piped()) // comment this out for complete devnet stdout
             .spawn()
             .map_err(|e| TestError::DevnetNotStartable(format!("Spawning error: {e:?}")))?;
 

--- a/tests/integration/common/background_devnet.rs
+++ b/tests/integration/common/background_devnet.rs
@@ -133,7 +133,7 @@ impl BackgroundDevnet {
 
         let process = Command::new(DEVNET_EXECUTABLE_BINARY_PATH)
             .args(Self::add_default_args(args))
-            // .stdout(Stdio::piped()) // comment this out for complete devnet stdout
+            .stdout(Stdio::piped()) // comment this out for complete devnet stdout
             .spawn()
             .map_err(|e| TestError::DevnetNotStartable(format!("Spawning error: {e:?}")))?;
 

--- a/tests/integration/common/constants.rs
+++ b/tests/integration/common/constants.rs
@@ -104,3 +104,5 @@ pub const QUERY_VERSION_OFFSET: Felt =
 
 pub const DEFAULT_ETH_ACCOUNT_PRIVATE_KEY: &str =
     "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+pub const DEFAULT_ETH_ACCOUNT_ADDRESS: &str = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";

--- a/tests/integration/common/constants.rs
+++ b/tests/integration/common/constants.rs
@@ -102,7 +102,7 @@ pub const INTEGRATION_SAFE_BLOCK: u64 = 64718;
 pub const QUERY_VERSION_OFFSET: Felt =
     Felt::from_raw([576460752142434320, 18446744073709551584, 17407, 18446744073700081665]);
 
+pub const DEFAULT_ANVIL_MNEMONIC_PHRASE: &str =
+    "test test test test test test test test test test test junk";
 pub const DEFAULT_ETH_ACCOUNT_PRIVATE_KEY: &str =
     "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
-
-pub const DEFAULT_ETH_ACCOUNT_ADDRESS: &str = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";

--- a/tests/integration/common/constants.rs
+++ b/tests/integration/common/constants.rs
@@ -104,5 +104,6 @@ pub const QUERY_VERSION_OFFSET: Felt =
 
 pub const DEFAULT_ANVIL_MNEMONIC_PHRASE: &str =
     "test test test test test test test test test test test junk";
+/// Account at index 0 if DEFAULT_ANVIL_MNEMONIC_PHRASE used
 pub const DEFAULT_ETH_ACCOUNT_PRIVATE_KEY: &str =
     "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";

--- a/tests/integration/test_messaging.rs
+++ b/tests/integration/test_messaging.rs
@@ -375,7 +375,7 @@ async fn setup_anvil_incorrect_eth_private_key() {
             "devnet_postmanLoad",
             json!({
                 "network_url": anvil.url,
-                "funded_account_private_key": DEFAULT_ETH_ACCOUNT_PRIVATE_KEY
+                "deployer_account_private_key": DEFAULT_ETH_ACCOUNT_PRIVATE_KEY
             }),
         )
         .await
@@ -400,7 +400,7 @@ async fn deploy_l1_messaging_contract_with_custom_key() {
             "devnet_postmanLoad",
             json!({
                 "network_url": anvil.url,
-                "funded_account_private_key": ACCOUNT_0_PRIVATE_KEY_WITH_SEED_42
+                "deployer_account_private_key": ACCOUNT_0_PRIVATE_KEY_WITH_SEED_42
             }),
         )
         .await

--- a/tests/integration/test_messaging.rs
+++ b/tests/integration/test_messaging.rs
@@ -29,7 +29,8 @@ use starknet_rs_signers::LocalWallet;
 use crate::common::background_anvil::BackgroundAnvil;
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants::{
-    CHAIN_ID, L1_HANDLER_SELECTOR, MESSAGING_L1_CONTRACT_ADDRESS, MESSAGING_L2_CONTRACT_ADDRESS,
+    CHAIN_ID, DEFAULT_ETH_ACCOUNT_ADDRESS, DEFAULT_ETH_ACCOUNT_PRIVATE_KEY, L1_HANDLER_SELECTOR,
+    MESSAGING_L1_CONTRACT_ADDRESS, MESSAGING_L2_CONTRACT_ADDRESS,
     MESSAGING_WHITELISTED_L1_CONTRACT,
 };
 use crate::common::errors::RpcError;
@@ -338,6 +339,44 @@ async fn can_deploy_l1_messaging_contract() {
 
     let body = devnet
         .send_custom_rpc("devnet_postmanLoad", json!({ "network_url": anvil.url }))
+        .await
+        .expect("deploy l1 messaging contract failed");
+
+    assert_eq!(
+        body.get("messaging_contract_address").unwrap().as_str().unwrap(),
+        MESSAGING_L1_ADDRESS
+    );
+}
+
+#[tokio::test]
+async fn setup_anvil_incorrect_eth_private_key() {
+    let anvil = BackgroundAnvil::spawn_with_additional_args(&["--balance", "0"]).await.unwrap();
+
+    let (devnet, _, _) = setup_devnet(&["--account-class", "cairo1"]).await;
+
+    let body = devnet
+        .send_custom_rpc(
+            "devnet_postmanLoad",
+            json!({ "network_url": anvil.url,
+            "funded_account_private_key": DEFAULT_ETH_ACCOUNT_PRIVATE_KEY }),
+        )
+        .await
+        .unwrap_err();
+    assert_contains(&body.message, "Out of gas: gas required exceeds allowance: 0");
+}
+
+#[tokio::test]
+async fn deploy_l1_messaging_contract_with_funded_account_private_key() {
+    let anvil = BackgroundAnvil::spawn().await.unwrap();
+    assert_eq!(
+        anvil.provider_signer.address(),
+        DEFAULT_ETH_ACCOUNT_ADDRESS.parse::<Address>().unwrap()
+    );
+
+    let (devnet, _, _) = setup_devnet(&["--account-class", "cairo1"]).await;
+
+    let body = devnet
+        .send_custom_rpc("devnet_postmanLoad", json!({ "network_url": anvil.url, "funded_account_private_key": DEFAULT_ETH_ACCOUNT_PRIVATE_KEY }))
         .await
         .expect("deploy l1 messaging contract failed");
 

--- a/tests/integration/test_messaging.rs
+++ b/tests/integration/test_messaging.rs
@@ -384,19 +384,31 @@ async fn setup_anvil_incorrect_eth_private_key() {
 }
 
 #[tokio::test]
-async fn deploy_l1_messaging_contract_with_funded_account_private_key() {
-    let anvil = BackgroundAnvil::spawn().await.unwrap();
+async fn deploy_l1_messaging_contract_with_custom_key() {
+    let anvil = BackgroundAnvil::spawn_with_additional_args_and_custom_signer(
+        &[],
+        MNEMONIC_FROM_SEED_42,
+        ACCOUNT_0_PRIVATE_KEY_WITH_SEED_42,
+    )
+    .await
+    .unwrap();
 
     let (devnet, _, _) = setup_devnet(&["--account-class", "cairo1"]).await;
 
     let body = devnet
-        .send_custom_rpc("devnet_postmanLoad", json!({ "network_url": anvil.url, "funded_account_private_key": DEFAULT_ETH_ACCOUNT_PRIVATE_KEY }))
+        .send_custom_rpc(
+            "devnet_postmanLoad",
+            json!({
+                "network_url": anvil.url,
+                "funded_account_private_key": ACCOUNT_0_PRIVATE_KEY_WITH_SEED_42
+            }),
+        )
         .await
         .expect("deploy l1 messaging contract failed");
 
     assert_eq!(
         body.get("messaging_contract_address").unwrap().as_str().unwrap(),
-        MESSAGING_L1_ADDRESS
+        "0xca945eebf408d4a73e5d330fc8f6b55cd1e419ff"
     );
 }
 

--- a/website/docs/postman.md
+++ b/website/docs/postman.md
@@ -16,7 +16,7 @@ You can use [**`starknet-devnet-js`**](https://github.com/0xSpaceShard/starknet-
 
 ## Load
 
-<!-- TODO Add info on how the messaging contract can be deployed various L1 networks. -->
+<!-- TODO Add info on how the messaging contract can be deployed on various L1 networks. -->
 
 ```
 POST /postman/load_l1_messaging_contract
@@ -43,7 +43,7 @@ JSON-RPC
 }
 ```
 
-Loads a `MockStarknetMessaging` contract. The `address` parameter is optional; if provided, the `MockStarknetMessaging` contract will be fetched from that address, otherwise a new one will be deployed. 
+Loads a `MockStarknetMessaging` contract. The `address` parameter is optional; if provided, the `MockStarknetMessaging` contract will be fetched from that address, otherwise a new one will be deployed.
 
 The `funded_account_private_key` parameter is optional; if provided, then this account would be used as the signer. The account associated with this private key must be pre-funded.
 

--- a/website/docs/postman.md
+++ b/website/docs/postman.md
@@ -16,6 +16,8 @@ You can use [**`starknet-devnet-js`**](https://github.com/0xSpaceShard/starknet-
 
 ## Load
 
+<!-- TODO Add info on how the messaging contract can be deployed various L1 networks. -->
+
 ```
 POST /postman/load_l1_messaging_contract
 ```

--- a/website/docs/postman.md
+++ b/website/docs/postman.md
@@ -25,7 +25,8 @@ POST /postman/load_l1_messaging_contract
 ```json
 {
   "network_url": "http://localhost:8545",
-  "address": "0x123...def" // optional
+  "address": "0x123...def", // optional
+  "funded_account_private_key": "0xe2ac...583f" // optional, different from the address parameter.
 }
 ```
 
@@ -42,7 +43,9 @@ JSON-RPC
 }
 ```
 
-Loads a `MockStarknetMessaging` contract. The `address` parameter is optional; if provided, the `MockStarknetMessaging` contract will be fetched from that address, otherwise a new one will be deployed.
+Loads a `MockStarknetMessaging` contract. The `address` parameter is optional; if provided, the `MockStarknetMessaging` contract will be fetched from that address, otherwise a new one will be deployed. 
+
+The `funded_account_private_key` parameter is optional; if provided, then this account would be used as the signer. The account associated with this private key must be pre-funded.
 
 :::note L1-L2 with dockerized Devnet
 

--- a/website/docs/postman.md
+++ b/website/docs/postman.md
@@ -28,20 +28,21 @@ POST /postman/load_l1_messaging_contract
 }
 ```
 
-```
-JSON-RPC
+```json
+// JSON-RPC
 {
-    "jsonrpc": "2.0",
-    "id": "1",
-    "method": "devnet_postmanLoad",
-    "params": {
-      "network_url": "http://localhost:8545",
-      "messaging_contract_address": "0x123...def"
-    }
+  "jsonrpc": "2.0",
+  "id": "1",
+  "method": "devnet_postmanLoad",
+  "params": {
+    "network_url": "http://localhost:8545",
+    "messaging_contract_address": "0x123...def", // optional
+    "deployer_account_private_key": "0xe2ac...583f" // optional
+  }
 }
 ```
 
-Loads a `MockStarknetMessaging` contract instance, potentially deploying a new one, which is used for exchanging message between L1 and L2.
+Loads an L1 `MockStarknetMessaging` contract instance, potentially deploying a new one, which is used for message exchange between L1 and L2.
 
 ### L1 network
 
@@ -58,8 +59,9 @@ The `network_url` parameter refers to the URL of the JSON-RPC API endpoint of th
 Here's how the rest of the parameters should be used, depending on your L1 network:
 
 - If your L1 network already has a messaging contract deployed that you wish to use, populate `messaging_contract_address` with its address.
+  - The provided address shall be checked by asserting that there indeed is contract code deployed at that address, without any ABI assertions.
 - If your L1 network does not have such a contract, or you simplify wish to deploy a new instance, leave out the `messaging_contract_address` property.
-  - If your L1 network is a local testnet (e.g. Anvil) with the default mnemonic seed and a default set of predeployed accounts, you don't have to specify anything else, a new messaging contract shall be deployed.
+  - If your L1 network is a local testnet (e.g. Anvil) with the default mnemonic seed and a default set of predeployed accounts, you don't have to specify anything else—a new messaging contract shall be deployed using a predeployed account.
   - Otherwise (e.g. on the Sepolia testnet or an Anvil with a custom mnemonic seed) you are expected to populate `deployer_account_private_key` with the private key of a funded account. This property is not applicable if `messaging_contract_address` is specified.
 
 :::note L1-L2 with dockerized Devnet

--- a/website/docs/postman.md
+++ b/website/docs/postman.md
@@ -16,8 +16,6 @@ You can use [**`starknet-devnet-js`**](https://github.com/0xSpaceShard/starknet-
 
 ## Load
 
-<!-- TODO Add info on how the messaging contract can be deployed on various L1 networks. -->
-
 ```
 POST /postman/load_l1_messaging_contract
 ```
@@ -25,8 +23,8 @@ POST /postman/load_l1_messaging_contract
 ```json
 {
   "network_url": "http://localhost:8545",
-  "address": "0x123...def", // optional
-  "funded_account_private_key": "0xe2ac...583f" // optional, different from the address parameter.
+  "messaging_contract_address": "0x123...def", // optional
+  "deployer_account_private_key": "0xe2ac...583f" // optional
 }
 ```
 
@@ -38,23 +36,12 @@ JSON-RPC
     "method": "devnet_postmanLoad",
     "params": {
       "network_url": "http://localhost:8545",
-      "address": "0x123...def"
+      "messaging_contract_address": "0x123...def"
     }
 }
 ```
 
-Loads a `MockStarknetMessaging` contract. The `address` parameter is optional; if provided, the `MockStarknetMessaging` contract will be fetched from that address, otherwise a new one will be deployed.
-
-The `funded_account_private_key` parameter is optional; if provided, then this account would be used as the signer. The account associated with this private key must be pre-funded.
-
-:::note L1-L2 with dockerized Devnet
-
-L1-L2 communication requires extra attention if Devnet is [run in a Docker container](./running/docker.md). The `network_url` argument must be on the same network as Devnet. E.g. if your L1 instance is run locally (i.e. using the host machine's network), then:
-
-- on Linux, it is enough to run the Devnet Docker container with `--network host`
-- on Mac and Windows, replace any `http://localhost` or `http://127.0.0.1` occurrence in the value of `network_url` with `http://host.docker.internal`.
-
-:::
+Loads a `MockStarknetMessaging` contract instance, potentially deploying a new one, which is used for exchanging message between L1 and L2.
 
 ### L1 network
 
@@ -65,6 +52,24 @@ The `network_url` parameter refers to the URL of the JSON-RPC API endpoint of th
 - [**Ganache**](https://www.npmjs.com/package/ganache)
 - [**Geth**](https://github.com/ethereum/go-ethereum#docker-quick-start)
 - [**Hardhat node**](https://hardhat.org/hardhat-network/#running-stand-alone-in-order-to-support-wallets-and-other-software)
+
+### Messaging contract deployment
+
+Here's how the rest of the parameters should be used, depending on your L1 network:
+
+- If your L1 network already has a messaging contract deployed that you wish to use, populate `messaging_contract_address` with its address.
+- If your L1 network does not have such a contract, or you simplify wish to deploy a new instance, leave out the `messaging_contract_address` property.
+  - If your L1 network is a local testnet (e.g. Anvil) with the default mnemonic seed and a default set of predeployed accounts, you don't have to specify anything else, a new messaging contract shall be deployed.
+  - Otherwise (e.g. on the Sepolia testnet or an Anvil with a custom mnemonic seed) you are expected to populate `deployer_account_private_key` with the private key of a funded account. This property is not applicable if `messaging_contract_address` is specified.
+
+:::note L1-L2 with dockerized Devnet
+
+L1-L2 communication requires extra attention if Devnet is [run in a Docker container](./running/docker.md). The `network_url` argument must be on the same network as Devnet. E.g. if your L1 instance is run locally (i.e. using the host machine's network), then:
+
+- on Linux, it is enough to run the Devnet Docker container with `--network host`
+- on Mac and Windows, replace any `http://localhost` or `http://127.0.0.1` occurrence in the value of `network_url` with `http://host.docker.internal`.
+
+:::
 
 :::info Dumping and Loading
 
@@ -109,7 +114,11 @@ JSON-RPC
 }
 ```
 
+:::note
+
 A running L1 node is required if `dry_run` is not set.
+
+:::
 
 :::info Dumping and Loading
 

--- a/website/static/devnet_api.json
+++ b/website/static/devnet_api.json
@@ -123,11 +123,19 @@
           }
         },
         {
-          "name": "address",
-          "description": "Address of contract deployed on L1 node",
+          "name": "messaging_contract_address",
+          "description": "Address of an already deployed messaging contract on L1. If specified, no new contract is deployed.",
           "required": false,
           "schema": {
-            "title": "Contract address",
+            "$ref": "#/components/schemas/ETH_ADDRESS"
+          }
+        },
+        {
+          "name": "deployer_account_private_key",
+          "description": "The private key of the account that shall be used for deploying the messaging contract. Not applicable if `messaging_contract_address` is specified.",
+          "required": false,
+          "schema": {
+            "title": "Deployer account private key",
             "type": "string"
           }
         }
@@ -141,8 +149,7 @@
             "messaging_contract_address": {
               "title": "The address of the messaging contract",
               "schema": {
-                "title": "Contract address",
-                "type": "string"
+                "$ref": "#/components/schemas/ETH_ADDRESS"
               }
             }
           },

--- a/website/static/devnet_api.json
+++ b/website/static/devnet_api.json
@@ -136,7 +136,8 @@
           "required": false,
           "schema": {
             "title": "Deployer account private key",
-            "type": "string"
+            "type": "string",
+            "pattern": "^0x[a-fA-F0-9]{64}$"
           }
         }
       ],


### PR DESCRIPTION
## Usage related changes

- Fixes #727
- Introduces validation on L1 messaging contract loading
  - In case an address of an already deployed contract is provided, it is asserted that there indeed is something deployed there (not checking ABI).
- The preferred property for specifying the address of the messaging contract is now: `messaging_contract_address` (`address` still acceptable for backwards compatibility but deprecated).
- Improve L1-L2 docs to include a complete messaging contract loading tutorial

## Development related changes

- Continuation of #740
- Add `BackgroundAnvil` methods for starting Anvil with custom signer.
  - Refactoring method for starting Anvil with custom args.

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
  - [x] Update devnet_api.json
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a deployer account private key when loading or deploying the L1 messaging contract, enabling custom signer configuration.
  - The messaging contract address is now validated to ensure it contains contract code before configuration proceeds.

- **API Changes**
  - The /postman/load_l1_messaging_contract endpoint now accepts messaging_contract_address (renamed from address) and an optional deployer_account_private_key.
  - API documentation and schema updated to reflect these new parameters.

- **Bug Fixes**
  - Improved error handling when loading a messaging contract that is not deployed or when using incorrect private keys.

- **Documentation**
  - Updated user guides and API references to describe the new parameters and deployment logic for messaging contracts.

- **Tests**
  - Added comprehensive tests for loading, deploying, and interacting with the L1 messaging contract, including custom key scenarios and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->