### PR TITLE
Remove non-RPC logic from docs and tests

### DIFF
--- a/contracts/l1-l2-messaging/README.md
+++ b/contracts/l1-l2-messaging/README.md
@@ -2,20 +2,24 @@
 
 This folder contains Cairo and Solidity contracts for Devnet development.
 If you wish to check specifically one of the two chains README, please refer to the corresponding README:
+
 1. `solidity` folder for Ethereum related contracts with the [README](./solidity/README.md).
 2. `cairo` folder for Starknet related contracts, and example of how to work with starknet without running an L1 node in the [README](./cairo/README.md).
 
 ## E2E testing with Anvil and Devnet
 
 ### Setup of the nodes
+
 You will need two terminals to run each node:
 
 First, please ensure that you have [anvil](https://book.getfoundry.sh/getting-started/installation) installed (or you can do the same with HardHat, but the commands here are done with anvil).
+
 ```bash
 anvil
 ```
 
 For Starknet, ensure you have Devnet compiled and running with the following params:
+
 ```bash
 # First, ensure you have compiled the artifacts required for abigen:
 cd contracts && bash generate_artifacts.sh
@@ -27,6 +31,7 @@ cargo run -- --seed 42
 Now both nodes are running, Devnet for Starknet and Anvil for Ethereum.
 
 Then, open a third terminal **in the same directory of this README**, from which we will operate on the running nodes:
+
 ```bash
 # This .env file combines variables for both chains.
 source ./.env
@@ -40,24 +45,34 @@ forge build --root ./solidity
 ```
 
 ### Ethereum setup
+
 1. Use Devnet postman endpoint to load the `MockStarknetMessaging` contract:
+
 ```bash
-curl -H 'Content-Type: application/json' \
-     -d '{"network_url": "http://127.0.0.1:8545"}' \
-     http://127.0.0.1:5050/postman/load_l1_messaging_contract
+curl http://127.0.0.1:5050/rpc --json '{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "method": "devnet_postmanLoad",
+  "params": {
+    "network_url": "http://localhost:8545"
+  }
+}'
 ```
+
 ```json
 {
-    "messaging_contract_address":"0x5fbdb2315678afecb367f032d93f642f64180aa3"
+  "messaging_contract_address": "0x5fbdb2315678afecb367f032d93f642f64180aa3"
 }
 ```
 
 2. Deploy the `L1L2.sol` contract in order to receive/send messages from/to L2.
+
 ```bash
 pushd ./solidity
 forge script ./script/L1L2.s.sol:Deploy --broadcast --rpc-url $ETH_RPC_URL
 popd
 ```
+
 ```
 ✅  [Success]Hash: 0x942cfaadc557f360b91e2bfe98e8246d87b8efb4bfe6c1803162cd4aa7a71e1d
 Contract Address: 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
@@ -66,15 +81,19 @@ Paid: 0.0013459867197597 ETH (346581 gas * 3.8836137 gwei)
 ```
 
 3. Check balance is 0 for user `0x1`:
+
 ```bash
 cast call 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512 "get_balance(uint256)(uint256)" 0x1
 ```
+
 ```bash
 0
 ```
 
 ### Starknet contracts and send message to L1
+
 1. On Devnet, we will declare and deploy the `cairo_l1_l2` contract to send-receive messages on the Starknet side:
+
 ```bash
 # Declare.
 starkli declare ./cairo/target/dev/cairo_l1_l2.contract_class.json
@@ -94,54 +113,70 @@ starkli invoke "$CONTRACT_L2" withdraw 0x1 0x1 0xe7f1725E7734CE288F8367e1Bb143E9
 # Here, you can still check on L1, the balance of the user 1 is still 0.
 
 # You can use the `dry run` version if you just want to check the messages before actually sending them.
-curl -H 'Content-Type: application/json' -d '{"dry_run": true}' http://127.0.0.1:5050/postman/flush
+curl http://127.0.0.1:5050 --json '{
+  "jsonrpc": "2.0",
+  "method": "devnet_postmanFlush",
+  "params": { "dry_run": true },
+  "id": 1
+}'
 ```
 ```json
 {
-    "messages_to_l1": [
-        {
-            "l2_contract_address":"0x34ba56f92265f0868c57d3fe72ecab144fc96f97954bbbc4252cef8e8a979ba",
-            "l1_contract_address":"0xe7f1725e7734ce288f8367e1bb143e90bb3f0512",
-            "payload":["0x0","0x1","0x1"]
-        }
-    ],
-    "messages_to_l2":[],
-    "generated_l2_transactions": [],
-    "l1_provider":"dry run"
+  "messages_to_l1": [
+    {
+      "l2_contract_address": "0x34ba56f92265f0868c57d3fe72ecab144fc96f97954bbbc4252cef8e8a979ba",
+      "l1_contract_address": "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512",
+      "payload": ["0x0", "0x1", "0x1"]
+    }
+  ],
+  "messages_to_l2": [],
+  "generated_l2_transactions": [],
+  "l1_provider": "dry run"
 }
 ```
+
 2. Actually flush the message to be sent on the L1 node.
+
 ```bash
 # Flushing the message to actually send them to the L1.
