### PR TITLE
Test case: set time when pre-confirmed txs

### DIFF
--- a/tests/integration/test_advancing_time.rs
+++ b/tests/integration/test_advancing_time.rs
@@ -309,21 +309,19 @@ async fn set_time_in_future_block_generation_on_demand() {
 }
 
 #[tokio::test]
-async fn set_time_with_preconfirmed_txs() {
+async fn set_time_with_pre_confirmed_txs() {
     let start_time = get_unix_timestamp_as_seconds();
     let devnet = BackgroundDevnet::spawn_with_additional_args(&["--block-generation-on", "demand"])
         .await
         .unwrap();
 
-    let dummy_address = Felt::ONE;
-    let dummy_amount = 1_u128;
-
     let mut sent_mint_txs = vec![];
     for _ in 0..2 {
-        let mint_tx = devnet.mint(dummy_address, dummy_amount).await;
+        // dummy data
+        let mint_tx = devnet.mint(Felt::ONE, 1_u128).await;
         sent_mint_txs.push(mint_tx);
     }
-    sent_mint_txs.sort();
+    sent_mint_txs.sort(); // sorting to allow equality assertion
 
     let pre_confirmed_block = devnet.get_pending_block_with_tx_hashes().await.unwrap();
     let mut pre_confirmed_txs = pre_confirmed_block.transactions.clone();


### PR DESCRIPTION
## Usage related changes

N/A

## Development related changes

- Expand testing as the title suggests.
- Motivated by [this Slack thread](https://spaceshard.slack.com/archives/C03031Y0LKC/p1751958010625149).
- Add utility for equality comparison with the same buffer used in inequality assertion.

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
  - @coderabbitai review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)
