### PR TITLE
Fix total supply in ERC20

### DIFF
--- a/crates/starknet-devnet-core/src/account.rs
+++ b/crates/starknet-devnet-core/src/account.rs
@@ -9,12 +9,11 @@ use starknet_types::contract_address::ContractAddress;
 use starknet_types::contract_class::ContractClass;
 use starknet_types::error::Error;
 use starknet_types::felt::{ClassHash, Key, felt_from_prefixed_hex, join_felts, split_biguint};
-use starknet_types::num_bigint::BigUint;
 use starknet_types::rpc::state::Balance;
 
 use crate::constants::{
     CHARGEABLE_ACCOUNT_ADDRESS, CHARGEABLE_ACCOUNT_PRIVATE_KEY, CHARGEABLE_ACCOUNT_PUBLIC_KEY,
-    ISRC6_ID_HEX,
+    ISRC6_ID_HEX, chargeable_account_initial_balance,
 };
 use crate::contract_class_choice::{AccountClassWrapper, AccountContractClassChoice};
 use crate::error::DevnetResult;
@@ -66,7 +65,7 @@ impl Account {
             account_address: ContractAddress::new(felt_from_prefixed_hex(
                 CHARGEABLE_ACCOUNT_ADDRESS,
             )?)?,
-            initial_balance: (BigUint::from(1_u32) << 256) - BigUint::from(1_u32), // max value
+            initial_balance: chargeable_account_initial_balance(),
             class_hash,
             class_metadata,
             contract_class,

--- a/crates/starknet-devnet-core/src/constants.rs
+++ b/crates/starknet-devnet-core/src/constants.rs
@@ -105,8 +105,9 @@ pub const CHARGEABLE_ACCOUNT_PUBLIC_KEY: &str =
 pub const CHARGEABLE_ACCOUNT_PRIVATE_KEY: &str = "0x5FB2959E3011A873A7160F5BB32B0ECE";
 pub const CHARGEABLE_ACCOUNT_ADDRESS: &str =
     "0x1CAF2DF5ED5DDE1AE3FAEF4ACD72522AC3CB16E23F6DC4C7F9FAED67124C511";
-
 pub fn chargeable_account_initial_balance() -> BigUint {
+    // Ideally, this would be a constant, but defining it as a string introduces parsing issues and
+    // making lazy_static a dependency seems too much.
     BigUint::from(1_u32) << 255
 }
 

--- a/crates/starknet-devnet-core/src/constants.rs
+++ b/crates/starknet-devnet-core/src/constants.rs
@@ -4,6 +4,7 @@ use std::num::NonZeroU128;
 use nonzero_ext::nonzero;
 use starknet_rs_core::types::Felt;
 use starknet_types::chain_id::ChainId;
+use starknet_types::num_bigint::BigUint;
 
 pub const CAIRO_0_ACCOUNT_CONTRACT: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
@@ -104,6 +105,10 @@ pub const CHARGEABLE_ACCOUNT_PUBLIC_KEY: &str =
 pub const CHARGEABLE_ACCOUNT_PRIVATE_KEY: &str = "0x5FB2959E3011A873A7160F5BB32B0ECE";
 pub const CHARGEABLE_ACCOUNT_ADDRESS: &str =
     "0x1CAF2DF5ED5DDE1AE3FAEF4ACD72522AC3CB16E23F6DC4C7F9FAED67124C511";
+
+pub fn chargeable_account_initial_balance() -> BigUint {
+    BigUint::from(1_u32) << 255
+}
 
 pub const ENTRYPOINT_NOT_FOUND_ERROR_ENCODED: Felt =
     Felt::from_hex_unchecked("0x454e545259504f494e545f4e4f545f464f554e44");

--- a/crates/starknet-devnet/src/cli.rs
+++ b/crates/starknet-devnet/src/cli.rs
@@ -288,6 +288,7 @@ impl Args {
         Ok((starknet_config, server_config))
     }
 
+    /// n_accounts * balance(single_account) + chargeable_balance < u256 capacity
     fn validate_total_account_balance(&self) -> Result<(), anyhow::Error> {
         let total_supply = self.accounts_count * self.initial_balance.0.clone()
             + chargeable_account_initial_balance();
@@ -759,7 +760,7 @@ mod tests {
     }
 
     #[test]
-    /// Fails because
+    /// Fails because 2 * (2 ** 254) + (2 ** 255) = 2 ** 256
     fn should_fail_on_exceeded_total_supply() {
         let initial_balance: BigUint = BigUint::from(1_u32) << 254;
         let err = Args::parse_from([


### PR DESCRIPTION
## Usage related changes

- Close #796
- Introduce a startup check: the `total_supply`, resulting from the balance of all pre-deployed accounts (including the dev-only chargeable account) in ETH and STRK ERC20 token contracts should be less than `2**256` (in each token contract).

## Development related changes

- Refactor custom CLI param validation - extract into helper methods.
- Reduce chargeable account initial balance from `2**256 - 1` to `2**255`

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)
