### PR TITLE
Expose default Devnet port in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,5 +21,7 @@ RUN apt-get -y update && \
 
 COPY --from=builder /target/release/starknet-devnet /usr/local/bin/starknet-devnet
 
+# The default port; exposing is beneficial if using Docker GUI
 EXPOSE 5050
+
 ENTRYPOINT [ "tini", "--", "starknet-devnet", "--host", "0.0.0.0" ]


### PR DESCRIPTION
## Usage related changes

- Expose docker port; good for Docker GUI users: prompts for port mapping on container start

## Development related changes

<!-- How these changes affect the developers of this project. E.g. changes in dev tools, testing, CI/CD... -->

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [ ] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] No spelling errors - `./scripts/check_spelling.sh`
- [ ] Performed code self-review
- [ ] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [ ] Updated the docs if needed - `./website/README.md`
- [ ] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container configuration to declare that port 5050 is exposed for network access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->