### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/contracts/l1-l2-messaging/solidity/.github/workflows/test.yml
+++ b/contracts/l1-l2-messaging/solidity/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0