### PR TITLE
Fix forking: replace blocking HTTP client; improve logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3716,7 +3716,7 @@ dependencies = [
  "lazy_static",
  "listeners",
  "rand",
- "reqwest 0.12.12",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "starknet-accounts",
@@ -5055,14 +5055,13 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.7",
@@ -6010,7 +6009,7 @@ dependencies = [
  "anyhow",
  "clap",
  "futures",
- "reqwest 0.12.12",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "serial_test",
@@ -6041,7 +6040,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "rand",
  "rand_mt",
- "reqwest 0.12.12",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "starknet-core",
@@ -6050,6 +6049,7 @@ dependencies = [
  "starknet-types-core",
  "starknet_api",
  "thiserror 1.0.69",
+ "tokio",
  "tracing",
  "url",
 ]
@@ -6068,7 +6068,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "regex_generate",
- "reqwest 0.12.12",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -7400,8 +7400,8 @@ checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -7428,14 +7428,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
+name = "windows-link"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result",
- "windows-strings",
- "windows-targets 0.52.6",
+ "windows-result 0.3.2",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -7448,13 +7454,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -7508,11 +7532,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -7528,6 +7568,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7538,6 +7584,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7552,10 +7604,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7570,6 +7634,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7580,6 +7650,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7594,6 +7670,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7604,6 +7686,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ tokio = { version = "1", features = [
 	"macros",
 	"rt-multi-thread",
 	"signal",
+	"sync",
 ] }
 futures = "0.3"
 async-trait = "0.1"
@@ -69,7 +70,7 @@ rand = "0.8.5"
 rand_chacha = "0.3.1"
 rand_mt = "4.2.2"
 regex_generate = "0.2.3"
-reqwest = { version = "0.12", features = ["blocking", "json"] }
+reqwest = { version = "0.12.15", features = ["json"] }
 url = "2.4"
 usc = { version = "2.4.0", package = "universal-sierra-compiler" }
 num-bigint = { version = "0.4" }

--- a/crates/starknet-devnet-core/Cargo.toml
+++ b/crates/starknet-devnet-core/Cargo.toml
@@ -32,6 +32,7 @@ indexmap = { workspace = true }
 url = { workspace = true }
 nonzero_ext = { workspace = true }
 parking_lot = { workspace = true }
+tokio = { workspace = true }
 
 # necessary for installing reqwest in Docker
 openssl = { workspace = true }

--- a/crates/starknet-devnet-core/src/starknet/defaulter.rs
+++ b/crates/starknet-devnet-core/src/starknet/defaulter.rs
@@ -7,6 +7,7 @@ use starknet_api::core::{ClassHash, ContractAddress, Nonce, PatriciaKey};
 use starknet_api::state::StorageKey;
 use starknet_rs_core::types::Felt;
 use starknet_types::contract_class::convert_codegen_to_blockifier_compiled_class;
+use tokio::sync::oneshot;
 use tracing::debug;
 
 use super::starknet_config::ForkConfig;
@@ -45,12 +46,37 @@ impl OriginError {
 struct BlockingOriginReader {
     url: url::Url,
     block_number: u64,
-    client: reqwest::blocking::Client,
+    client: reqwest::Client,
 }
 
 impl BlockingOriginReader {
     fn new(url: url::Url, block_number: u64) -> Self {
-        Self { url, block_number, client: reqwest::blocking::Client::new() }
+        Self { url, block_number, client: reqwest::Client::new() }
+    }
+
+    fn blocking_post(&self, body: serde_json::Value) -> Result<serde_json::Value, String> {
+        let (tx, rx) = oneshot::channel();
+
+        let client = self.client.clone();
+        let url = self.url.clone();
+
+        tokio::spawn(async move {
+            let result = async {
+                let resp = client.post(url).json(&body).send().await?;
+
+                resp.json::<serde_json::Value>().await
+            }
+            .await;
+
+            let _ = tx.send(result.map_err(|e| e.to_string()));
+        });
+
+        tokio::task::block_in_place(move || {
+            match rx.blocking_recv() {
+                Ok(res) => res,
+                Err(err) => Err(format!("Error in receiving channel message: {err:?}")),
+            }
+        })
     }
 
     fn send_body(
@@ -69,35 +95,36 @@ impl BlockingOriginReader {
         });
 
         match self
-            .client
-            .post(self.url.clone())
-            .header(reqwest::header::CONTENT_TYPE, "application/json")
-            .body(body.to_string())
-            .send()
+            .blocking_post(body.clone())
         {
-            Ok(mut resp) => {
-                let resp_status = resp.status();
-                if resp_status != reqwest::StatusCode::OK {
-                    return Err(OriginError::from_status_code(resp_status));
-                }
+            Ok(resp_json_value) => {
+                // let resp_status = resp.status();
+                // if resp_status != reqwest::StatusCode::OK {
+                //     return Err(OriginError::from_status_code(resp_status));
+                // }
 
-                // load json
-                let mut buff = vec![];
-                resp.read_to_end(&mut buff).map_err(|e| OriginError::FormatError(e.to_string()))?;
-                let resp_json_value: serde_json::Value = serde_json::from_slice(&buff)
-                    .map_err(|e| OriginError::FormatError(e.to_string()))?;
+                // // load json
+                // let mut buff = vec![];
+                // resp.read_to_end(&mut buff).map_err(|e| OriginError::FormatError(e.to_string()))?;
+                // let resp_json_value: serde_json::Value = serde_json::from_slice(&buff)
+                //     .map_err(|e| OriginError::FormatError(e.to_string()))?;
 
                 let result = &resp_json_value["result"];
                 if result.is_null() {
                     // the received response is assumed to mean that the origin doesn't contain the
                     // requested resource
-                    debug!("Origin response contains no 'result': {resp_json_value}");
+                    debug!("FORK LOG: Origin response contains no 'result': {resp_json_value}");
                     Err(OriginError::NoResult)
                 } else {
+                    debug!("FORK LOG: Successful response from origin for body: {body:?}");
                     Ok(result.clone())
                 }
             }
-            Err(other_err) => Err(OriginError::CommunicationError(other_err.to_string())),
+            Err(other_err) => {
+                debug!("FORK LOG: Error in sending body: {body:?}");
+                debug!("Got error from origin: {other_err:?}");
+                Err(OriginError::CommunicationError(other_err))
+            }
         }
     }
 }

--- a/crates/starknet-devnet/src/main.rs
+++ b/crates/starknet-devnet/src/main.rs
@@ -171,8 +171,9 @@ async fn set_erc20_contract_class_and_class_hash_if_different_than_default(
             Ok(origin_class_hash) => {
                 if origin_class_hash != default_class_hash {
                     tracing::debug!(
-                        "Found ERC20 class hash difference: origin={origin_class_hash}, \
-                         default={default_class_hash}"
+                        "Found ERC20 class hash difference at address {contract_address:#x}; \
+                         origin={origin_class_hash:#x}, default={default_class_hash:#x}. \
+                         Replacing..."
                     );
                     let origin_contract_class =
                         json_rpc_client.get_class(block_id, origin_class_hash).await?;

--- a/crates/starknet-devnet/src/main.rs
+++ b/crates/starknet-devnet/src/main.rs
@@ -170,6 +170,7 @@ async fn set_erc20_contract_class_and_class_hash_if_different_than_default(
         match json_rpc_client.get_class_hash_at(block_id, contract_address).await {
             Ok(origin_class_hash) => {
                 if origin_class_hash != default_class_hash {
+                    tracing::debug!("Found ERC20 class hash difference: origin={origin_class_hash}, default={default_class_hash}");
                     let origin_contract_class =
                         json_rpc_client.get_class(block_id, origin_class_hash).await?;
                     let contract_class_json_str = match origin_contract_class {

--- a/crates/starknet-devnet/src/main.rs
+++ b/crates/starknet-devnet/src/main.rs
@@ -170,7 +170,10 @@ async fn set_erc20_contract_class_and_class_hash_if_different_than_default(
         match json_rpc_client.get_class_hash_at(block_id, contract_address).await {
             Ok(origin_class_hash) => {
                 if origin_class_hash != default_class_hash {
-                    tracing::debug!("Found ERC20 class hash difference: origin={origin_class_hash}, default={default_class_hash}");
+                    tracing::debug!(
+                        "Found ERC20 class hash difference: origin={origin_class_hash}, \
+                         default={default_class_hash}"
+                    );
                     let origin_contract_class =
                         json_rpc_client.get_class(block_id, origin_class_hash).await?;
                     let contract_class_json_str = match origin_contract_class {


### PR DESCRIPTION
## Usage related changes

- In case of transactions that heavily used the origin state via forking, odd things would happen that are described [on Slack](https://spaceshard.slack.com/archives/C029F9AN8LX/p1746432478007399)
- Make forking errors more informative
- Add more debug logging lines to the origin defaulter.

## Development related changes

- Update reqwest
  - 0.12.15 (this didn't directly help, but leaving it)
  - Remove the `"blocking"` feature
- Use custom blocking HTTP client
  - It is also possible to implement this without relying on the oneshot channel of tokio's sync feature, but it seems to be marginally slower than the approach in this PR (this alternative approach performs the whole async logic inside `block_in_place` instead of just waiting for the channel to receive the message)
- Update `tokio`:
  - Add `"sync"` to the list of used `tokio` features
  - Use `tokio` in the core crate
- Close #530
  - Putting this under dev changes as it was only present in debug mode, not in release

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)
