### PR TITLE
Test time advancing with forking (impersonation)

### DIFF
--- a/tests/integration/common/utils.rs
+++ b/tests/integration/common/utils.rs
@@ -666,6 +666,19 @@ pub fn assert_contains(text: &str, pattern: &str) {
     }
 }
 
+/// Set time and generate a new block
+/// Returns the block timestamp of the newly generated block
+pub async fn set_time(devnet: &BackgroundDevnet, time: u64) -> u64 {
+    let resp_body =
+        devnet.send_custom_rpc("devnet_setTime", json!({ "time": time })).await.unwrap();
+
+    resp_body["block_timestamp"].as_u64().unwrap()
+}
+
+pub async fn increase_time(devnet: &BackgroundDevnet, time: u64) {
+    devnet.send_custom_rpc("devnet_increaseTime", json!({ "time": time })).await.unwrap();
+}
+
 #[cfg(test)]
 mod test_unique_auto_deletable_file {
     use std::path::Path;

--- a/tests/integration/lib.rs
+++ b/tests/integration/lib.rs
@@ -11,6 +11,7 @@ mod test_abort_blocks;
 mod test_account_impersonation;
 mod test_account_selection;
 mod test_advancing_time;
+mod test_advancing_time_on_fork;
 mod test_balance;
 mod test_blocks_generation;
 mod test_call;

--- a/tests/integration/test_advancing_time.rs
+++ b/tests/integration/test_advancing_time.rs
@@ -10,15 +10,14 @@ use starknet_rs_core::types::{
 };
 use starknet_rs_core::utils::{get_selector_from_name, get_udc_deployed_address};
 use starknet_rs_providers::{Provider, ProviderError};
-use starknet_rs_signers::{LocalWallet, SigningKey};
 
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants;
 use crate::common::utils::{
-    ImpersonationAction, UniqueAutoDeletableFile, assert_contains, declare_v3_deploy_v3,
-    extract_message_error, extract_nested_error,
-    get_block_reader_contract_in_sierra_and_compiled_class_hash, get_timestamp_asserter,
-    get_unix_timestamp_as_seconds, increase_time, send_ctrl_c_signal_and_wait, set_time,
+    UniqueAutoDeletableFile, assert_contains, declare_v3_deploy_v3, extract_message_error,
+    extract_nested_error, get_block_reader_contract_in_sierra_and_compiled_class_hash,
+    get_timestamp_asserter, get_unix_timestamp_as_seconds, increase_time,
+    send_ctrl_c_signal_and_wait, set_time,
 };
 
 const DUMMY_ADDRESS: u128 = 1;
@@ -614,84 +613,6 @@ async fn tx_resource_estimation_fails_unless_time_incremented() {
 }
 
 #[tokio::test]
-async fn tx_resource_estimation_fails_on_forked_devnet_with_impersonation_unless_time_incremented()
-{
-    let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
-
-    let (signer, address) = origin_devnet.get_first_predeployed_account().await;
-    let origin_account = SingleOwnerAccount::new(
-        &origin_devnet.json_rpc_client,
-        signer,
-        address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
-
-    let (contract_class, casm_hash) = get_timestamp_asserter();
-
-    let lock_interval = 86_400;
-    let ctor_args = &[Felt::from(lock_interval)];
-    let (_, contract_address) =
-        declare_v3_deploy_v3(&origin_account, contract_class, casm_hash, ctor_args).await.unwrap();
-
-    // Spawn a forked Devnet
-    let forked_devnet = BackgroundDevnet::spawn_with_additional_args(&[
-        "--fork-network",
-        &origin_devnet.url,
-        "--seed",
-        "18726",
-    ])
-    .await
-    .unwrap();
-
-    // Create a new, dummy account, which should work after activating impersonation
-    let fork_account = SingleOwnerAccount::new(
-        &forked_devnet.json_rpc_client,
-        LocalWallet::from(SigningKey::from_secret_scalar(Felt::TWO)),
-        address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
-    forked_devnet
-        .execute_impersonation_action(&ImpersonationAction::AutoImpersonate)
-        .await
-        .unwrap();
-
-    let time_check_selector = get_selector_from_name("check_time").unwrap();
-    let time_check_call =
-        Call { to: contract_address, selector: time_check_selector, calldata: vec![] };
-
-    // A failure is expected without time change.
-    let error =
-        fork_account.execute_v3(vec![time_check_call.clone()]).estimate_fee().await.unwrap_err();
-    match error {
-        AccountError::Provider(ProviderError::StarknetError(
-            StarknetError::TransactionExecutionError(error_data),
-        )) => {
-            assert_eq!(error_data.transaction_index, 0);
-
-            let root_error = extract_nested_error(&error_data.execution_error);
-            assert_eq!(root_error.contract_address, fork_account.address());
-            assert_eq!(root_error.selector, get_selector_from_name("__execute__").unwrap());
-
-            // Currently the root error is twice mentioned, so we extract twice
-            let inner_error = extract_nested_error(&root_error.error);
-            let inner_error = extract_nested_error(&inner_error.error);
-            assert_eq!(inner_error.contract_address, contract_address);
-            assert_eq!(inner_error.selector, time_check_selector);
-
-            let message = extract_message_error(&inner_error.error);
-            assert_contains(message, "Wait a bit more");
-        }
-        other => panic!("Invalid error: {other:?}"),
-    }
-
-    // Increasing the system timestamp should make the estimation succeed
-    increase_time(&forked_devnet, lock_interval).await;
-    fork_account.execute_v3(vec![time_check_call]).estimate_fee().await.unwrap();
-}
-
-#[tokio::test]
 async fn tx_execution_fails_unless_time_incremented() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
 
@@ -736,74 +657,4 @@ async fn tx_execution_fails_unless_time_incremented() {
     // Increasing the system timestamp should make the tx succeed (and the implicit fee estimation)
     increase_time(&devnet, lock_interval).await;
     account.execute_v3(vec![time_check_call]).send().await.unwrap();
-}
-
-#[tokio::test]
-async fn tx_execution_fails_on_forked_devnet_with_impersonation_unless_time_incremented() {
-    let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
-
-    let (signer, address) = origin_devnet.get_first_predeployed_account().await;
-    let origin_account = SingleOwnerAccount::new(
-        &origin_devnet.json_rpc_client,
-        signer.clone(),
-        address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
-
-    let (contract_class, casm_hash) = get_timestamp_asserter();
-
-    let lock_interval = 86_400;
-    let ctor_args = &[Felt::from(lock_interval)];
-    let (_, contract_address) =
-        declare_v3_deploy_v3(&origin_account, contract_class, casm_hash, ctor_args).await.unwrap();
-
-    // Spawn a forked Devnet
-    let forked_devnet = BackgroundDevnet::spawn_with_additional_args(&[
-        "--fork-network",
-        &origin_devnet.url,
-        "--seed",
-        "18726",
-    ])
-    .await
-    .unwrap();
-
-    // Create a new, dummy account, which should work after activating impersonation
-    let fork_account = SingleOwnerAccount::new(
-        &forked_devnet.json_rpc_client,
-        LocalWallet::from(SigningKey::from_secret_scalar(Felt::TWO)),
-        address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
-    forked_devnet
-        .execute_impersonation_action(&ImpersonationAction::AutoImpersonate)
-        .await
-        .unwrap();
-
-    let time_check_selector = get_selector_from_name("check_time").unwrap();
-    let time_check_call =
-        Call { to: contract_address, selector: time_check_selector, calldata: vec![] };
-
-    // A failure is expected without time change.
-    let reverted_tx = fork_account
-        .execute_v3(vec![time_check_call.clone()])
-        .l1_gas(0)
-        .l1_data_gas(1000)
-        .l2_gas(1e7 as u64)
-        .send()
-        .await
-        .unwrap();
-
-    match forked_devnet.json_rpc_client.get_transaction_status(reverted_tx.transaction_hash).await {
-        Ok(TransactionStatus::AcceptedOnL2(tx_details)) => {
-            assert_eq!(tx_details.status(), TransactionExecutionStatus::Reverted);
-            assert_contains(tx_details.revert_reason().unwrap(), "Wait a bit more");
-        }
-        other => panic!("Unexpected tx: {other:?}"),
-    }
-
-    // Increasing the system timestamp should make the tx succeed (and the implicit fee estimation)
-    increase_time(&forked_devnet, lock_interval).await;
-    fork_account.execute_v3(vec![time_check_call]).send().await.unwrap();
 }

--- a/tests/integration/test_advancing_time.rs
+++ b/tests/integration/test_advancing_time.rs
@@ -10,13 +10,15 @@ use starknet_rs_core::types::{
 };
 use starknet_rs_core::utils::{get_selector_from_name, get_udc_deployed_address};
 use starknet_rs_providers::{Provider, ProviderError};
+use starknet_rs_signers::{LocalWallet, SigningKey};
 
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants;
 use crate::common::utils::{
-    UniqueAutoDeletableFile, assert_contains, declare_v3_deploy_v3, extract_message_error,
-    extract_nested_error, get_block_reader_contract_in_sierra_and_compiled_class_hash,
-    get_timestamp_asserter, get_unix_timestamp_as_seconds, send_ctrl_c_signal_and_wait,
+    ImpersonationAction, UniqueAutoDeletableFile, assert_contains, declare_v3_deploy_v3,
+    extract_message_error, extract_nested_error,
+    get_block_reader_contract_in_sierra_and_compiled_class_hash, get_timestamp_asserter,
+    get_unix_timestamp_as_seconds, increase_time, send_ctrl_c_signal_and_wait, set_time,
 };
 
 const DUMMY_ADDRESS: u128 = 1;
@@ -27,19 +29,6 @@ const BUFFER_TIME_SECONDS: u64 = 30;
 async fn sleep_until_new_timestamp() {
     // Sometimes sleeping for 1 second isn't enough.
     tokio::time::sleep(time::Duration::from_millis(1500)).await
-}
-
-/// Set time and generate a new block
-/// Returns the block timestamp of the newly generated block
-pub async fn set_time(devnet: &BackgroundDevnet, time: u64) -> u64 {
-    let resp_body =
-        devnet.send_custom_rpc("devnet_setTime", json!({ "time": time })).await.unwrap();
-
-    resp_body["block_timestamp"].as_u64().unwrap()
-}
-
-pub async fn increase_time(devnet: &BackgroundDevnet, time: u64) {
-    devnet.send_custom_rpc("devnet_increaseTime", json!({ "time": time })).await.unwrap();
 }
 
 pub fn assert_ge_with_buffer(val1: u64, val2: u64) {
@@ -625,6 +614,84 @@ async fn tx_resource_estimation_fails_unless_time_incremented() {
 }
 
 #[tokio::test]
+async fn tx_resource_estimation_fails_on_forked_devnet_with_impersonation_unless_time_incremented()
+{
+    let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
+
+    let (signer, address) = origin_devnet.get_first_predeployed_account().await;
+    let origin_account = SingleOwnerAccount::new(
+        &origin_devnet.json_rpc_client,
+        signer,
+        address,
+        constants::CHAIN_ID,
+        ExecutionEncoding::New,
+    );
+
+    let (contract_class, casm_hash) = get_timestamp_asserter();
+
+    let lock_interval = 86_400;
+    let ctor_args = &[Felt::from(lock_interval)];
+    let (_, contract_address) =
+        declare_v3_deploy_v3(&origin_account, contract_class, casm_hash, ctor_args).await.unwrap();
+
+    // Spawn a forked Devnet
+    let forked_devnet = BackgroundDevnet::spawn_with_additional_args(&[
+        "--fork-network",
+        &origin_devnet.url,
+        "--seed",
+        "18726",
+    ])
+    .await
+    .unwrap();
+
+    // Create a new, dummy account, which should work after activating impersonation
+    let fork_account = SingleOwnerAccount::new(
+        &forked_devnet.json_rpc_client,
+        LocalWallet::from(SigningKey::from_secret_scalar(Felt::TWO)),
+        address,
+        constants::CHAIN_ID,
+        ExecutionEncoding::New,
+    );
+    forked_devnet
+        .execute_impersonation_action(&ImpersonationAction::AutoImpersonate)
+        .await
+        .unwrap();
+
+    let time_check_selector = get_selector_from_name("check_time").unwrap();
+    let time_check_call =
+        Call { to: contract_address, selector: time_check_selector, calldata: vec![] };
+
+    // A failure is expected without time change.
+    let error =
+        fork_account.execute_v3(vec![time_check_call.clone()]).estimate_fee().await.unwrap_err();
+    match error {
+        AccountError::Provider(ProviderError::StarknetError(
+            StarknetError::TransactionExecutionError(error_data),
+        )) => {
+            assert_eq!(error_data.transaction_index, 0);
+
+            let root_error = extract_nested_error(&error_data.execution_error);
+            assert_eq!(root_error.contract_address, fork_account.address());
+            assert_eq!(root_error.selector, get_selector_from_name("__execute__").unwrap());
+
+            // Currently the root error is twice mentioned, so we extract twice
+            let inner_error = extract_nested_error(&root_error.error);
+            let inner_error = extract_nested_error(&inner_error.error);
+            assert_eq!(inner_error.contract_address, contract_address);
+            assert_eq!(inner_error.selector, time_check_selector);
+
+            let message = extract_message_error(&inner_error.error);
+            assert_contains(message, "Wait a bit more");
+        }
+        other => panic!("Invalid error: {other:?}"),
+    }
+
+    // Increasing the system timestamp should make the estimation succeed
+    increase_time(&forked_devnet, lock_interval).await;
+    fork_account.execute_v3(vec![time_check_call]).estimate_fee().await.unwrap();
+}
+
+#[tokio::test]
 async fn tx_execution_fails_unless_time_incremented() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
 
@@ -669,4 +736,74 @@ async fn tx_execution_fails_unless_time_incremented() {
     // Increasing the system timestamp should make the tx succeed (and the implicit fee estimation)
     increase_time(&devnet, lock_interval).await;
     account.execute_v3(vec![time_check_call]).send().await.unwrap();
+}
+
+#[tokio::test]
+async fn tx_execution_fails_on_forked_devnet_with_impersonation_unless_time_incremented() {
+    let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
+
+    let (signer, address) = origin_devnet.get_first_predeployed_account().await;
+    let origin_account = SingleOwnerAccount::new(
+        &origin_devnet.json_rpc_client,
+        signer.clone(),
+        address,
+        constants::CHAIN_ID,
+        ExecutionEncoding::New,
+    );
+
+    let (contract_class, casm_hash) = get_timestamp_asserter();
+
+    let lock_interval = 86_400;
+    let ctor_args = &[Felt::from(lock_interval)];
+    let (_, contract_address) =
+        declare_v3_deploy_v3(&origin_account, contract_class, casm_hash, ctor_args).await.unwrap();
+
+    // Spawn a forked Devnet
+    let forked_devnet = BackgroundDevnet::spawn_with_additional_args(&[
+        "--fork-network",
+        &origin_devnet.url,
+        "--seed",
+        "18726",
+    ])
+    .await
+    .unwrap();
+
+    // Create a new, dummy account, which should work after activating impersonation
+    let fork_account = SingleOwnerAccount::new(
+        &forked_devnet.json_rpc_client,
+        LocalWallet::from(SigningKey::from_secret_scalar(Felt::TWO)),
+        address,
+        constants::CHAIN_ID,
+        ExecutionEncoding::New,
+    );
+    forked_devnet
+        .execute_impersonation_action(&ImpersonationAction::AutoImpersonate)
+        .await
+        .unwrap();
+
+    let time_check_selector = get_selector_from_name("check_time").unwrap();
+    let time_check_call =
+        Call { to: contract_address, selector: time_check_selector, calldata: vec![] };
+
+    // A failure is expected without time change.
+    let reverted_tx = fork_account
+        .execute_v3(vec![time_check_call.clone()])
+        .l1_gas(0)
+        .l1_data_gas(1000)
+        .l2_gas(1e7 as u64)
+        .send()
+        .await
+        .unwrap();
+
+    match forked_devnet.json_rpc_client.get_transaction_status(reverted_tx.transaction_hash).await {
+        Ok(TransactionStatus::AcceptedOnL2(tx_details)) => {
+            assert_eq!(tx_details.status(), TransactionExecutionStatus::Reverted);
+            assert_contains(tx_details.revert_reason().unwrap(), "Wait a bit more");
+        }
+        other => panic!("Unexpected tx: {other:?}"),
+    }
+
+    // Increasing the system timestamp should make the tx succeed (and the implicit fee estimation)
+    increase_time(&forked_devnet, lock_interval).await;
+    fork_account.execute_v3(vec![time_check_call]).send().await.unwrap();
 }

--- a/tests/integration/test_advancing_time_on_fork.rs
+++ b/tests/integration/test_advancing_time_on_fork.rs
@@ -42,7 +42,7 @@ async fn tx_resource_estimation_fails_on_forked_devnet_with_impersonation_unless
     let fork_account = SingleOwnerAccount::new(
         &forked_devnet.json_rpc_client,
         LocalWallet::from(SigningKey::from_secret_scalar(Felt::TWO)),
-        Felt::THREE, // dummy address
+        address,
         constants::CHAIN_ID,
         ExecutionEncoding::New,
     );
@@ -113,7 +113,7 @@ async fn tx_execution_fails_on_forked_devnet_with_impersonation_unless_time_incr
     let fork_account = SingleOwnerAccount::new(
         &forked_devnet.json_rpc_client,
         LocalWallet::from(SigningKey::from_secret_scalar(Felt::TWO)),
-        Felt::THREE, // dummy address
+        address,
         constants::CHAIN_ID,
         ExecutionEncoding::New,
     );

--- a/tests/integration/test_advancing_time_on_fork.rs
+++ b/tests/integration/test_advancing_time_on_fork.rs
@@ -34,21 +34,15 @@ async fn tx_resource_estimation_fails_on_forked_devnet_with_impersonation_unless
     let (_, contract_address) =
         declare_v3_deploy_v3(&origin_account, contract_class, casm_hash, ctor_args).await.unwrap();
 
-    // Spawn a forked Devnet
-    let forked_devnet = BackgroundDevnet::spawn_with_additional_args(&[
-        "--fork-network",
-        &origin_devnet.url,
-        "--seed",
-        "18726",
-    ])
-    .await
-    .unwrap();
+    // Spawn a forked Devnet; use random seed to force predeployment of new accounts
+    let fork_args = ["--fork-network", &origin_devnet.url, "--seed", "18726"];
+    let forked_devnet = BackgroundDevnet::spawn_with_additional_args(&fork_args).await.unwrap();
 
     // Create a new, dummy account, which should work after activating impersonation
     let fork_account = SingleOwnerAccount::new(
         &forked_devnet.json_rpc_client,
         LocalWallet::from(SigningKey::from_secret_scalar(Felt::TWO)),
-        address,
+        Felt::THREE, // dummy address
         constants::CHAIN_ID,
         ExecutionEncoding::New,
     );
@@ -98,7 +92,7 @@ async fn tx_execution_fails_on_forked_devnet_with_impersonation_unless_time_incr
     let (signer, address) = origin_devnet.get_first_predeployed_account().await;
     let origin_account = SingleOwnerAccount::new(
         &origin_devnet.json_rpc_client,
-        signer.clone(),
+        signer,
         address,
         constants::CHAIN_ID,
         ExecutionEncoding::New,
@@ -111,21 +105,15 @@ async fn tx_execution_fails_on_forked_devnet_with_impersonation_unless_time_incr
     let (_, contract_address) =
         declare_v3_deploy_v3(&origin_account, contract_class, casm_hash, ctor_args).await.unwrap();
 
-    // Spawn a forked Devnet
-    let forked_devnet = BackgroundDevnet::spawn_with_additional_args(&[
-        "--fork-network",
-        &origin_devnet.url,
-        "--seed",
-        "18726",
-    ])
-    .await
-    .unwrap();
+    // Spawn a forked Devnet; use random seed to force predeployment of new accounts
+    let fork_args = ["--fork-network", &origin_devnet.url, "--seed", "18726"];
+    let forked_devnet = BackgroundDevnet::spawn_with_additional_args(&fork_args).await.unwrap();
 
     // Create a new, dummy account, which should work after activating impersonation
     let fork_account = SingleOwnerAccount::new(
         &forked_devnet.json_rpc_client,
         LocalWallet::from(SigningKey::from_secret_scalar(Felt::TWO)),
-        address,
+        Felt::THREE, // dummy address
         constants::CHAIN_ID,
         ExecutionEncoding::New,
     );

--- a/tests/integration/test_advancing_time_on_fork.rs
+++ b/tests/integration/test_advancing_time_on_fork.rs
@@ -1,0 +1,162 @@
+use starknet_rs_accounts::{Account, AccountError, ExecutionEncoding, SingleOwnerAccount};
+use starknet_rs_core::types::{
+    Call, Felt, StarknetError, TransactionExecutionStatus, TransactionStatus,
+};
+use starknet_rs_core::utils::get_selector_from_name;
+use starknet_rs_providers::{Provider, ProviderError};
+use starknet_rs_signers::{LocalWallet, SigningKey};
+
+use crate::common::background_devnet::BackgroundDevnet;
+use crate::common::constants;
+use crate::common::utils::{
+    ImpersonationAction, assert_contains, declare_v3_deploy_v3, extract_message_error,
+    extract_nested_error, get_timestamp_asserter, increase_time,
+};
+
+#[tokio::test]
+async fn tx_resource_estimation_fails_on_forked_devnet_with_impersonation_unless_time_incremented()
+{
+    let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
+
+    let (signer, address) = origin_devnet.get_first_predeployed_account().await;
+    let origin_account = SingleOwnerAccount::new(
+        &origin_devnet.json_rpc_client,
+        signer,
+        address,
+        constants::CHAIN_ID,
+        ExecutionEncoding::New,
+    );
+
+    let (contract_class, casm_hash) = get_timestamp_asserter();
+
+    let lock_interval = 86_400;
+    let ctor_args = &[Felt::from(lock_interval)];
+    let (_, contract_address) =
+        declare_v3_deploy_v3(&origin_account, contract_class, casm_hash, ctor_args).await.unwrap();
+
+    // Spawn a forked Devnet
+    let forked_devnet = BackgroundDevnet::spawn_with_additional_args(&[
+        "--fork-network",
+        &origin_devnet.url,
+        "--seed",
+        "18726",
+    ])
+    .await
+    .unwrap();
+
+    // Create a new, dummy account, which should work after activating impersonation
+    let fork_account = SingleOwnerAccount::new(
+        &forked_devnet.json_rpc_client,
+        LocalWallet::from(SigningKey::from_secret_scalar(Felt::TWO)),
+        address,
+        constants::CHAIN_ID,
+        ExecutionEncoding::New,
+    );
+    forked_devnet
+        .execute_impersonation_action(&ImpersonationAction::AutoImpersonate)
+        .await
+        .unwrap();
+
+    let time_check_selector = get_selector_from_name("check_time").unwrap();
+    let time_check_call =
+        Call { to: contract_address, selector: time_check_selector, calldata: vec![] };
+
+    // A failure is expected without time change.
+    let error =
+        fork_account.execute_v3(vec![time_check_call.clone()]).estimate_fee().await.unwrap_err();
+    match error {
+        AccountError::Provider(ProviderError::StarknetError(
+            StarknetError::TransactionExecutionError(error_data),
+        )) => {
+            assert_eq!(error_data.transaction_index, 0);
+
+            let root_error = extract_nested_error(&error_data.execution_error);
+            assert_eq!(root_error.contract_address, fork_account.address());
+            assert_eq!(root_error.selector, get_selector_from_name("__execute__").unwrap());
+
+            // Currently the root error is twice mentioned, so we extract twice
+            let inner_error = extract_nested_error(&root_error.error);
+            let inner_error = extract_nested_error(&inner_error.error);
+            assert_eq!(inner_error.contract_address, contract_address);
+            assert_eq!(inner_error.selector, time_check_selector);
+
+            let message = extract_message_error(&inner_error.error);
+            assert_contains(message, "Wait a bit more");
+        }
+        other => panic!("Invalid error: {other:?}"),
+    }
+
+    // Increasing the system timestamp should make the estimation succeed
+    increase_time(&forked_devnet, lock_interval).await;
+    fork_account.execute_v3(vec![time_check_call]).estimate_fee().await.unwrap();
+}
+
+#[tokio::test]
+async fn tx_execution_fails_on_forked_devnet_with_impersonation_unless_time_incremented() {
+    let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
+
+    let (signer, address) = origin_devnet.get_first_predeployed_account().await;
+    let origin_account = SingleOwnerAccount::new(
+        &origin_devnet.json_rpc_client,
+        signer.clone(),
+        address,
+        constants::CHAIN_ID,
+        ExecutionEncoding::New,
+    );
+
+    let (contract_class, casm_hash) = get_timestamp_asserter();
+
+    let lock_interval = 86_400;
+    let ctor_args = &[Felt::from(lock_interval)];
+    let (_, contract_address) =
+        declare_v3_deploy_v3(&origin_account, contract_class, casm_hash, ctor_args).await.unwrap();
+
+    // Spawn a forked Devnet
+    let forked_devnet = BackgroundDevnet::spawn_with_additional_args(&[
+        "--fork-network",
+        &origin_devnet.url,
+        "--seed",
+        "18726",
+    ])
+    .await
+    .unwrap();
+
+    // Create a new, dummy account, which should work after activating impersonation
+    let fork_account = SingleOwnerAccount::new(
+        &forked_devnet.json_rpc_client,
+        LocalWallet::from(SigningKey::from_secret_scalar(Felt::TWO)),
+        address,
+        constants::CHAIN_ID,
+        ExecutionEncoding::New,
+    );
+    forked_devnet
+        .execute_impersonation_action(&ImpersonationAction::AutoImpersonate)
+        .await
+        .unwrap();
+
+    let time_check_selector = get_selector_from_name("check_time").unwrap();
+    let time_check_call =
+        Call { to: contract_address, selector: time_check_selector, calldata: vec![] };
+
+    // A failure is expected without time change.
+    let reverted_tx = fork_account
+        .execute_v3(vec![time_check_call.clone()])
+        .l1_gas(0)
+        .l1_data_gas(1000)
+        .l2_gas(1e7 as u64)
+        .send()
+        .await
+        .unwrap();
+
+    match forked_devnet.json_rpc_client.get_transaction_status(reverted_tx.transaction_hash).await {
+        Ok(TransactionStatus::AcceptedOnL2(tx_details)) => {
+            assert_eq!(tx_details.status(), TransactionExecutionStatus::Reverted);
+            assert_contains(tx_details.revert_reason().unwrap(), "Wait a bit more");
+        }
+        other => panic!("Unexpected tx: {other:?}"),
+    }
+
+    // Increasing the system timestamp should make the tx succeed (and the implicit fee estimation)
+    increase_time(&forked_devnet, lock_interval).await;
+    fork_account.execute_v3(vec![time_check_call]).send().await.unwrap();
+}

--- a/tests/integration/test_fork.rs
+++ b/tests/integration/test_fork.rs
@@ -659,8 +659,10 @@ async fn test_forked_devnet_new_block_has_parent_hash_of_the_origin_block() {
 
     forked_devnet.create_block().await.unwrap();
 
+    let previous_block_hash = latest_block.block_hash;
     let latest_block = forked_devnet.get_latest_block_with_tx_hashes().await.unwrap();
     assert_ne!(latest_block.parent_hash, origin_block_hash);
+    assert_eq!(latest_block.parent_hash, previous_block_hash);
 }
 
 #[tokio::test]

--- a/website/docs/account-impersonation.md
+++ b/website/docs/account-impersonation.md
@@ -8,21 +8,24 @@ This page is about account impersonation. To read about account class selection 
 
 ## Introduction
 
-Devnet allows you to use impersonated account from mainnet/testnet. This means that a transaction sent from an impersonated account will not fail with an invalid signature error. In the general case, a transaction sent with an account that is not in the local state fails with the aforementioned error. For impersonation to work, Devnet needs to be run in [forking mode](./forking.md).
+Devnet allows you to impersonate an account that exists on the Starknet mainnet or testnet. This is achieved by skipping the validation step of transactions for all or some accounts, on a running Devnet via JSON-RPC.
+
+A transaction sent from an impersonated account will not fail with an invalid signature error, which is what happens in the general case of locally absent accounts. For impersonation to work, Devnet needs to [fork](./forking.md) the network that has the desired account.
 
 :::warning Caveat
 
 - Only `INVOKE` and `DECLARE` transactions are supported. `DEPLOY_ACCOUNT` transaction is not supported, but you can create an `INVOKE` transaction to UDC.
-- Overall fee, for transactions sent with an impersonated account, will be lower compared to normal transactions. The reason is that validation part is skipped.
-- The most common way of sending a transaction is via starknet-rs/starknet.js or starkli. Trying to send with an account that **does not** exist even in the origin network will return an error:
-  - In transaction construction, if account nonce is not hardcoded, Devnet is queried and returns `ContractNotFound`.
-  - Otherwise the nonce fetching part is skipped and `InsufficientAccountBalance` is returned.
+- Due to the validation step being skipped, the overall fee of transactions sent with an impersonated account will be lower than regular transactions.
+- Trying to send a transaction with an account that **does not** even exist in the origin network returns an error:
+  - `ContractNotFound` if, during transaction preparation, you do not specify a nonce value, leading to the implicit querying of Devnet for the nonce.
+  - `InsufficientAccountBalance` or similar if the nonce is supplied in the transaction; this happens because the token balance of a non-existent contract is 0 indeed insufficient.
 
 :::
 
-## Disabling impersonation
+## Tips
 
-Click [here](./restrictive.md) to learn how to disable account impersonation.
+- The impersonated account may have had all or a part of its funds used up on the origin network. You may need to give it more funds via [minting](./balance.md).
+- If you're defining a new account in your Starknet client application (starknet.js, starknet.rs, starkli...), you may need to specify a private key for it. Since the signature validation is skipped, you may provide a dummy key.
 
 ## API
 
@@ -83,3 +86,7 @@ Stops the effect of [automatic impersonation](#devnet_autoimpersonate).
     "params": {}
 }
 ```
+
+## Preventing impersonation
+
+If you want to learn about completely preventing impersonation from being activated on your Devnet, click [here](./restrictive.md).

--- a/website/docs/restrictive.md
+++ b/website/docs/restrictive.md
@@ -1,10 +1,10 @@
 # Restrictive mode
 
-The --restrictive-mode argument enables a restrictive mode for Devnet, allowing you to specify methods that are forbidden during execution. This option ensures that certain operations are restricted, enhancing control over Devnet's behavior. When a user sends a request to one of the restricted methods, Devnet will return either a JSON-RPC error with code -32604 or, if the method was targeted directly via the HTTP endpoint, a response with status 403.
+The `--restrictive-mode` argument enables a restrictive mode for Devnet, allowing you to specify methods that are forbidden during execution. This option ensures that certain operations are restricted, enhancing control over Devnet's behavior. When a user sends a request to one of the restricted methods, Devnet will return either a JSON-RPC error with code -32604 or, if the method was targeted directly via the HTTP endpoint, a response with status 403.
 
 ## Default restricted methods
 
-When no methods are specified, the following default methods will be restricted and their HTTP endpoints counterparts (if any):
+When no methods are specified, the following default methods will be restricted, together with their HTTP endpoint counterparts (if any):
 
 - devnet_mint
 - devnet_load
@@ -25,7 +25,11 @@ $ starknet-devnet --restrictive-mode
 
 ### With a list of methods
 
-Note! Devnet will fail to start if any of the methods/routes is misspelled.
+:::note
+
+Devnet will fail to start if any of the methods/routes are misspelled.
+
+:::
 
 ```
 $ starknet-devnet --restrictive-mode devnet_dump devnet_config

--- a/website/versioned_docs/version-0.4.0/account-impersonation.md
+++ b/website/versioned_docs/version-0.4.0/account-impersonation.md
@@ -8,21 +8,24 @@ This page is about account impersonation. To read about account class selection 
 
 ## Introduction
 
-Devnet allows you to use impersonated account from mainnet/testnet. This means that a transaction sent from an impersonated account will not fail with an invalid signature error. In the general case, a transaction sent with an account that is not in the local state fails with the aforementioned error. For impersonation to work, Devnet needs to be run in [forking mode](./forking.md).
+Devnet allows you to impersonate an account that exists on the Starknet mainnet or testnet. This is achieved by skipping the validation step of transactions for all or some accounts, on a running Devnet via JSON-RPC.
+
+A transaction sent from an impersonated account will not fail with an invalid signature error, which is what happens in the general case of locally absent accounts. For impersonation to work, Devnet needs to [fork](./forking.md) the network that has the desired account.
 
 :::warning Caveat
 
 - Only `INVOKE` and `DECLARE` transactions are supported. `DEPLOY_ACCOUNT` transaction is not supported, but you can create an `INVOKE` transaction to UDC.
-- Overall fee, for transactions sent with an impersonated account, will be lower compared to normal transactions. The reason is that validation part is skipped.
-- The most common way of sending a transaction is via starknet-rs/starknet.js or starkli. Trying to send with an account that **does not** exist even in the origin network will return an error:
-  - In transaction construction, if account nonce is not hardcoded, Devnet is queried and returns `ContractNotFound`.
-  - Otherwise the nonce fetching part is skipped and `InsufficientAccountBalance` is returned.
+- Due to the validation step being skipped, the overall fee of transactions sent with an impersonated account will be lower than regular transactions.
+- Trying to send a transaction with an account that **does not** even exist in the origin network returns an error:
+  - `ContractNotFound` if, during transaction preparation, you do not specify a nonce value, leading to the implicit querying of Devnet for the nonce.
+  - `InsufficientAccountBalance` or similar if the nonce is supplied in the transaction; this happens because the token balance of a non-existent contract is 0 indeed insufficient.
 
 :::
 
-## Disabling impersonation
+## Tips
 
-Click [here](./restrictive.md) to learn how to disable account impersonation.
+- The impersonated account may have had all or a part of its funds used up on the origin network. You may need to give it more funds via [minting](./balance.md).
+- If you're defining a new account in your Starknet client application (starknet.js, starknet.rs, starkli...), you may need to specify a private key for it. Since the signature validation is skipped, you may provide a dummy key.
 
 ## API
 
@@ -83,3 +86,7 @@ Stops the effect of [automatic impersonation](#devnet_autoimpersonate).
     "params": {}
 }
 ```
+
+## Preventing impersonation
+
+If you want to learn about completely preventing impersonation from being activated on your Devnet, click [here](./restrictive.md).

--- a/website/versioned_docs/version-0.4.0/restrictive.md
+++ b/website/versioned_docs/version-0.4.0/restrictive.md
@@ -1,10 +1,10 @@
 # Restrictive mode
 
-The --restrictive-mode argument enables a restrictive mode for Devnet, allowing you to specify methods that are forbidden during execution. This option ensures that certain operations are restricted, enhancing control over Devnet's behavior. When a user sends a request to one of the restricted methods, Devnet will return either a JSON-RPC error with code -32604 or, if the method was targeted directly via the HTTP endpoint, a response with status 403.
+The `--restrictive-mode` argument enables a restrictive mode for Devnet, allowing you to specify methods that are forbidden during execution. This option ensures that certain operations are restricted, enhancing control over Devnet's behavior. When a user sends a request to one of the restricted methods, Devnet will return either a JSON-RPC error with code -32604 or, if the method was targeted directly via the HTTP endpoint, a response with status 403.
 
 ## Default restricted methods
 
-When no methods are specified, the following default methods will be restricted and their HTTP endpoints counterparts (if any):
+When no methods are specified, the following default methods will be restricted, together with their HTTP endpoint counterparts (if any):
 
 - devnet_mint
 - devnet_load
@@ -25,7 +25,11 @@ $ starknet-devnet --restrictive-mode
 
 ### With a list of methods
 
-Note! Devnet will fail to start if any of the methods/routes is misspelled.
+:::note
+
+Devnet will fail to start if any of the methods/routes are misspelled.
+
+:::
 
 ```
 $ starknet-devnet --restrictive-mode devnet_dump devnet_config

--- a/website/versioned_docs/version-0.4.1/account-impersonation.md
+++ b/website/versioned_docs/version-0.4.1/account-impersonation.md
@@ -8,21 +8,24 @@ This page is about account impersonation. To read about account class selection 
 
 ## Introduction
 
-Devnet allows you to use impersonated account from mainnet/testnet. This means that a transaction sent from an impersonated account will not fail with an invalid signature error. In the general case, a transaction sent with an account that is not in the local state fails with the aforementioned error. For impersonation to work, Devnet needs to be run in [forking mode](./forking.md).
+Devnet allows you to impersonate an account that exists on the Starknet mainnet or testnet. This is achieved by skipping the validation step of transactions for all or some accounts, on a running Devnet via JSON-RPC.
+
+A transaction sent from an impersonated account will not fail with an invalid signature error, which is what happens in the general case of locally absent accounts. For impersonation to work, Devnet needs to [fork](./forking.md) the network that has the desired account.
 
 :::warning Caveat
 
 - Only `INVOKE` and `DECLARE` transactions are supported. `DEPLOY_ACCOUNT` transaction is not supported, but you can create an `INVOKE` transaction to UDC.
-- Overall fee, for transactions sent with an impersonated account, will be lower compared to normal transactions. The reason is that validation part is skipped.
-- The most common way of sending a transaction is via starknet-rs/starknet.js or starkli. Trying to send with an account that **does not** exist even in the origin network will return an error:
-  - In transaction construction, if account nonce is not hardcoded, Devnet is queried and returns `ContractNotFound`.
-  - Otherwise the nonce fetching part is skipped and `InsufficientAccountBalance` is returned.
+- Due to the validation step being skipped, the overall fee of transactions sent with an impersonated account will be lower than regular transactions.
+- Trying to send a transaction with an account that **does not** even exist in the origin network returns an error:
+  - `ContractNotFound` if, during transaction preparation, you do not specify a nonce value, leading to the implicit querying of Devnet for the nonce.
+  - `InsufficientAccountBalance` or similar if the nonce is supplied in the transaction; this happens because the token balance of a non-existent contract is 0 indeed insufficient.
 
 :::
 
-## Disabling impersonation
+## Tips
 
-Click [here](./restrictive.md) to learn how to disable account impersonation.
+- The impersonated account may have had all or a part of its funds used up on the origin network. You may need to give it more funds via [minting](./balance.md).
+- If you're defining a new account in your Starknet client application (starknet.js, starknet.rs, starkli...), you may need to specify a private key for it. Since the signature validation is skipped, you may provide a dummy key.
 
 ## API
 
@@ -83,3 +86,7 @@ Stops the effect of [automatic impersonation](#devnet_autoimpersonate).
     "params": {}
 }
 ```
+
+## Preventing impersonation
+
+If you want to learn about completely preventing impersonation from being activated on your Devnet, click [here](./restrictive.md).

--- a/website/versioned_docs/version-0.4.1/restrictive.md
+++ b/website/versioned_docs/version-0.4.1/restrictive.md
@@ -1,10 +1,10 @@
 # Restrictive mode
 
-The --restrictive-mode argument enables a restrictive mode for Devnet, allowing you to specify methods that are forbidden during execution. This option ensures that certain operations are restricted, enhancing control over Devnet's behavior. When a user sends a request to one of the restricted methods, Devnet will return either a JSON-RPC error with code -32604 or, if the method was targeted directly via the HTTP endpoint, a response with status 403.
+The `--restrictive-mode` argument enables a restrictive mode for Devnet, allowing you to specify methods that are forbidden during execution. This option ensures that certain operations are restricted, enhancing control over Devnet's behavior. When a user sends a request to one of the restricted methods, Devnet will return either a JSON-RPC error with code -32604 or, if the method was targeted directly via the HTTP endpoint, a response with status 403.
 
 ## Default restricted methods
 
-When no methods are specified, the following default methods will be restricted and their HTTP endpoints counterparts (if any):
+When no methods are specified, the following default methods will be restricted, together with their HTTP endpoint counterparts (if any):
 
 - devnet_mint
 - devnet_load
@@ -25,7 +25,11 @@ $ starknet-devnet --restrictive-mode
 
 ### With a list of methods
 
-Note! Devnet will fail to start if any of the methods/routes is misspelled.
+:::note
+
+Devnet will fail to start if any of the methods/routes are misspelled.
+
+:::
 
 ```
 $ starknet-devnet --restrictive-mode devnet_dump devnet_config


### PR DESCRIPTION
## Usage related changes

- Improve impersonation docs

## Development related changes

- Improve testing: combine time advancing, forking and account impersonation
- Move time manipulation testing utilities to utils.rs
- Improve assertion in `test_forked_devnet_new_block_has_parent_hash_of_the_origin_block`

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)
