### PR TITLE
Fix dead link in foundry.toml

### DIFF
--- a/contracts/l1-l2-messaging/solidity/foundry.toml
+++ b/contracts/l1-l2-messaging/solidity/foundry.toml
@@ -3,4 +3,4 @@ src = "src"
 out = "out"
 libs = ["lib"]
 
-# See more config options https://github.com/foundry-rs/foundry/tree/master/config
+# See more config options https://github.com/foundry-rs/foundry/tree/master/crates/config


### PR DESCRIPTION
## Usage related changes

Hey team! Fixed broken link

https://github.com/foundry-rs/foundry/tree/master/config - old link
https://github.com/foundry-rs/foundry/tree/master/crates/config - link

## Checklist:

- [x] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] No spelling errors - `./scripts/check_spelling.sh`
- [ ] Performed code self-review
- [ ] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [ ] Updated the docs if needed - `./website/README.md`
- [ ] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)