-curl -H 'Content-Type: application/json' -X POST http://127.0.0.1:5050/postman/flush
+curl http://127.0.0.1:5050/ --json '{
+  "jsonrpc": "2.0",
+  "method": "devnet_postmanFlush",
+  "params": {},
+  "id": 1
+}'
 ```
+
 ```json
 {
-    "messagesToL1": [
-        {
-            "l2_contract_address":"0x34ba56f92265f0868c57d3fe72ecab144fc96f97954bbbc4252cef8e8a979ba",
-            "l1_contract_address":"0xe7f1725e7734ce288f8367e1bb143e90bb3f0512",
-            "payload":["0x0","0x1","0x1"]
-        }
-    ],
-    "messages_to_l2":[],
-    "generated_l2_transactions": [],
-    "l1_provider":"http://127.0.0.1:8545/"
+  "messagesToL1": [
+    {
+      "l2_contract_address": "0x34ba56f92265f0868c57d3fe72ecab144fc96f97954bbbc4252cef8e8a979ba",
+      "l1_contract_address": "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512",
+      "payload": ["0x0", "0x1", "0x1"]
+    }
+  ],
+  "messages_to_l2": [],
+  "generated_l2_transactions": [],
+  "l1_provider": "http://127.0.0.1:8545/"
 }
 ```
 
 ### Ethereum receive message and send message to L2
+
 1. Now the message is received, we can consume it. You can try to run this command several times,
    you'll see the transaction reverting with `INVALID_MESSAGE_TO_CONSUME` once the message is consumed once. To consume the message, we have to provide its content (balance of 1 to user 1).
+
 ```bash
 cast send 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512 "withdraw(uint256, uint256, uint256)" \
      0x34ba56f92265f0868c57d3fe72ecab144fc96f97954bbbc4252cef8e8a979ba 0x1 0x1 \
      --rpc-url $ETH_RPC_URL --private-key $ACCOUNT_PRIVATE_KEY \
      --gas-limit 999999
-     
+
 # We can now check the balance of user 1 on L1, it's 1.
 cast call 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512 "get_balance(uint256)(uint256)" 0x1
 ```
+
 ```bash
 # output of send...
 
@@ -149,15 +184,17 @@ cast call 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512 "get_balance(uint256)(uint2
 ```
 
 2. Let's now send back the amount 1 we just received to the user 1 on L2. As we will send a message, we need to provide at least 30k WEI.
+
 ```bash
 cast send 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512 "deposit(uint256, uint256, uint256)" \
      "$CONTRACT_L2" 0x1 0x1 \
      --rpc-url $ETH_RPC_URL --private-key $ACCOUNT_PRIVATE_KEY \
      --gas-limit 999999 --value 1gwei
-     
+
 # The balance is now 0 for the user 1 on ethereum.
 cast call 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512 "get_balance(uint256)(uint256)" 0x1
 ```
+
 ```bash
 # output of send...
 
@@ -165,90 +202,128 @@ cast call 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512 "get_balance(uint256)(uint2
 ```
 
 3. Flush the messages.
+
 ```bash
