### PR TITLE
Improve L1->L2 mock docs

### DIFF
--- a/website/docs/postman.md
+++ b/website/docs/postman.md
@@ -138,11 +138,13 @@ constructor(MockStarknetMessaging mockStarknetMessaging_) public {
 
 A running L1 node is **not** required for this operation.
 
+The L2 target entrypoint must be an `l1_handler`.
+
 :::
 
-Sends a mock transactions to L2, as if coming from L1, without the need for running L1. The deployed L2 contract address `l2_contract_address` and `entry_point_selector` must be valid, otherwise a new block will not be created. The `l1_transaction_hash` property is optional and, if provided, enables future `starknet_getMessagesStatus` requests with that hash value provided.
+Sends a mock transactions to L2, as if coming from L1, without the need for running L1. The target L2 contract's address must be provided to `l2_contract_address` and the `entry_point_selector` must refer to a public method of the target contract. The method must be annotated with `l1_handler`, otherwise an `ENTRYPOINT_NOT_FOUND` error may be returned. The `l1_transaction_hash` property is optional and, if provided, enables future `starknet_getMessagesStatus` requests with that hash value provided.
 
-Normally `nonce` is calculated by the L1 Starknet contract and it is used in L1 and L2. In this case, it needs to be provided manually.
+In regular (non-mocking) L1-L2 interaction, `nonce` is determined by the L1 Starknet contract. In this mock case, it is up to the developer to set it.
 
 ```
 POST /postman/send_message_to_l2
@@ -155,12 +157,9 @@ Request:
     "l2_contract_address": "0x00285ddb7e5c777b310d806b9b2a0f7c7ba0a41f12b420219209d97a3b7f25b2",
     "entry_point_selector": "0xC73F681176FC7B3F9693986FD7B14581E8D540519E27400E88B8713932BE01",
     "l1_contract_address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
-    "payload": [
-      "0x1",
-      "0x2"
-    ],
+    "payload": [ "0x1", "0x2" ],
     "paid_fee_on_l1": "0x123456abcdef",
-    "nonce":"0x0",
+    "nonce": "0x0",
     "l1_transaction_hash": "0x000abc123", // optional
 }
 ```
@@ -175,12 +174,9 @@ JSON-RPC
       "l2_contract_address": "0x00285ddb7e5c777b310d806b9b2a0f7c7ba0a41f12b420219209d97a3b7f25b2",
       "entry_point_selector": "0xC73F681176FC7B3F9693986FD7B14581E8D540519E27400E88B8713932BE01",
       "l1_contract_address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
-      "payload": [
-        "0x1",
-        "0x2"
-      ],
+      "payload": [ "0x1", "0x2" ],
       "paid_fee_on_l1": "0x123456abcdef",
-      "nonce":"0x0",
+      "nonce": "0x0",
       "l1_transaction_hash": "0x000abc123", // optional
   }
 }

