### PR TITLE
Fix calling forked Devnet at non-existent block

### DIFF
--- a/crates/starknet-devnet-server/src/api/json_rpc/origin_forwarder.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/origin_forwarder.rs
@@ -43,7 +43,9 @@ impl OriginForwarder {
             }
             crate::rpc_core::request::RequestParams::Object(ref mut params) => {
                 if let Some(block_id) = params.get_mut("block_id") {
-                    *block_id = origin_block_id;
+                    if let Some("latest" | "pending") = block_id.as_str() {
+                        *block_id = origin_block_id;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Usage related changes

- What the title says

## Development related changes

- Despite the comment in L28-29 of `crates/starknet-devnet-server/src/api/json_rpc/origin_forwarder.rs`, the block ID was not always properly modified when polling origin.

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)