-curl -H 'Content-Type: application/json' -X POST http://127.0.0.1:5050/postman/flush
-```
-```json
-{
-    "messagesToL1": [],
-    "messagesToL2": [
-        {
-            "l2_contract_address":"...",
-            "entry_point_selector":"0xc73f681176fc7b3f9693986fd7b14581e8d540519e27400e88b8713932be01",
-            "l1_contract_address":"0xe7f1725e7734ce288f8367e1bb143e90bb3f0512",
-            "payload":["0x1","0x1"],
-            "paid_fee_on_l1":"0x3b9aca00",
-            "nonce":"0x1"
-        }
-    ],
-    "generated_l2_transactions": ["0x75337b9eb7f731226ba4ddea7a9c5b2f984ee9546c0cbb5d1c04e69f5d62aac"],
-    "l1_provider":"http://127.0.0.1:8545/"
-}
-```
-We can now check the balance of user 1 on L2, it's back to `0xff`.
-```bash
-starkli call "$CONTRACT_L2" get_balance 0x1
-```
-```json
-[
-    "0x00000000000000000000000000000000000000000000000000000000000000ff"
-]
+curl http://127.0.0.1:5050/ --json '{
+  "jsonrpc": "2.0",
+  "method": "devnet_postmanFlush",
+  "params": {},
+  "id": 1
+}'
 ```
 
-###  Mocking messages without running L1 node
-1. Now, let's say we want to increase the balance of the user on L2 as if a message was sent from L1. Devnet has an endpoint `postman/send_message_to_l2` to mock a message coming from L1, without actually running an L1 node. Let's mock a message that sends the amount 2 to the user 1.
-```bash
-curl -H 'Content-Type: application/json' \
-    -d '{"paid_fee_on_l1": "0x123", "l2_contract_address": '"$CONTRACT_L2"', "l1_contract_address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512", "entry_point_selector": "0x00c73f681176fc7b3f9693986fd7b14581e8d540519e27400e88b8713932be01", "payload": ["0x1", "0x2"], "nonce": "0x1"}' \
-    http://127.0.0.1:5050/postman/send_message_to_l2
-```
 ```json
 {
-    "transaction_hash": "0x7f5c523f47bc88fa21f86ec4aaac8bbad69dafb43ae7072319dcec4d5d40af9"
+  "messagesToL1": [],
+  "messagesToL2": [
+    {
+      "l2_contract_address": "...",
+      "entry_point_selector": "0xc73f681176fc7b3f9693986fd7b14581e8d540519e27400e88b8713932be01",
+      "l1_contract_address": "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512",
+      "payload": ["0x1", "0x1"],
+      "paid_fee_on_l1": "0x3b9aca00",
+      "nonce": "0x1"
+    }
+  ],
+  "generated_l2_transactions": [
+    "0x75337b9eb7f731226ba4ddea7a9c5b2f984ee9546c0cbb5d1c04e69f5d62aac"
+  ],
+  "l1_provider": "http://127.0.0.1:8545/"
 }
 ```
-The balance is now increased by 2, exactly as a message from L1 would have done.
+
+We can now check the balance of user 1 on L2, it's back to `0xff`.
+
 ```bash
 starkli call "$CONTRACT_L2" get_balance 0x1
 ```
+
 ```json
-[
-    "0x0000000000000000000000000000000000000000000000000000000000000101"
-]
+["0x00000000000000000000000000000000000000000000000000000000000000ff"]
+```
+
+### Mocking messages without running L1 node
+
+1. Now, let's say we want to increase the balance of the user on L2 as if a message was sent from L1. Devnet has an endpoint `postman/send_message_to_l2` to mock a message coming from L1, without actually running an L1 node. Let's mock a message that sends the amount 2 to the user 1.
+
+```bash
+curl http://127.0.0.1:5050/ --json '{
+  "jsonrpc": "2.0",
+  "method": "devnet_postmanSendMessageToL2",
+  "params": {
+    "paid_fee_on_l1": "0x123",
+    "l2_contract_address": '"$CONTRACT_L2"',
+    "l1_contract_address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+    "entry_point_selector": "0x00c73f681176fc7b3f9693986fd7b14581e8d540519e27400e88b8713932be01",
+    "payload": ["0x1", "0x2"],
+    "nonce": "0x1"
+  },
+  "id": 1
+}'
+
+```json
+{
+  "transaction_hash": "0x7f5c523f47bc88fa21f86ec4aaac8bbad69dafb43ae7072319dcec4d5d40af9"
+}
+```
+
+The balance is now increased by 2, exactly as a message from L1 would have done.
+
+```bash
+starkli call "$CONTRACT_L2" get_balance 0x1
+```
+
+```json
+["0x0000000000000000000000000000000000000000000000000000000000000101"]
 ```
 
 2. Finally, to give an example of how to test a message sent by a Cairo contract without running the L1 node. Let's withdraw the amount 2 from the user 1.
+
 ```bash
 # Withdraw to have the Cairo contract creating the message.
 starkli invoke "$CONTRACT_L2" withdraw 0x1 0x2 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
 ```
+
 Now that the message has been created by the Cairo contract, instead of using `flush` to send the message to L1 node, we can consume it manually and verify that the message has been correctly created by the Cairo contract:
+
 ```bash
-curl -H 'Content-Type: application/json' \
-    -d '{"from_address": "0x34ba56f92265f0868c57d3fe72ecab144fc96f97954bbbc4252cef8e8a979ba", "to_address": "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512", "payload": ["0x0","0x1","0x2"]}' \
-    http://127.0.0.1:5050/postman/consume_message_from_l2
+curl http://127.0.0.1:5050/ --json '{
+  "jsonrpc": "2.0",
+  "method": "devnet_postmanConsumeMessageFromL2",
+  "params": {
+    "from_address": "0x34ba56f92265f0868c57d3fe72ecab144fc96f97954bbbc4252cef8e8a979ba",
+    "to_address": "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512",
+    "payload": ["0x0", "0x1", "0x2"]
+  },
+  "id": 1
+}'
+
 ```
+
 ```json
 {
-    "message_hash": "0x987b98434563ce4683f38c443d0c060492592960b525200ff7345d39c2f94fa2"
+  "message_hash": "0x987b98434563ce4683f38c443d0c060492592960b525200ff7345d39c2f94fa2"
 }
 ```
+
 You can try to run the command again, and you'll see an error saying that the message has been totally consumed.
 
 If we now check the balance of the user 1, it should be back to `0xff`.
