### PR TITLE
Update BouncerConfig

### DIFF
--- a/crates/starknet-devnet-core/src/utils.rs
+++ b/crates/starknet-devnet-core/src/utils.rs
@@ -53,7 +53,7 @@ pub(crate) fn custom_bouncer_config() -> BouncerConfig {
     BouncerConfig {
         block_max_capacity: BouncerWeights {
             l1_gas: 4_950_000,
-            sierra_gas: starknet_api::execution_resources::GasAmount(500_000_000),
+            sierra_gas: starknet_api::execution_resources::GasAmount(5_000_000_000),
             state_diff_size: 4_000,
             n_events: 5_000,
             ..BouncerWeights::max()

--- a/crates/starknet-devnet-core/src/utils.rs
+++ b/crates/starknet-devnet-core/src/utils.rs
@@ -53,7 +53,7 @@ pub(crate) fn custom_bouncer_config() -> BouncerConfig {
     BouncerConfig {
         block_max_capacity: BouncerWeights {
             l1_gas: 4_950_000,
-            sierra_gas: starknet_api::execution_resources::GasAmount(250_000_000),
+            sierra_gas: starknet_api::execution_resources::GasAmount(500_000_000),
             state_diff_size: 4_000,
             n_events: 5_000,
             ..BouncerWeights::max()


### PR DESCRIPTION
## Usage related changes

- Waiting for [this Slack thread](https://spaceshard.slack.com/archives/C029F9AN8LX/p1744792501495849) to be resolved. The number that is currently configured (5e8) is probably wrong.

- The final mentioned number is 5e9

## Development related changes

<!-- How these changes affect the developers of this project. E.g. changes in dev tools, testing, CI/CD... -->

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [ ] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] No spelling errors - `./scripts/check_spelling.sh`
- [ ] Performed code self-review
- [ ] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [ ] Updated the docs if needed - `./website/README.md`
- [ ] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)
