### PR TITLE
Replace remaining occurrences of pending with pre-confirmed

### DIFF
--- a/crates/starknet-devnet-core/src/blocks/mod.rs
+++ b/crates/starknet-devnet-core/src/blocks/mod.rs
@@ -477,7 +477,7 @@ mod tests {
 
         // latest block returns none, because collection is empty
         assert!(blocks.block_number_from_block_id(&BlockId::Tag(BlockTag::Latest)).is_none());
-        // pending block returns some
+        // pre-confirmed block returns some
         assert!(blocks.block_number_from_block_id(&BlockId::Tag(BlockTag::PreConfirmed)).is_some());
 
         let block_hash = block_to_insert.generate_hash().unwrap();
@@ -574,7 +574,7 @@ mod tests {
                 .len(),
             8
         );
-        // from first block to latest/pending, should return all blocks
+        // from first block to latest/pre-confirmed, should return all blocks
         assert_eq!(
             blocks
                 .get_blocks(Some(BlockId::Number(2)), Some(BlockId::Tag(BlockTag::Latest)))
@@ -597,7 +597,7 @@ mod tests {
                 .unwrap()
                 .is_empty()
         );
-        // from last block to latest/pending, should return 1 block
+        // from last block to latest/pre-confirmed, should return 1 block
         assert_eq!(
             blocks
                 .get_blocks(Some(BlockId::Number(11)), Some(BlockId::Tag(BlockTag::Latest)))
@@ -643,7 +643,7 @@ mod tests {
                 .len(),
             8
         );
-        // from last block hash to latest/pending
+        // from last block hash to latest/pre-confirmed
         assert_eq!(
             blocks
                 .get_blocks(

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -324,10 +324,11 @@ impl JsonRpcHandler {
                     .get_transaction_by_hash(*tx_hash)
                     .map_err(error::ApiError::StarknetDevnetError)?;
 
-                // There are no pending txs in this mode, but basically we are pretending that the
-                // transaction existed for a short period of time in the pending block, thus
-                // triggering the notification. This is important for users depending on this
-                // subscription type to find out about all new transactions.
+                // There are no pre-confirmed txs in this mode, but basically we are pretending that
+                // the transaction existed for a short period of time in the
+                // pre-confirmed block, thus triggering the notification. This is
+                // important for users depending on this subscription type to find
+                // out about all new transactions.
                 notifications.push(NotificationData::PendingTransaction(
                     PendingTransactionNotification::Full(Box::new(tx.clone())),
                 ));
@@ -338,8 +339,9 @@ impl JsonRpcHandler {
                     }),
                 ));
 
-                // If pending block used, tx status notifications have already been sent.
-                // If we are here, pending block is not used and subscribers need to be notified.
+                // If pre-confirmed block used, tx status notifications have already been sent.
+                // If we are here, pre-confirmed block is not used and subscribers need to be
+                // notified.
                 let status = starknet
                     .get_transaction_execution_and_finality_status(*tx_hash)
                     .map_err(error::ApiError::StarknetDevnetError)?;

--- a/crates/starknet-devnet-server/src/api/json_rpc/origin_forwarder.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/origin_forwarder.rs
@@ -101,7 +101,8 @@ impl OriginForwarder {
             Ok(MaybePreConfirmedBlockWithTxHashes::PreConfirmedBlock(_)) => {
                 Err(ApiError::StarknetDevnetError(
                     starknet_core::error::Error::UnexpectedInternalError {
-                        msg: "Impossible: received pending block when querying by hash".to_string(),
+                        msg: "Impossible: received pre-confirmed block when querying by hash"
+                            .into(),
                     },
                 ))
             }

--- a/crates/starknet-devnet-types/src/rpc/block.rs
+++ b/crates/starknet-devnet-types/src/rpc/block.rs
@@ -68,7 +68,7 @@ pub enum BlockResult {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum BlockStatus {
-    /// Almost like pending.
+    /// Almost like pre-confirmed.
     PreConfirmed,
     /// A block that was created on L2.
     AcceptedOnL2,

--- a/tests/integration/common/background_devnet.rs
+++ b/tests/integration/common/background_devnet.rs
@@ -280,7 +280,7 @@ impl BackgroundDevnet {
     }
 
     /// Get balance at contract_address, as written in the ERC20 contract corresponding to `unit`
-    /// from pending state or latest state
+    /// from pre-confirmed state or latest state
     pub async fn get_balance_by_tag(
         &self,
         address: &Felt,
@@ -365,7 +365,7 @@ impl BackgroundDevnet {
         }
     }
 
-    pub async fn get_pending_block_with_tx_hashes(
+    pub async fn get_pre_confirmed_block_with_tx_hashes(
         &self,
     ) -> Result<PreConfirmedBlockWithTxHashes, anyhow::Error> {
         match self
@@ -385,7 +385,7 @@ impl BackgroundDevnet {
         }
     }
 
-    pub async fn get_pending_block_with_txs(
+    pub async fn get_pre_confirmed_block_with_txs(
         &self,
     ) -> Result<PreConfirmedBlockWithTxs, anyhow::Error> {
         match self.json_rpc_client.get_block_with_txs(BlockId::Tag(BlockTag::PreConfirmed)).await {

--- a/tests/integration/test_accepting_blocks_on_l1.rs
+++ b/tests/integration/test_accepting_blocks_on_l1.rs
@@ -188,7 +188,7 @@ async fn should_fail_if_accepting_pre_confirmed() {
     assert_eq!(latest_block.block_number, 0);
 
     // Assert pre_confirmed intact
-    let pre_confirmed_block = devnet.get_pending_block_with_tx_hashes().await.unwrap();
+    let pre_confirmed_block = devnet.get_pre_confirmed_block_with_tx_hashes().await.unwrap();
     assert_eq!(pre_confirmed_block.transactions, vec![tx_hash]);
 }
 

--- a/tests/integration/test_advancing_time.rs
+++ b/tests/integration/test_advancing_time.rs
@@ -323,7 +323,7 @@ async fn set_time_with_pre_confirmed_txs() {
     }
     sent_mint_txs.sort(); // sorting to allow equality assertion
 
-    let pre_confirmed_block = devnet.get_pending_block_with_tx_hashes().await.unwrap();
+    let pre_confirmed_block = devnet.get_pre_confirmed_block_with_tx_hashes().await.unwrap();
     let mut pre_confirmed_txs = pre_confirmed_block.transactions.clone();
     pre_confirmed_txs.sort();
     assert_eq!(pre_confirmed_txs, sent_mint_txs);
@@ -574,7 +574,7 @@ async fn correct_pending_block_timestamp() {
             .await
             .unwrap();
 
-    let block = devnet.get_pending_block_with_txs().await.unwrap();
+    let block = devnet.get_pre_confirmed_block_with_txs().await.unwrap();
     assert_eq!(block.timestamp, initial_time);
 }
 
@@ -586,13 +586,13 @@ async fn correct_pending_block_timestamp_after_setting() {
             .await
             .unwrap();
 
-    let block = devnet.get_pending_block_with_txs().await.unwrap();
+    let block = devnet.get_pre_confirmed_block_with_txs().await.unwrap();
     assert_eq!(block.timestamp, initial_time);
 
     sleep_until_new_timestamp().await;
     devnet.create_block().await.unwrap();
 
-    let block = devnet.get_pending_block_with_txs().await.unwrap();
+    let block = devnet.get_pre_confirmed_block_with_txs().await.unwrap();
     assert_gt_with_buffer(block.timestamp, initial_time);
 }
 

--- a/tests/integration/test_blocks_generation.rs
+++ b/tests/integration/test_blocks_generation.rs
@@ -59,7 +59,7 @@ async fn assert_latest_block_with_tx_hashes(
 }
 
 async fn assert_pending_block_with_tx_hashes(devnet: &BackgroundDevnet, tx_count: usize) {
-    let pending_block = devnet.get_pending_block_with_tx_hashes().await.unwrap();
+    let pending_block = devnet.get_pre_confirmed_block_with_tx_hashes().await.unwrap();
 
     assert_eq!(pending_block.transactions.len(), tx_count);
 
@@ -85,7 +85,7 @@ async fn assert_latest_block_with_txs(
 }
 
 async fn assert_pending_block_with_txs(devnet: &BackgroundDevnet, tx_count: usize) {
-    let pending_block = devnet.get_pending_block_with_txs().await.unwrap();
+    let pending_block = devnet.get_pre_confirmed_block_with_txs().await.unwrap();
 
     assert_eq!(pending_block.transactions.len(), tx_count);
 

--- a/tests/integration/test_gas_modification.rs
+++ b/tests/integration/test_gas_modification.rs
@@ -286,13 +286,13 @@ async fn set_gas_check_blocks() {
     let latest_block = devnet.get_latest_block_with_txs().await.unwrap();
     assert_eq!(latest_block.block_number, 0);
 
-    let pending_block = devnet.get_pending_block_with_tx_hashes().await.unwrap();
+    let pending_block = devnet.get_pre_confirmed_block_with_tx_hashes().await.unwrap();
     assert_eq!(pending_block.l1_gas_price, default_gas_price);
     assert_eq!(pending_block.l1_data_gas_price, default_gas_price);
 
     devnet.create_block().await.unwrap();
 
-    let pending_block = devnet.get_pending_block_with_tx_hashes().await.unwrap();
+    let pending_block = devnet.get_pre_confirmed_block_with_tx_hashes().await.unwrap();
     assert_eq!(pending_block.l1_gas_price, first_update_gas_price);
     assert_eq!(pending_block.l1_data_gas_price, first_update_data_gas_price);
 
@@ -327,7 +327,7 @@ async fn set_gas_check_blocks() {
     assert_eq!(latest_block.l1_data_gas_price, second_update_data_gas_price);
     assert_eq!(latest_block.l2_gas_price, second_update_l2_gas_price);
 
-    let pending_block = devnet.get_pending_block_with_tx_hashes().await.unwrap();
+    let pending_block = devnet.get_pre_confirmed_block_with_tx_hashes().await.unwrap();
     assert_eq!(pending_block.l1_gas_price, second_update_gas_price);
     assert_eq!(pending_block.l1_data_gas_price, second_update_data_gas_price);
     assert_eq!(pending_block.l2_gas_price, second_update_l2_gas_price);
@@ -375,7 +375,7 @@ async fn unsuccessful_declare_set_gas_successful_declare() {
     let latest_block = devnet.get_latest_block_with_txs().await.unwrap();
     assert_eq!(latest_block.block_number, 1);
 
-    let pending_block = devnet.get_pending_block_with_tx_hashes().await.unwrap();
+    let pending_block = devnet.get_pre_confirmed_block_with_tx_hashes().await.unwrap();
     assert_eq!(
         pending_block.l1_gas_price,
         ResourcePrice {

--- a/tests/integration/test_simulate_transactions.rs
+++ b/tests/integration/test_simulate_transactions.rs
@@ -461,8 +461,8 @@ async fn test_simulation_of_panicking_invoke() {
         starknet_rs_core::types::MaybePreConfirmedBlockWithTxHashes::Block(latest) => {
             latest.l2_gas_price.price_in_fri
         }
-        MaybePreConfirmedBlockWithTxHashes::PreConfirmedBlock(pending) => {
-            pending.l2_gas_price.price_in_fri
+        MaybePreConfirmedBlockWithTxHashes::PreConfirmedBlock(pre_confirmed) => {
+            pre_confirmed.l2_gas_price.price_in_fri
         }
     };
     let gas_price = u128::from_le_bytes(gas_price.to_bytes_le()[..16].try_into().unwrap());


### PR DESCRIPTION
## Usage related changes

N/A

## Development related changes

- Continuation of #802 
- Modify comments and variable names, keep intact the enums related to pending tx subscription

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated terminology throughout the application from "pending" to "pre-confirmed" for block tags, methods, variables, and documentation.
  * Renamed public methods and updated references in tests and comments to reflect the new "pre-confirmed" terminology.

* **Documentation**
  * Revised comments and error messages to use "pre-confirmed" instead of "pending" for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->