+
 ```bash
 starkli call "$CONTRACT_L2" get_balance 0x1
 ```
+
 ```json
-[
-    "0x00000000000000000000000000000000000000000000000000000000000000ff"
-]
+["0x00000000000000000000000000000000000000000000000000000000000000ff"]
 ```
 
 ### Re-run with a script
 
 To quickly setup the nodes for testing and re-run this exact sequence after restarting your nodes, you can use the following bash script:
+
 ```bash
 bash run_e2e.sh
 ```
+
 It's important to note that those operations must be done in this exact order to ensure that hard-coded addresses used in this guide are still valid.

--- a/contracts/l1-l2-messaging/run_e2e.sh
+++ b/contracts/l1-l2-messaging/run_e2e.sh
@@ -13,9 +13,12 @@ forge install --root ./solidity
 forge build --root ./solidity
 
 # Deploy mock messaging contract on L1.
-curl --json \
-     -d '{"network_url": "http://127.0.0.1:8545"}' \
-     http://127.0.0.1:5050/postman/load_l1_messaging_contract
+curl http://127.0.0.1:5050/ --json '{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "devnet_postmanLoad",
+  "params": { "network_url": "http://127.0.0.1:8545" }
+}'
 
 # Deploy L1L2 contract on L1.
 pushd ./solidity

--- a/scripts/benchmark/mint_benchmark.sh
+++ b/scripts/benchmark/mint_benchmark.sh
@@ -5,8 +5,13 @@ set -eu
 N=$1
 
 for _ in $(seq 1 $N); do
-    curl -w "\n" -sSf -H "Content-Type: application/json" -d '{
-        "amount": 1,
-        "address": "0x1"
-    }' localhost:5050/mint
+    curl localhost:5050/ -w "\n" -sSf --json '{
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "devnet_mint",
+        "params": {
+            "amount": 1,
+            "address": "0x1"
+        }
+    }'
 done

--- a/tests/integration/common/reqwest_client.rs
+++ b/tests/integration/common/reqwest_client.rs
@@ -47,11 +47,6 @@ impl ReqwestClient {
             request_builder.json(&body).send().await.map_err(ReqwestError::Error)
         }
     }
-
-    pub async fn post_no_body(&self, path: &str) -> Result<reqwest::Response, ReqwestError> {
-        let url = format!("{}{}", self.url, path);
-        self.reqwest_client.post(&url).send().await.map_err(ReqwestError::Error)
-    }
 }
 
 #[async_trait::async_trait]

--- a/tests/integration/test_abort_blocks.rs
+++ b/tests/integration/test_abort_blocks.rs
@@ -4,7 +4,6 @@ use starknet_rs_providers::{Provider, ProviderError};
 
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::errors::RpcError;
-use crate::common::reqwest_client::PostReqwestSender;
 use crate::common::utils::{FeeUnit, assert_contains, to_hex_felt};
 
 static DUMMY_ADDRESS: u128 = 1;
@@ -328,29 +327,4 @@ async fn abort_pending_block() {
     let latest_balance =
         devnet.get_balance_latest(&Felt::from(DUMMY_ADDRESS), FeeUnit::Fri).await.unwrap();
     assert_eq!(latest_balance, DUMMY_AMOUNT.into());
-}
-
-#[tokio::test]
-async fn block_abortion_via_non_rpc() {
-    let devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .unwrap();
-
-    let created_block_hash = devnet.create_block().await.unwrap();
-
-    let last_block_before_abortion = devnet.get_latest_block_with_tx_hashes().await.unwrap();
-
-    let _: serde_json::Value = devnet
-        .reqwest_client()
-        .post_json_async(
-            "/abort_blocks",
-            json!({ "starting_block_id": { "block_hash": created_block_hash } }),
-        )
-        .await
-        .unwrap();
-
-    let last_block_after_abortion = devnet.get_latest_block_with_tx_hashes().await.unwrap();
-
-    assert_eq!(last_block_after_abortion.block_number, last_block_before_abortion.block_number - 1);
 }

--- a/tests/integration/test_blocks_generation.rs
+++ b/tests/integration/test_blocks_generation.rs
@@ -619,15 +619,3 @@ async fn get_data_by_specifying_latest_block_hash_and_number() {
         assert_eq!(storage, signer.get_public_key().await.unwrap().scalar());
     }
 }
-
-#[tokio::test]
-async fn block_generation_via_non_rpc() {
-    let devnet = BackgroundDevnet::spawn().await.unwrap();
-
-    let last_block_before = devnet.get_latest_block_with_tx_hashes().await.unwrap();
-
-    let _ = devnet.reqwest_client().post_no_body("/create_block").await.unwrap();
-
-    let last_block_after = devnet.get_latest_block_with_tx_hashes().await.unwrap();
-    assert_eq!(last_block_after.block_number, last_block_before.block_number + 1);
-}

