### PR TITLE
Support simulation of ACCEPTED_ON_L1

### DIFF
--- a/crates/starknet-devnet-core/src/blocks/mod.rs
+++ b/crates/starknet-devnet-core/src/blocks/mod.rs
@@ -26,7 +26,6 @@ pub(crate) struct StarknetBlocks {
     pub(crate) hash_to_state: HashMap<BlockHash, StarknetState>,
     pub(crate) aborted_blocks: Vec<Felt>,
     pub(crate) starting_block_number: u64,
-    pub(crate) last_accepted_on_l1: Option<BlockHash>,
 }
 
 impl HashIdentified for StarknetBlocks {
@@ -51,7 +50,6 @@ impl Default for StarknetBlocks {
             hash_to_state: HashMap::new(),
             aborted_blocks: Vec::new(),
             starting_block_number: DEVNET_DEFAULT_STARTING_BLOCK_NUMBER,
-            last_accepted_on_l1: None,
         }
     }
 }

--- a/crates/starknet-devnet-core/src/blocks/mod.rs
+++ b/crates/starknet-devnet-core/src/blocks/mod.rs
@@ -26,6 +26,7 @@ pub(crate) struct StarknetBlocks {
     pub(crate) hash_to_state: HashMap<BlockHash, StarknetState>,
     pub(crate) aborted_blocks: Vec<Felt>,
     pub(crate) starting_block_number: u64,
+    pub(crate) last_accepted_on_l1: Option<BlockHash>,
 }
 
 impl HashIdentified for StarknetBlocks {
@@ -50,6 +51,7 @@ impl Default for StarknetBlocks {
             hash_to_state: HashMap::new(),
             aborted_blocks: Vec::new(),
             starting_block_number: DEVNET_DEFAULT_STARTING_BLOCK_NUMBER,
+            last_accepted_on_l1: None,
         }
     }
 }

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -1032,6 +1032,7 @@ impl Starknet {
 
     pub fn accept_on_l1(&mut self, block_id: BlockId) -> DevnetResult<Vec<BlockHash>> {
         let block = self.get_block(&block_id)?;
+        // Only the starting block is validated; all ancestors are guaranteed to be ACCEPTED_ON_L2
         self.validate_acceptability_on_l1(block.status)?;
 
         let mut acceptable_block =

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -1022,11 +1022,9 @@ impl Starknet {
     fn validate_acceptability_on_l1(&self, block_status: BlockStatus) -> DevnetResult<()> {
         let err_msg = match block_status {
             BlockStatus::AcceptedOnL2 => return Ok(()),
-            BlockStatus::PreConfirmed => {
-                "Cannot accept a pre-confirmed block on L1; first call devnet_createBlock"
-            }
+            BlockStatus::PreConfirmed => "Pre-confirmed block cannot be accepted on L1",
             BlockStatus::AcceptedOnL1 => "Block already accepted on L1",
-            BlockStatus::Rejected => "Cannot accept a rejected block on L1",
+            BlockStatus::Rejected => "Rejected block cannot be accepted on L1",
         };
 
         Err(Error::UnsupportedAction { msg: err_msg.into() })

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -1056,7 +1056,6 @@ impl Starknet {
             }
         }
 
-        self.blocks.last_accepted_on_l1 = Some(accepted[0]);
         Ok(accepted)
     }
 

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -928,7 +928,10 @@ impl Starknet {
         Ok(self.next_block_gas.clone())
     }
 
-    pub fn abort_blocks(&mut self, mut starting_block_id: BlockId) -> DevnetResult<Vec<Felt>> {
+    pub fn abort_blocks(
+        &mut self,
+        mut starting_block_id: BlockId,
+    ) -> DevnetResult<Vec<TransactionHash>> {
         if self.config.state_archive != StateArchiveCapacity::Full {
             let msg = "The abort blocks feature requires state-archive-capacity set to full.";
             return Err(Error::UnsupportedAction { msg: msg.into() });
@@ -1014,6 +1017,49 @@ impl Starknet {
         self.blocks.aborted_blocks = aborted.clone();
 
         Ok(aborted)
+    }
+
+    fn validate_acceptability_on_l1(&self, block_status: BlockStatus) -> DevnetResult<()> {
+        let err_msg = match block_status {
+            BlockStatus::AcceptedOnL2 => return Ok(()),
+            BlockStatus::PreConfirmed => {
+                "Cannot accept a pre-confirmed block on L1; first call devnet_createBlock"
+            }
+            BlockStatus::AcceptedOnL1 => "Block already accepted on L1",
+            BlockStatus::Rejected => "Cannot accept a rejected block on L1",
+        };
+
+        Err(Error::UnsupportedAction { msg: err_msg.into() })
+    }
+
+    pub fn accept_on_l1(&mut self, block_id: BlockId) -> DevnetResult<Vec<BlockHash>> {
+        let block = self.get_block(&block_id)?;
+        self.validate_acceptability_on_l1(block.status)?;
+
+        let mut acceptable_block =
+            self.blocks.hash_to_block.get_mut(&block.block_hash()).ok_or(Error::NoBlock)?;
+        let mut accepted = vec![];
+        while acceptable_block.status != BlockStatus::AcceptedOnL1 {
+            // Accept block on L1
+            acceptable_block.status = BlockStatus::AcceptedOnL1;
+            accepted.push(acceptable_block.block_hash());
+
+            // Mark the transactions from the block as accepted on L1
+            for tx_hash in acceptable_block.get_transactions() {
+                let tx = self.transactions.get_by_hash_mut(tx_hash).ok_or(Error::NoTransaction)?;
+                tx.finality_status = TransactionFinalityStatus::AcceptedOnL1;
+            }
+
+            // Get next block for accepting: parent
+            let parent_block_hash = acceptable_block.parent_hash();
+            match self.blocks.hash_to_block.get_mut(&parent_block_hash) {
+                Some(parent_block) => acceptable_block = parent_block,
+                None => break, // Means genesis block is encountered
+            }
+        }
+
+        self.blocks.last_accepted_on_l1 = Some(accepted[0]);
+        Ok(accepted)
     }
 
     pub fn get_block_txs_count(&self, block_id: &BlockId) -> DevnetResult<u64> {

--- a/crates/starknet-devnet-server/src/api/http/models.rs
+++ b/crates/starknet-devnet-server/src/api/http/models.rs
@@ -64,6 +64,18 @@ pub struct AbortedBlocks {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(test, derive(Debug))]
+pub struct AcceptOnL1Request {
+    pub(crate) starting_block_id: BlockId,
+}
+
+#[derive(Serialize)]
+pub struct AcceptedOnL1Blocks {
+    pub(crate) accepted: Vec<BlockHash>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(test, derive(Debug))]
 pub struct IncreaseTime {
     pub time: u64,
 }

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -53,11 +53,11 @@ use super::Api;
 use super::http::endpoints::DevnetConfig;
 use super::http::endpoints::accounts::{BalanceQuery, PredeployedAccountsQuery};
 use super::http::models::{
-    AbortedBlocks, AbortingBlocks, AccountBalanceResponse, CreatedBlock, DumpPath,
-    DumpResponseBody, FlushParameters, FlushedMessages, IncreaseTime, IncreaseTimeResponse,
-    LoadPath, MessageHash, MessagingLoadAddress, MintTokensRequest, MintTokensResponse,
-    PostmanLoadL1MessagingContract, RestartParameters, SerializableAccount, SetTime,
-    SetTimeResponse,
+    AbortedBlocks, AbortingBlocks, AcceptedOnL1Blocks, AccountBalanceResponse, CreatedBlock,
+    DumpPath, DumpResponseBody, FlushParameters, FlushedMessages, IncreaseTime,
+    IncreaseTimeResponse, LoadPath, MessageHash, MessagingLoadAddress, MintTokensRequest,
+    MintTokensResponse, PostmanLoadL1MessagingContract, RestartParameters, SerializableAccount,
+    SetTime, SetTimeResponse,
 };
 use crate::ServerConfig;
 use crate::api::json_rpc::models::{
@@ -1036,6 +1036,7 @@ pub enum DevnetResponse {
     MessageHash(MessageHash),
     CreatedBlock(CreatedBlock),
     AbortedBlocks(AbortedBlocks),
+    AcceptedOnL1Blocks(AcceptedOnL1Blocks),
     GasModification(GasModification),
     SetTime(SetTimeResponse),
     IncreaseTime(IncreaseTimeResponse),

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -53,8 +53,8 @@ use super::Api;
 use super::http::endpoints::DevnetConfig;
 use super::http::endpoints::accounts::{BalanceQuery, PredeployedAccountsQuery};
 use super::http::models::{
-    AbortedBlocks, AbortingBlocks, AcceptedOnL1Blocks, AccountBalanceResponse, CreatedBlock,
-    DumpPath, DumpResponseBody, FlushParameters, FlushedMessages, IncreaseTime,
+    AbortedBlocks, AbortingBlocks, AcceptOnL1Request, AcceptedOnL1Blocks, AccountBalanceResponse,
+    CreatedBlock, DumpPath, DumpResponseBody, FlushParameters, FlushedMessages, IncreaseTime,
     IncreaseTimeResponse, LoadPath, MessageHash, MessagingLoadAddress, MintTokensRequest,
     MintTokensResponse, PostmanLoadL1MessagingContract, RestartParameters, SerializableAccount,
     SetTime, SetTimeResponse,
@@ -546,6 +546,7 @@ impl JsonRpcHandler {
             }
             JsonRpcRequest::CreateBlock => self.create_block().await,
             JsonRpcRequest::AbortBlocks(data) => self.abort_blocks(data).await,
+            JsonRpcRequest::AcceptOnL1(data) => self.accept_on_l1(data).await,
             JsonRpcRequest::SetGasPrice(data) => self.set_gas_price(data).await,
             JsonRpcRequest::Restart(data) => self.restart(data).await,
             JsonRpcRequest::SetTime(data) => self.set_time(data).await,
@@ -730,6 +731,8 @@ pub enum JsonRpcRequest {
     CreateBlock,
     #[serde(rename = "devnet_abortBlocks")]
     AbortBlocks(AbortingBlocks),
+    #[serde(rename = "devnet_acceptOnL1")]
+    AcceptOnL1(AcceptOnL1Request),
     #[serde(rename = "devnet_setGasPrice")]
     SetGasPrice(GasModificationRequest),
     #[serde(rename = "devnet_restart", with = "optional_params")]
@@ -759,6 +762,7 @@ impl JsonRpcRequest {
             | Self::PostmanSendMessageToL2(_)
             | Self::CreateBlock
             | Self::AbortBlocks(_)
+            | Self::AcceptOnL1(_)
             | Self::SetTime(_)
             | Self::IncreaseTime(_)
             | Self::Mint(_) => true,
@@ -855,6 +859,7 @@ impl JsonRpcRequest {
             | Self::PostmanConsumeMessageFromL2(_)
             | Self::CreateBlock
             | Self::AbortBlocks(_)
+            | Self::AcceptOnL1(_)
             | Self::SetGasPrice(_)
             | Self::Restart(_)
             | Self::SetTime(_)
@@ -879,6 +884,7 @@ impl JsonRpcRequest {
             | Self::PostmanConsumeMessageFromL2(_)
             | Self::CreateBlock
             | Self::AbortBlocks(_)
+            | Self::AcceptOnL1(_)
             | Self::SetGasPrice(_)
             | Self::SetTime(_)
             | Self::IncreaseTime(_)

--- a/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
@@ -19,8 +19,9 @@ use crate::api::http::endpoints::postman::{
 };
 use crate::api::http::endpoints::time::{increase_time_impl, set_time_impl};
 use crate::api::http::models::{
-    AbortedBlocks, AbortingBlocks, CreatedBlock, DumpPath, FlushParameters, IncreaseTime,
-    MintTokensRequest, PostmanLoadL1MessagingContract, RestartParameters, SetTime,
+    AbortedBlocks, AbortingBlocks, AcceptOnL1Request, AcceptedOnL1Blocks, CreatedBlock, DumpPath,
+    FlushParameters, IncreaseTime, MintTokensRequest, PostmanLoadL1MessagingContract,
+    RestartParameters, SetTime,
 };
 use crate::api::json_rpc::JsonRpcHandler;
 use crate::dump_util::load_events;
@@ -154,6 +155,13 @@ impl JsonRpcHandler {
     pub async fn abort_blocks(&self, data: AbortingBlocks) -> StrictRpcResult {
         let aborted = self.api.starknet.lock().await.abort_blocks(data.starting_block_id.into())?;
         Ok(DevnetResponse::AbortedBlocks(AbortedBlocks { aborted }).into())
+    }
+
+    /// devnet_acceptOnL1
+    pub async fn accept_on_l1(&self, data: AcceptOnL1Request) -> StrictRpcResult {
+        let accepted =
+            self.api.starknet.lock().await.accept_on_l1(data.starting_block_id.into())?;
+        Ok(DevnetResponse::AcceptedOnL1Blocks(AcceptedOnL1Blocks { accepted }).into())
     }
 
     /// devnet_setGasPrice

--- a/tests/integration/lib.rs
+++ b/tests/integration/lib.rs
@@ -8,6 +8,7 @@ mod get_transaction_by_block_id_and_index;
 mod get_transaction_by_hash;
 mod get_transaction_receipt_by_hash;
 mod test_abort_blocks;
+mod test_accepting_blocks_on_l1;
 mod test_account_impersonation;
 mod test_account_selection;
 mod test_advancing_time;

--- a/tests/integration/test_accepting_blocks_on_l1.rs
+++ b/tests/integration/test_accepting_blocks_on_l1.rs
@@ -66,13 +66,13 @@ async fn should_convert_accepted_on_l2_with_id_latest() {
     let origin_block_hash = devnet.get_latest_block_with_tx_hashes().await.unwrap().block_hash;
     let mut block_hashes = vec![origin_block_hash];
     for _ in 0..2 {
-        let tx_hash = send_dummy_tx(&devnet).await; // dummy data
+        let tx_hash = send_dummy_tx(&devnet).await;
         tx_hashes.push(tx_hash);
         let block_hash = devnet.get_latest_block_with_tx_hashes().await.unwrap().block_hash;
         block_hashes.push(block_hash);
     }
 
-    block_hashes.reverse(); // the hashes are in reverse chronological order TODO?
+    block_hashes.reverse(); // the hashes are in reverse chronological order
 
     let accepted_block_hashes =
         accept_on_l1(&devnet, &BlockId::Tag(BlockTag::Latest)).await.unwrap();
@@ -90,7 +90,7 @@ async fn should_convert_all_txs_in_block_on_demand() {
     let mut tx_hashes = vec![];
     let origin_block_hash = devnet.get_latest_block_with_tx_hashes().await.unwrap().block_hash;
     for _ in 0..2 {
-        let tx_hash = send_dummy_tx(&devnet).await; // dummy data
+        let tx_hash = send_dummy_tx(&devnet).await;
         tx_hashes.push(tx_hash);
     }
 
@@ -111,14 +111,14 @@ async fn should_convert_accepted_on_l2_with_numeric_id() {
     let origin_block_hash = devnet.get_latest_block_with_tx_hashes().await.unwrap().block_hash;
     let mut block_hashes = vec![origin_block_hash];
 
-    let tx_hash = send_dummy_tx(&devnet).await; // dummy data
+    let tx_hash = send_dummy_tx(&devnet).await;
     let block_hash = devnet.get_latest_block_with_tx_hashes().await.unwrap().block_hash;
     block_hashes.push(block_hash);
 
     // Extra tx that won't be accepted on l1
-    send_dummy_tx(&devnet).await; // dummy data
+    send_dummy_tx(&devnet).await;
 
-    block_hashes.reverse(); // the hashes are in reverse chronological order TODO?
+    block_hashes.reverse(); // the hashes are in reverse chronological order
 
     let accepted_block_hashes = accept_on_l1(&devnet, &BlockId::Number(1)).await.unwrap();
     assert_eq!(accepted_block_hashes, block_hashes);
@@ -134,14 +134,14 @@ async fn should_convert_accepted_on_l2_with_hash_id() {
     let origin_block_hash = devnet.get_latest_block_with_tx_hashes().await.unwrap().block_hash;
     let mut block_hashes = vec![origin_block_hash];
 
-    let tx_hash = send_dummy_tx(&devnet).await; // dummy data
+    let tx_hash = send_dummy_tx(&devnet).await;
     let block_hash = devnet.get_latest_block_with_tx_hashes().await.unwrap().block_hash;
     block_hashes.push(block_hash);
 
     // Extra tx that won't be accepted on l1
-    send_dummy_tx(&devnet).await; // dummy data
+    send_dummy_tx(&devnet).await;
 
-    block_hashes.reverse(); // the hashes are in reverse chronological order TODO?
+    block_hashes.reverse(); // the hashes are in reverse chronological order
 
     let accepted_block_hashes = accept_on_l1(&devnet, &BlockId::Hash(block_hash)).await.unwrap();
     assert_eq!(accepted_block_hashes, block_hashes);
@@ -168,7 +168,7 @@ async fn should_fail_if_accepting_pre_confirmed() {
         .await
         .unwrap();
 
-    let tx_hash = send_dummy_tx(&devnet).await; // dummy data
+    let tx_hash = send_dummy_tx(&devnet).await;
 
     let err = accept_on_l1(&devnet, &BlockId::Tag(BlockTag::PreConfirmed)).await.unwrap_err();
     assert_eq!(
@@ -199,7 +199,7 @@ async fn should_fail_if_accepting_rejected() {
             .await
             .unwrap();
 
-    send_dummy_tx(&devnet).await; // dummy data
+    send_dummy_tx(&devnet).await;
     let aborted_blocks = devnet.abort_blocks(&BlockId::Tag(BlockTag::Latest)).await.unwrap();
     assert_eq!(aborted_blocks.len(), 1);
     let aborted_block_hash = aborted_blocks[0];

--- a/tests/integration/test_accepting_blocks_on_l1.rs
+++ b/tests/integration/test_accepting_blocks_on_l1.rs
@@ -1,0 +1,184 @@
+use serde_json::json;
+use starknet_rs_core::types::{
+    BlockId, BlockStatus, BlockTag, Felt, MaybePreConfirmedBlockWithTxHashes,
+    SequencerTransactionStatus,
+};
+use starknet_rs_providers::Provider;
+
+use crate::common::background_devnet::BackgroundDevnet;
+use crate::common::errors::RpcError;
+
+async fn accept_on_l1(
+    devnet: &BackgroundDevnet,
+    starting_block_id: &BlockId,
+) -> Result<Vec<Felt>, RpcError> {
+    let accepted_block_hashes_raw = devnet
+        .send_custom_rpc("devnet_acceptOnL1", json!({ "starting_block_id" : starting_block_id }))
+        .await?;
+
+    let accepted_block_hashes =
+        serde_json::from_value(accepted_block_hashes_raw["accepted"].clone()).unwrap();
+    Ok(accepted_block_hashes)
+}
+
+/// Asserts blocks and txs are accepted on L1. `block_hashes` are expected in reverse chronological
+/// and `tx_hashes` in chronological order.
+async fn assert_accepted_on_l1(
+    devnet: &BackgroundDevnet,
+    block_hashes: &[Felt],
+    tx_hashes: &[Felt],
+) {
+    for block_hash in block_hashes {
+        match devnet.json_rpc_client.get_block_with_tx_hashes(BlockId::Hash(*block_hash)).await {
+            Ok(MaybePreConfirmedBlockWithTxHashes::Block(block)) => {
+                assert_eq!(block.status, BlockStatus::AcceptedOnL1)
+            }
+            other => panic!("Unexpected block: {other:?}"),
+        }
+    }
+
+    for tx_hash in tx_hashes {
+        let tx_status = devnet.json_rpc_client.get_transaction_status(tx_hash).await.unwrap();
+        assert_eq!(tx_status.finality_status(), SequencerTransactionStatus::AcceptedOnL1);
+    }
+}
+
+#[tokio::test]
+async fn should_convert_accepted_on_l2_with_id_latest() {
+    let devnet = BackgroundDevnet::spawn().await.unwrap();
+
+    let mut tx_hashes = vec![];
+    let origin_block_hash = devnet.get_latest_block_with_tx_hashes().await.unwrap().block_hash;
+    let mut block_hashes = vec![origin_block_hash];
+    for _ in 0..2 {
+        let tx_hash = devnet.mint(Felt::ONE, 1).await; // dummy data
+        tx_hashes.push(tx_hash);
+        let block_hash = devnet.get_latest_block_with_tx_hashes().await.unwrap().block_hash;
+        block_hashes.push(block_hash);
+    }
+
+    block_hashes.reverse(); // the hashes are in reverse chronological order TODO?
+
+    let accepted_block_hashes =
+        accept_on_l1(&devnet, &BlockId::Tag(BlockTag::Latest)).await.unwrap();
+    assert_eq!(accepted_block_hashes, block_hashes);
+
+    assert_accepted_on_l1(&devnet, &block_hashes, &tx_hashes).await;
+}
+
+#[tokio::test]
+async fn should_convert_all_txs_in_block_on_demand() {
+    let devnet = BackgroundDevnet::spawn_with_additional_args(&["--block-generation-on", "demand"])
+        .await
+        .unwrap();
+
+    let mut tx_hashes = vec![];
+    let origin_block_hash = devnet.get_latest_block_with_tx_hashes().await.unwrap().block_hash;
+    for _ in 0..2 {
+        let tx_hash = devnet.mint(Felt::ONE, 1).await; // dummy data
+        tx_hashes.push(tx_hash);
+    }
+
+    let generated_block_hash = devnet.create_block().await.unwrap();
+    let block_hashes = vec![generated_block_hash, origin_block_hash];
+
+    let accepted_block_hashes =
+        accept_on_l1(&devnet, &BlockId::Tag(BlockTag::Latest)).await.unwrap();
+    assert_eq!(accepted_block_hashes, block_hashes);
+
+    assert_accepted_on_l1(&devnet, &block_hashes, &tx_hashes).await;
+}
+
+#[tokio::test]
+async fn should_convert_accepted_on_l2_with_numeric_id() {
+    let devnet = BackgroundDevnet::spawn().await.unwrap();
+
+    let origin_block_hash = devnet.get_latest_block_with_tx_hashes().await.unwrap().block_hash;
+    let mut block_hashes = vec![origin_block_hash];
+
+    let tx_hash = devnet.mint(Felt::ONE, 1).await; // dummy data
+    let block_hash = devnet.get_latest_block_with_tx_hashes().await.unwrap().block_hash;
+    block_hashes.push(block_hash);
+
+    // Extra tx that won't be accepted on l1
+    let extra_tx_hash = devnet.mint(Felt::ONE, 1).await; // dummy data
+
+    block_hashes.reverse(); // the hashes are in reverse chronological order TODO?
+
+    let accepted_block_hashes = accept_on_l1(&devnet, &BlockId::Number(1)).await.unwrap();
+    assert_eq!(accepted_block_hashes, block_hashes);
+
+    assert_accepted_on_l1(&devnet, &block_hashes, &[tx_hash]).await;
+
+    // Assert latest block and tx untouched
+    assert_eq!(
+        devnet.get_latest_block_with_tx_hashes().await.unwrap().status,
+        BlockStatus::AcceptedOnL2,
+    );
+    assert_eq!(
+        devnet
+            .json_rpc_client
+            .get_transaction_status(extra_tx_hash)
+            .await
+            .unwrap()
+            .finality_status(),
+        SequencerTransactionStatus::AcceptedOnL2
+    )
+}
+
+#[tokio::test]
+async fn should_convert_accepted_on_l2_with_hash_id() {
+    let devnet = BackgroundDevnet::spawn().await.unwrap();
+
+    let origin_block_hash = devnet.get_latest_block_with_tx_hashes().await.unwrap().block_hash;
+    let mut block_hashes = vec![origin_block_hash];
+
+    let tx_hash = devnet.mint(Felt::ONE, 1).await; // dummy data
+    let block_hash = devnet.get_latest_block_with_tx_hashes().await.unwrap().block_hash;
+    block_hashes.push(block_hash);
+
+    // Extra tx that won't be accepted on l1
+    let extra_tx_hash = devnet.mint(Felt::ONE, 1).await; // dummy data
+
+    block_hashes.reverse(); // the hashes are in reverse chronological order TODO?
+
+    let accepted_block_hashes = accept_on_l1(&devnet, &BlockId::Hash(block_hash)).await.unwrap();
+    assert_eq!(accepted_block_hashes, block_hashes);
+
+    assert_accepted_on_l1(&devnet, &block_hashes, &[tx_hash]).await;
+
+    // Assert latest block and tx untouched
+    assert_eq!(
+        devnet.get_latest_block_with_tx_hashes().await.unwrap().status,
+        BlockStatus::AcceptedOnL2,
+    );
+    assert_eq!(
+        devnet
+            .json_rpc_client
+            .get_transaction_status(extra_tx_hash)
+            .await
+            .unwrap()
+            .finality_status(),
+        SequencerTransactionStatus::AcceptedOnL2
+    )
+}
+
+#[tokio::test]
+async fn should_fail_if_accepting_already_accepted_on_l1() {
+    todo!()
+}
+
+#[tokio::test]
+async fn should_fail_if_accepting_pre_confirmed() {
+    todo!()
+}
+
+#[tokio::test]
+async fn should_fail_if_accepting_rejected() {
+    todo!()
+}
+
+#[tokio::test]
+async fn should_fail_if_invalid_block_id() {
+    todo!("block hash, block number")
+}

--- a/website/docs/blocks.md
+++ b/website/docs/blocks.md
@@ -69,7 +69,7 @@ JSON-RPC
 }
 ```
 
-Response:
+Result:
 
 ```
 {"block_hash": "0x115e1b390cafa7942b6ab141ab85040defe7dee9bef3bc31d8b5b3d01cc9c67"}
@@ -130,7 +130,7 @@ JSON-RPC
 }
 ```
 
-Response:
+Result:
 
 ```
 {
@@ -147,6 +147,12 @@ When aborting the currently `pre_confirmed` block, it is mined and aborted as la
 ## Accepting blocks on L1
 
 This functionality allows simulating block acceptance on L1 (Ethereum). It merely marks the requested blocks and their transactions as `ACCEPTED_ON_L1`. It is only supported on blocks that are `ACCEPTED_ON_L2` and fails for all others, including blocks already `ACCEPTED_ON_L1`. In case of [forking](./forking), blocks on forking origin cannot be affected by this feature.
+
+:::note
+
+This functionality does not actually perform actions on L1.
+
+:::
 
 ### Example
 
@@ -168,7 +174,7 @@ JSON-RPC
 }
 ```
 
-Response:
+Result:
 
 ```
 {

--- a/website/docs/blocks.md
+++ b/website/docs/blocks.md
@@ -77,13 +77,13 @@ Response:
 
 The newly created block will contain all pre-confirmed transactions, if any, since the last block creation.
 
-### Timestamp manipulation
+## Timestamp manipulation
 
 To affect the timestamp of the newly created block, check out [this page](./starknet-time#set-time)
 
-## Abort blocks
+## Block abortion
 
-This functionality allows simulating block abortion that can occur on mainnet. It is supported in the `--state-archive-capacity full` mode.
+This functionality allows simulating block abortion that can occur on mainnet. It is only supported if Devnet is started in the `--state-archive-capacity full` mode.
 
 You can abort blocks and revert transactions from the specified block to the currently latest block. Newly created blocks after the abortion will have accepted status and will continue with numbering where the last accepted block left off.
 
@@ -99,7 +99,7 @@ Aborted blocks can only be queried by block hash. Devnet does not support the ab
 
 - blocks in the forking origin (i.e. blocks mined before the forked block)
 - already aborted blocks
-- Devnet's genesis block
+- Devnet's genesis block.
 
 ### Websocket subscription notifications
 
@@ -143,3 +143,35 @@ Response:
 When aborting the currently `pre_confirmed` block, it is mined and aborted as latest.
 
 :::
+
+## Accepting blocks on L1
+
+This functionality allows simulating block acceptance on L1 (Ethereum). It merely marks the requested blocks and their transactions as `ACCEPTED_ON_L1`. It is only supported on blocks that are `ACCEPTED_ON_L2` and fails for all others, including blocks already `ACCEPTED_ON_L1`. In case of [forking](./forking), blocks on forking origin cannot be affected by this feature.
+
+### Example
+
+Assume Devnet has mined blocks with numbers: 0 (origin), 1, 2 and 3. If this feature is invoked with `starting_block_id=BlockNumber(2)`, blocks 0, 1 and 2 shall be `ACCEPTED_ON_L1` and block 3 shall remain `ACCEPTED_ON_L2`. If after that another block (number 4) is mined, and this feature is invoked with `starting_block_id="latest"`, blocks 0, 1, 2, 3 and 4 shall be `ACCEPTED_ON_L1`. If a new block is mined after that (number 5), it shall be `ACCEPTED_ON_L2`.
+
+### Request and response
+
+To accept a block and its transactions on L1, send:
+
+```
+JSON-RPC
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "devnet_acceptOnL1",
+    "params": {
+        "starting_block_id": BLOCK_ID
+    }
+}
+```
+
+Response:
+
+```
+{
+    "accepted": [BLOCK_HASH_0, BLOCK_HASH_1, ...]
+}
+```

--- a/website/docs/blocks.md
+++ b/website/docs/blocks.md
@@ -150,7 +150,7 @@ This functionality allows simulating block acceptance on L1 (Ethereum). It merel
 
 ### Example
 
-Assume Devnet has mined blocks with numbers: 0 (origin), 1, 2 and 3. If this feature is invoked with `starting_block_id=BlockNumber(2)`, blocks 0, 1 and 2 shall be `ACCEPTED_ON_L1` and block 3 shall remain `ACCEPTED_ON_L2`. If after that another block (number 4) is mined, and this feature is invoked with `starting_block_id="latest"`, blocks 0, 1, 2, 3 and 4 shall be `ACCEPTED_ON_L1`. If a new block is mined after that (number 5), it shall be `ACCEPTED_ON_L2`.
+Assume Devnet has mined blocks with numbers: 0 (origin), 1, 2 and 3. If this feature is invoked with `starting_block_id={"block_number": 2}`, blocks 0, 1 and 2 shall be `ACCEPTED_ON_L1` and block 3 shall remain `ACCEPTED_ON_L2`. If after that another block (number 4) is mined, and this feature is invoked with `starting_block_id="latest"`, blocks 0, 1, 2, 3 and 4 shall be `ACCEPTED_ON_L1`. If a new block is mined after that (number 5), it shall be `ACCEPTED_ON_L2`.
 
 ### Request and response
 

--- a/website/static/devnet_api.json
+++ b/website/static/devnet_api.json
@@ -352,11 +352,11 @@
     },
     {
       "name": "devnet_abortBlocks",
-      "summary": "Abort blocks",
+      "summary": "Abort blocks from starting_block_id to the currently latest block",
       "params": [
         {
           "name": "starting_block_id",
-          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag, being the first block to be aborted.",
+          "description": "The first block to be aborted.",
           "required": true,
           "schema": {
             "title": "Block id",
@@ -366,7 +366,7 @@
       ],
       "result": {
         "name": "result",
-        "description": "Arary of aborted blocks hashes.",
+        "description": "Array of block hashes of aborted blocks.",
         "schema": {
           "type": "object",
           "properties": {
@@ -379,6 +379,43 @@
             }
           },
           "required": ["aborted"]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/WILDCARD_ERROR"
+        }
+      ]
+    },
+    {
+      "name": "devnet_acceptOnL1",
+      "summary": "Accept on L1 the blocks from starting_block_id to the oldest local block that is accepted on L2",
+      "params": [
+        {
+          "name": "starting_block_id",
+          "description": "The first block to be accepted on L1.",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "Array of block hashes of blocks accepted on L1.",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "accepted": {
+              "description": "Accepted blocks hashes",
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/FELT"
+              }
+            }
+          },
+          "required": ["accepted"]
         }
       },
       "errors": [


### PR DESCRIPTION
## Usage related changes

- Close #808
- Introduce a new JSON-RPC method: `devnet_acceptOnL1`
  - Marks as `ACCEPTED_ON_L1` blocks from `starting_block_id` to last accepted on L1, does the same for their txs.
  - Does not actually perform actions on L1.

## Development related changes

- Improve block abortion docs

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new JSON-RPC method to mark blocks and their transactions as accepted on L1, simulating L1 acceptance for blocks currently accepted on L2.
  * Added API request and response models for accepting blocks on L1.
  * Updated API documentation to describe the new block acceptance on L1 feature, including usage examples.

* **Bug Fixes**
  * Corrected descriptions and typos in the API documentation for block abortion.

* **Tests**
  * Added comprehensive integration tests to verify correct behavior and error handling for the new block acceptance on L1 feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->