### PR TITLE
Warning message for old V3 transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6112,6 +6112,7 @@ dependencies = [
  "starknet-types-core",
  "starknet_api",
  "thiserror 1.0.69",
+ "tracing",
  "universal-sierra-compiler",
 ]
 

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -1256,7 +1256,7 @@ impl Starknet {
                     // fail if the fee provided is 0
                     // succeed if the fee provided is 0 and SKIP_FEE_CHARGE is set
                     // succeed if the fee provided is > 0
-                    if !txn.is_max_fee_valid() && !skip_fee_charge {
+                    if !skip_fee_charge && !txn.is_max_fee_valid()  {
                         return Err(Error::ContractExecutionErrorInSimulation {
                             failure_index: tx_idx,
                             execution_error: ContractExecutionError::from(TransactionValidationError::InsufficientResourcesForValidate

--- a/crates/starknet-devnet-types/Cargo.toml
+++ b/crates/starknet-devnet-types/Cargo.toml
@@ -32,6 +32,7 @@ serde_json = { workspace = true, features = [
 num-bigint = { workspace = true }
 bigdecimal = { workspace = true }
 usc = { workspace = true }
+tracing = { workspace = true }
 
 # Cairo-lang dependencies
 cairo-lang-compiler = { workspace = true }

--- a/crates/starknet-devnet-types/src/rpc/transactions.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions.rs
@@ -427,7 +427,8 @@ impl BroadcastedTransactionCommonV3 {
                 true
             }
             // l2 > 0 and l1_data > 0
-            // l1 gas is not checked, because l1 gas is used for L2->L1 messages and not every transaction sends data to L1
+            // l1 gas is not checked, because l1 gas is used for L2->L1 messages and not every
+            // transaction sends data to L1
             (_, l2, l1_data) if is_gt_zero(l2) && is_gt_zero(l1_data) => true,
             _ => false,
         }


### PR DESCRIPTION
## Usage related changes

- Warning message is displayed, when only only `resource_bounds.l1_gas > 0`
- Refactored `are_gas_bounds_valid`
- Remove `fn log_if_deprecated_tx`

## Development related changes

<!-- How these changes affect the developers of this project. E.g. changes in dev tools, testing, CI/CD... -->

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [ ] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] No spelling errors - `./scripts/check_spelling.sh`
- [ ] Performed code self-review
- [ ] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [ ] Updated the docs if needed - `./website/README.md`
- [ ] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation logic for gas resource bounds in transaction processing, ensuring more accurate handling of L2 and L1 data gas requirements.
- **Chores**
	- Removed deprecated transaction logging and related methods, streamlining transaction handling and reducing unnecessary warnings.
	- Updated dependencies to include enhanced tracing capabilities for improved diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->