--- a/tests/integration/test_dump_and_load.rs
+++ b/tests/integration/test_dump_and_load.rs
@@ -6,7 +6,6 @@ use starknet_rs_providers::Provider;
 
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants;
-use crate::common::reqwest_client::PostReqwestSender;
 use crate::common::utils::{FeeUnit, UniqueAutoDeletableFile, send_ctrl_c_signal_and_wait};
 
 static DUMMY_ADDRESS: u128 = 1;
@@ -485,71 +484,6 @@ async fn set_time_with_later_block_generation_dump_and_load() {
 
     assert_eq!(latest_block.block_number, 1);
     assert_eq!(latest_block.timestamp, past_time);
-}
-
-/// Ever since the introduction of non-rpc to rpc mapper, it is worth testing if non-rpc
-/// requests do what we want. Especially since the vast majority of our e2e tests
-/// rely on the JSON-RPC API.
-#[tokio::test]
-async fn test_dumping_of_non_rpc_requests() {
-    let devnet = BackgroundDevnet::spawn_with_additional_args(&[
-        "--dump-on",
-        "request",
-        "--state-archive-capacity",
-        "full",
-    ])
-    .await
-    .unwrap();
-
-    // mint, create block, abort block, create block
-    let address = Felt::ONE;
-    let mint_amount = 100;
-    let unit = FeeUnit::Wei;
-    let _: serde_json::Value = devnet
-        .reqwest_client()
-        .post_json_async(
-            "/mint",
-            json!({ "address": address, "amount": mint_amount, "unit": unit }),
-        )
-        .await
-        .unwrap();
-
-    let first_created_block: serde_json::Value =
-        devnet.reqwest_client().post_json_async("/create_block", json!({})).await.unwrap();
-
-    let second_created_block: serde_json::Value =
-        devnet.reqwest_client().post_json_async("/create_block", json!({})).await.unwrap();
-
-    let _: serde_json::Value = devnet
-        .reqwest_client()
-        .post_json_async(
-            "/abort_blocks",
-            json!({ "starting_block_id": { "block_hash": second_created_block["block_hash"] } }),
-        )
-        .await
-        .unwrap();
-
-    // dump and spawn a new devnet by loading
-    let dump_file = UniqueAutoDeletableFile::new("non-rpc-dump");
-    devnet.send_custom_rpc("devnet_dump", json!({ "path": dump_file.path })).await.unwrap();
-
-    let loaded_devnet = BackgroundDevnet::spawn_with_additional_args(&[
-        "--dump-path",
-        &dump_file.path,
-        "--state-archive-capacity",
-        "full",
-    ])
-    .await
-    .unwrap();
-
-    let loaded_balance = loaded_devnet.get_balance_latest(&address, unit).await.unwrap();
-    assert_eq!(loaded_balance, Felt::from(mint_amount));
-
-    let loaded_latest_block = loaded_devnet.get_latest_block_with_tx_hashes().await.unwrap();
-    assert_eq!(
-        loaded_latest_block.block_hash,
-        Felt::from_hex_unchecked(first_created_block["block_hash"].as_str().unwrap())
-    );
 }
 
 #[tokio::test]

--- a/tests/integration/test_minting.rs
+++ b/tests/integration/test_minting.rs
@@ -4,8 +4,8 @@ use starknet_rs_core::types::Felt;
 
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants::{PREDEPLOYED_ACCOUNT_ADDRESS, PREDEPLOYED_ACCOUNT_INITIAL_BALANCE};
-use crate::common::reqwest_client::{GetReqwestSender, HttpEmptyResponseBody, PostReqwestSender};
-use crate::common::utils::{FeeUnit, assert_contains};
+use crate::common::reqwest_client::{GetReqwestSender, HttpEmptyResponseBody};
+use crate::common::utils::FeeUnit;
 
 static DUMMY_ADDRESS: &str = "0x42";
 static DUMMY_AMOUNT: u128 = 42;
@@ -179,27 +179,4 @@ async fn reject_invalid_unit_when_querying() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
     reject_bad_balance_query(&devnet, "address=0x1&unit=INVALID").await;
     reject_bad_json_rpc_request(&devnet, json!({ "address": "0x1", "unit": "INVALID" })).await;
-}
-
-#[tokio::test]
-async fn minting_via_non_rpc() {
-    let devnet = BackgroundDevnet::spawn().await.unwrap();
-
-    let dummy_address = "0x1";
-
-    match devnet
-        .reqwest_client()
-        .post_json_async("/mint", json!({ "address": dummy_address, "invalid_param": 2 }))
-        .await
-        .map(|_: serde_json::Value| ())
-    {
-        Err(e) => assert_contains(&e.error_message(), "unknown field `invalid_param`"),
-        other => panic!("Invalid response: {other:?}"),
-    }
-
-    let _: serde_json::Value = devnet
-        .reqwest_client()
-        .post_json_async("/mint", json!({ "address": dummy_address, "amount": 1 }))
-        .await
-        .unwrap();
 }