--- a/website/versioned_docs/version-0.2.4/postman.md
+++ b/website/versioned_docs/version-0.2.4/postman.md
@@ -117,11 +117,13 @@ constructor(MockStarknetMessaging mockStarknetMessaging_) public {
 
 A running L1 node is **not** required for this operation.
 
+The L2 target entrypoint must be an `l1_handler`.
+
 :::
 
-Sends a mock transactions to L2, as if coming from L1, without the need for running L1. The deployed L2 contract address `l2_contract_address` and `entry_point_selector` must be valid, otherwise a new block will not be created.
+Sends a mock transactions to L2, as if coming from L1, without the need for running L1. The target L2 contract's address must be provided to `l2_contract_address` and the `entry_point_selector` must refer to a public method of the target contract. The method must be annotated with `l1_handler`, otherwise an `ENTRYPOINT_NOT_FOUND` error may be returned.
 
-Normally `nonce` is calculated by the L1 Starknet contract and it is used in L1 and L2. In this case, it needs to be provided manually.
+In regular (non-mocking) L1-L2 interaction, `nonce` is determined by the L1 Starknet contract. In this mock case, it is up to the developer to set it.
 
 ```
 POST /postman/send_message_to_l2
@@ -134,12 +136,9 @@ Request:
     "l2_contract_address": "0x00285ddb7e5c777b310d806b9b2a0f7c7ba0a41f12b420219209d97a3b7f25b2",
     "entry_point_selector": "0xC73F681176FC7B3F9693986FD7B14581E8D540519E27400E88B8713932BE01",
     "l1_contract_address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
-    "payload": [
-      "0x1",
-      "0x2"
-    ],
+    "payload": [ "0x1", "0x2" ],
     "paid_fee_on_l1": "0x123456abcdef",
-    "nonce":"0x0"
+    "nonce": "0x0"
 }
 ```
 
@@ -153,12 +152,9 @@ JSON-RPC
       "l2_contract_address": "0x00285ddb7e5c777b310d806b9b2a0f7c7ba0a41f12b420219209d97a3b7f25b2",
       "entry_point_selector": "0xC73F681176FC7B3F9693986FD7B14581E8D540519E27400E88B8713932BE01",
       "l1_contract_address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
-      "payload": [
-        "0x1",
-        "0x2"
-      ],
+      "payload": [ "0x1", "0x2" ],
       "paid_fee_on_l1": "0x123456abcdef",
-      "nonce":"0x0"
+      "nonce": "0x0"
   }
 }
 ```

--- a/website/versioned_docs/version-0.3.0/postman.md
+++ b/website/versioned_docs/version-0.3.0/postman.md
@@ -138,11 +138,13 @@ constructor(MockStarknetMessaging mockStarknetMessaging_) public {
 
 A running L1 node is **not** required for this operation.
 
+The L2 target entrypoint must be an `l1_handler`.
+
 :::
 
-Sends a mock transactions to L2, as if coming from L1, without the need for running L1. The deployed L2 contract address `l2_contract_address` and `entry_point_selector` must be valid, otherwise a new block will not be created. The `l1_transaction_hash` property is optional and, if provided, enables future `starknet_getMessagesStatus` requests with that hash value provided.
+Sends a mock transactions to L2, as if coming from L1, without the need for running L1. The target L2 contract's address must be provided to `l2_contract_address` and the `entry_point_selector` must refer to a public method of the target contract. The method must be annotated with `l1_handler`, otherwise an `ENTRYPOINT_NOT_FOUND` error may be returned. The `l1_transaction_hash` property is optional and, if provided, enables future `starknet_getMessagesStatus` requests with that hash value provided.
 
-Normally `nonce` is calculated by the L1 Starknet contract and it is used in L1 and L2. In this case, it needs to be provided manually.
+In regular (non-mocking) L1-L2 interaction, `nonce` is determined by the L1 Starknet contract. In this mock case, it is up to the developer to set it.
 
 ```
 POST /postman/send_message_to_l2
@@ -155,12 +157,9 @@ Request:
     "l2_contract_address": "0x00285ddb7e5c777b310d806b9b2a0f7c7ba0a41f12b420219209d97a3b7f25b2",
     "entry_point_selector": "0xC73F681176FC7B3F9693986FD7B14581E8D540519E27400E88B8713932BE01",
     "l1_contract_address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
-    "payload": [
-      "0x1",
-      "0x2"
-    ],
+    "payload": [ "0x1", "0x2" ],
     "paid_fee_on_l1": "0x123456abcdef",
-    "nonce":"0x0",
+    "nonce": "0x0",
     "l1_transaction_hash": "0x000abc123", // optional
 }
 ```
@@ -175,12 +174,9 @@ JSON-RPC
       "l2_contract_address": "0x00285ddb7e5c777b310d806b9b2a0f7c7ba0a41f12b420219209d97a3b7f25b2",
       "entry_point_selector": "0xC73F681176FC7B3F9693986FD7B14581E8D540519E27400E88B8713932BE01",
       "l1_contract_address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
-      "payload": [
-        "0x1",
-        "0x2"
-      ],
+      "payload": [ "0x1", "0x2" ],
       "paid_fee_on_l1": "0x123456abcdef",
-      "nonce":"0x0",
+      "nonce": "0x0",
       "l1_transaction_hash": "0x000abc123", // optional
   }
 }


### PR DESCRIPTION
## Usage related changes

- Motivated by [this Slack thread](https://spaceshard.slack.com/archives/C03031Y0LKC/p1744830956847219)

## Development related changes

- Reduce line count by writing `calldata` in a single line.

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)