--- a/tests/integration/test_restart.rs
+++ b/tests/integration/test_restart.rs
@@ -250,17 +250,3 @@ async fn assert_load_not_affecting_restart() {
 
     remove_file(dump_file_name);
 }
-
-#[tokio::test]
-async fn restarting_via_non_rpc() {
-    let devnet = BackgroundDevnet::spawn().await.unwrap();
-
-    let dummy_address = Felt::ONE;
-    let mint_amount = 100;
-    devnet.mint(dummy_address, mint_amount).await;
-
-    devnet.reqwest_client().post_no_body("/restart").await.unwrap();
-
-    let balance_after = devnet.get_balance_latest(&dummy_address, FeeUnit::Wei).await.unwrap();
-    assert_eq!(balance_after, Felt::ZERO);
-}

--- a/tests/integration/test_restrictive_mode.rs
+++ b/tests/integration/test_restrictive_mode.rs
@@ -2,7 +2,7 @@ use serde_json::json;
 
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::errors::RpcError;
-use crate::common::reqwest_client::{GetReqwestSender, HttpEmptyResponseBody, PostReqwestSender};
+use crate::common::reqwest_client::{GetReqwestSender, HttpEmptyResponseBody};
 
 #[tokio::test]
 async fn restrictive_mode_with_default_methods_doesnt_affect_other_functionality() {
@@ -23,13 +23,6 @@ async fn restrictive_mode_with_default_methods() {
     let devnet = BackgroundDevnet::spawn_with_additional_args(&["--restrictive-mode"])
         .await
         .expect("Could not start Devnet");
-    let http_err = devnet
-        .reqwest_client()
-        .post_json_async("/mint", json!({ "address": "0x1", "amount": 1 }))
-        .await
-        .map(|_: HttpEmptyResponseBody| ())
-        .unwrap_err();
-    assert_eq!(http_err.status(), reqwest::StatusCode::FORBIDDEN);
 
     let json_rpc_error = devnet
         .send_custom_rpc("devnet_mint", json!({ "address": "0x1", "amount": 1 }))
@@ -46,19 +39,11 @@ async fn restrictive_mode_with_default_methods() {
 async fn restrictive_mode_with_custom_methods() {
     let devnet = BackgroundDevnet::spawn_with_additional_args(&[
         "--restrictive-mode",
-        "/load",
+        "devnet_load",
         "devnet_mint",
     ])
     .await
     .expect("Could not start Devnet");
-    let err = devnet
-        .reqwest_client()
-        .post_json_async("/load", json!({ "path": "dummy_path" }))
-        .await
-        .map(|_: HttpEmptyResponseBody| ())
-        .unwrap_err();
-
-    assert_eq!(err.status(), reqwest::StatusCode::FORBIDDEN);
 
     let json_rpc_error = devnet
         .send_custom_rpc("devnet_mint", json!({ "address": "0x1", "amount": 1 }))

--- a/website/docs/balance.md
+++ b/website/docs/balance.md
@@ -27,7 +27,7 @@ JSON-RPC
 }
 ```
 
-Response:
+Result:
 
 ```
 {

--- a/website/docs/balance.md
+++ b/website/docs/balance.md
@@ -9,18 +9,9 @@ Separate tokens use separate ERC20 contracts for minting and charging fees. Thes
 
 ## Mint token - Local faucet
 
-By sending a `POST` request to `/mint` or `JSON-RPC` request with method name `devnet_mint` for a token, you initiate a transaction on that token's ERC20 contract. The response contains the hash of this transaction, as well as the new balance after minting. The token is specified by providing the unit, and defaults to `FRI` (the unit of `STRK`).
+By sending a `JSON-RPC` request with method name `devnet_mint` for a token, you initiate a transaction on that token's ERC20 contract. The response contains the hash of this transaction, as well as the new balance after minting. The token is specified by providing the unit, and defaults to `FRI` (the unit of `STRK`).
 
 The value of `amount` is in WEI or FRI. The precision is preserved if specifying an integer or a float whose fractional part is zero (e.g. `1000.0`, `1e21`). If the fractional part is non-zero, the amount is truncated to the nearest integer (e.g. `3.9` becomes `3` and `1.23e1` becomes `12`).
-
-```
-POST /mint
-{
-    "address": "0x6e3205f...",
-    "amount": 500000,
-    "unit": "WEI" | "FRI"
-}
-```
 
 ```
 JSON-RPC

--- a/website/docs/blocks.md
+++ b/website/docs/blocks.md
@@ -58,7 +58,7 @@ $ starknet-devnet --block-generation-on 10
 
 ## Request new block creation
 
-To request the creation of a new block, `POST` a request with no body to `/create_block` or send:
+To request the creation of a new block, send:
 
 ```
 JSON-RPC
@@ -115,14 +115,7 @@ If a socket has subscribed to transaction status changes of a transaction `tx1` 
 
 ### Request and response
 
-To abort, send one of the following:
-
-```
-POST /abort_blocks
-{
-    "starting_block_id": BLOCK_ID
-}
-```
+To abort, send:
 
 ```
 JSON-RPC

--- a/website/docs/dump-load-restart.md
+++ b/website/docs/dump-load-restart.md
@@ -86,7 +86,7 @@ If you dumped a Devnet utilizing one class for account predeployment (e.g. `--ac
 
 ## Restarting
 
-Devnet can be restarted by making a `JSON-RPC` request with method name `devnet_restart`. All of the deployed contracts (including predeployed), blocks and storage updates will be restarted to the original state, without the transactions and requests that may have been loaded from a dump file on startup. Websocket subscriptions will also be forgotten.
+Devnet can be restarted by making a `JSON-RPC` request with method name `devnet_restart`. All deployed contracts (including predeployed), blocks and storage updates will be restarted to the original state, without the transactions and requests that may have been loaded from a dump file on startup. Websocket subscriptions will also be forgotten.
 
 ### Restarting and L1-L2 messaging
 

--- a/website/docs/dump-load-restart.md
+++ b/website/docs/dump-load-restart.md
@@ -20,17 +20,13 @@ $ starknet-devnet --dump-on block --dump-path <PATH>
 
 ### Dumping on request
 
-You can request dumping by sending `POST` to `/dump` or via JSON-RPC. An optional file path can be provided in the request or on startup via `--dump-path <FILE>` (the HTTP request parameter takes precedence). If no dumping path is specified, the dump is included in the response body. This means that if you request dumping via [`curl`](https://curl.se/), it will be printed to STDOUT, which you can then redirect to a destination of your choice.
+You can request dumping via JSON-RPC. An optional file path can be provided in the request or on startup via `--dump-path <FILE>` (the HTTP request parameter takes precedence). If no dumping path is specified, the dump is included in the response body. This means that if you request dumping via [`curl`](https://curl.se/), it will be printed to STDOUT, which you can then redirect to a destination of your choice.
 
 ```
 $ starknet-devnet --dump-on <MODE> [--dump-path <FILE>]
 ```
 
 - No body parameters:
-
-```
-POST /dump
-```
 
 ```
 JSON-RPC
@@ -42,14 +38,6 @@ JSON-RPC
 ```
 
 - With a custom path:
-
-```
-POST /dump
-{
-  // optional; defaults to the path specified via CLI if defined
-  "path": <PATH>
-}
-```
 
 ```
 JSON-RPC
@@ -74,12 +62,7 @@ To load a preserved Devnet instance, the options are:
 $ starknet-devnet --dump-path <PATH>
 ```
 
-- Loading on request, which replaces the current state with the one in the provided file. It can be done by sending `POST` to `/load` or via JSON-RPC:
-
-```
-POST /load
-{ "path": <PATH> }
-```
+- Loading on request, which replaces the current state with the one in the provided file. It can be done via JSON-RPC:
 
 ```
 JSON-RPC
@@ -103,7 +86,7 @@ If you dumped a Devnet utilizing one class for account predeployment (e.g. `--ac
 
 ## Restarting
 
-Devnet can be restarted by making a `POST /restart` request (no body required) or `JSON-RPC` request with method name `devnet_restart`. All of the deployed contracts (including predeployed), blocks and storage updates will be restarted to the original state, without the transactions and requests that may have been loaded from a dump file on startup. Websocket subscriptions will also be forgotten.
+Devnet can be restarted by making a `JSON-RPC` request with method name `devnet_restart`. All of the deployed contracts (including predeployed), blocks and storage updates will be restarted to the original state, without the transactions and requests that may have been loaded from a dump file on startup. Websocket subscriptions will also be forgotten.
 
 ### Restarting and L1-L2 messaging
 

--- a/website/docs/postman.md
+++ b/website/docs/postman.md
@@ -154,7 +154,7 @@ JSON-RPC
 }
 ```
 
-Response:
+Result:
 
 ```js
 { "transaction_hash": "0x0548c761a9fd5512782998b2da6f44c42bf78fb88c3794eea330a91c9abb10bb" }
@@ -186,7 +186,7 @@ JSON-RPC
 }
 ```
 
-Response:
+Result:
 
 ```js
 {"message_hash": "0xae14f241131b524ac8d043d9cb4934253ac5c5589afef19f0d761816a9c7e26d"}

--- a/website/docs/postman.md
+++ b/website/docs/postman.md
@@ -16,18 +16,6 @@ You can use [**`starknet-devnet-js`**](https://github.com/0xSpaceShard/starknet-
 
 ## Load
 
-```
-POST /postman/load_l1_messaging_contract
-```
-
-```json
-{
-  "network_url": "http://localhost:8545",
-  "messaging_contract_address": "0x123...def", // optional
-  "deployer_account_private_key": "0xe2ac...583f" // optional
-}
-```
-
 ```json
 // JSON-RPC
 {
@@ -82,10 +70,6 @@ Loading a messaging contract is a dumpable event, meaning that, if you've enable
 ## Flush
 
 ```
-POST /postman/flush
-```
-
-```
 JSON-RPC
 {
     "jsonrpc": "2.0",
@@ -97,22 +81,12 @@ JSON-RPC
 Goes through the newly enqueued messages since the last flush, consuming and sending them from L1 to L2 and from L2 to L1. Use it for end-to-end testing. Requires no body. Optionally, set the `dry_run` boolean flag to just see the result of flushing, without actually triggering it:
 
 ```
-POST /postman/flush
-```
-
-```js
-{ "dry_run": true }
-```
-
-```
 JSON-RPC
 {
     "jsonrpc": "2.0",
     "id": "1",
     "method": "devnet_postmanFlush",
-    "params": {
-      "dry_run": true
-    }
+    "params": { "dry_run": true }
 }
 ```
 
@@ -163,24 +137,6 @@ Sends a mock transactions to L2, as if coming from L1, without the need for runn
 In regular (non-mocking) L1-L2 interaction, `nonce` is determined by the L1 Starknet contract. In this mock case, it is up to the developer to set it.
 
 ```
-POST /postman/send_message_to_l2
-```
-
-Request:
-
-```js
-{
-    "l2_contract_address": "0x00285ddb7e5c777b310d806b9b2a0f7c7ba0a41f12b420219209d97a3b7f25b2",
-    "entry_point_selector": "0xC73F681176FC7B3F9693986FD7B14581E8D540519E27400E88B8713932BE01",
-    "l1_contract_address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
-    "payload": [ "0x1", "0x2" ],
-    "paid_fee_on_l1": "0x123456abcdef",
-    "nonce": "0x0",
-    "l1_transaction_hash": "0x000abc123", // optional
-}
-```
-
-```
 JSON-RPC
 {
     "jsonrpc": "2.0",
@@ -215,20 +171,6 @@ It is a mock message, but only in the sense that you are mocking an L2 contract'
 A running L1 node is required for this operation.
 
 :::
-
-```
-POST /postman/consume_message_from_l2
-```
-
-Request:
-
-```js
-{
-    "from_address": "0x00285ddb7e5c777b310d806b9b2a0f7c7ba0a41f12b420219209d97a3b7f25b2",
-    "to_address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
-    "payload": ["0x0", "0x1", "0x3e8"],
-}
-```
 
 ```
 JSON-RPC

--- a/website/docs/starknet-time.md
+++ b/website/docs/starknet-time.md
@@ -1,19 +1,12 @@
 # Starknet time
 
-Block and state timestamp can be manipulated by setting the exact time or setting the time offset. By default, timestamp methods `/set_time`, `/increase_time` and `JSON-RPC` methods `devnet_setTime`, `devnet_increaseTime` generate a new block. This can be changed for `/set_time` (`devnet_setTime`) by setting the optional parameter `generate_block` to `false`. This skips immediate new block generation, but will use the specified timestamp whenever the next block is supposed to be generated.
+Block and state timestamp can be manipulated by setting the exact time or setting the time offset. By default, timestamp methods `devnet_setTime` and `devnet_increaseTime` of JSON-RPC API generate a new block. This can be changed for `devnet_setTime` by setting the optional parameter `generate_block` to `false`. This skips immediate new block generation, but will use the specified timestamp whenever the next block is supposed to be generated.
 
 All values should be set in [Unix time seconds](https://en.wikipedia.org/wiki/Unix_time). After [startup](#start-time), the time progresses naturally.
 
 ## Set time
 
 The following sets the exact time and generates a new block:
-
-```
-POST /set_time
-{
-    "time": TIME_IN_SECONDS
-}
-```
 
 ```
 JSON-RPC
@@ -28,14 +21,6 @@ JSON-RPC
 ```
 
 The following doesn't generate a new block, but sets the exact time for the next generated block:
-
-```
-POST /set_time
-{
-    "time": TIME_IN_SECONDS,
-    "generate_block": false
-}
-```
 
 ```
 JSON-RPC
@@ -55,13 +40,6 @@ Warning: block time can be set in the past which might lead to unexpected behavi
 ## Increase time
 
 Increases the block timestamp by the provided amount and generates a new block. All subsequent blocks will keep this increment.
-
-```
-POST /increase_time
-{
-    "time": TIME_IN_SECONDS
-}
-```
 
 ```
 JSON-RPC


### PR DESCRIPTION
## Usage related changes

- Close #809

## Development related changes

- Remove non-rpc logic from tests.

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all user and developer documentation to exclusively describe JSON-RPC methods, removing references and examples for legacy HTTP POST endpoints.
  * Improved formatting and consistency of JSON-RPC request and response examples across guides.
* **Chores**
  * Modernized internal scripts to use JSON-RPC requests instead of REST-style HTTP endpoints.
* **Tests**
  * Removed integration tests and utilities related to non-JSON-RPC (legacy HTTP POST) endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->