### PR TITLE
Custom assertion methods return Result

### DIFF
--- a/tests/integration/common/assertions.rs
+++ b/tests/integration/common/assertions.rs
@@ -1,0 +1,185 @@
+/// Asserts that a boolean expression is `true` at runtime, propagating an `Err` if it's false.
+#[macro_export]
+macro_rules! assert_prop {
+    ($cond:expr) => {
+        if $cond {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "Assertion failed: {}",
+                stringify!($cond)
+            ))
+        }
+    };
+    ($cond:expr, $($arg:tt)+) => {
+        if $cond {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "Assertion failed: {}: {}",
+                stringify!($cond),
+                format!($($arg)+)
+            ))
+        }
+    };
+}
+
+/// Asserts that two expressions are equal to each other, propagating an `Err` if they are not.
+#[macro_export]
+macro_rules! assert_eq_prop {
+    ($left:expr, $right:expr) => {
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if *left_val == *right_val {
+                    Ok(())
+                } else {
+                    Err(anyhow::anyhow!(
+                        "Assertion failed: `(left == right)`
+  left: `{:?}`,
+ right: `{:?}`",
+                        left_val,
+                        right_val
+                    ))
+                }
+            }
+        }
+    };
+    ($left:expr, $right:expr, $($arg:tt)+) => {
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if *left_val == *right_val {
+                    Ok(())
+                } else {
+                    Err(anyhow::anyhow!(
+                        "Assertion failed: `(left == right)`: {}
+  left: `{:?}`,
+ right: `{:?}`",
+                        format!($($arg)+),
+                        left_val,
+                        right_val
+                    ))
+                }
+            }
+        }
+    };
+}
+
+/// Asserts that two expressions are not equal to each other, propagating an `Err` if they are.
+#[macro_export]
+macro_rules! assert_ne_prop {
+    ($left:expr, $right:expr) => {
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if *left_val != *right_val {
+                    Ok(())
+                } else {
+                    Err(anyhow::anyhow!(
+                        "Assertion failed: `(left != right)`
+  left: `{:?}`,
+ right: `{:?}`",
+                        left_val,
+                        right_val
+                    ))
+                }
+            }
+        }
+    };
+    ($left:expr, $right:expr, $($arg:tt)+) => {
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if *left_val != *right_val {
+                    Ok(())
+                } else {
+                    Err(anyhow::anyhow!(
+                        "Assertion failed: `(left != right)`: {}
+  left: `{:?}`,
+ right: `{:?}`",
+                        format!($($arg)+),
+                        left_val,
+                        right_val
+                    ))
+                }
+            }
+        }
+    };
+}
+
+/// Asserts that an expression is greater than or equal to the other, propagating an `Err` if they are not.
+#[macro_export]
+macro_rules! assert_gte_prop {
+    ($left:expr, $right:expr) => {
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if *left_val >= *right_val {
+                    Ok(())
+                } else {
+                    Err(anyhow::anyhow!(
+                        "Assertion failed: `(left >= right)`
+  left: `{:?}`,
+ right: `{:?}`",
+                        left_val,
+                        right_val
+                    ))
+                }
+            }
+        }
+    };
+    ($left:expr, $right:expr, $($arg:tt)+) => {
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if *left_val >= *right_val {
+                    Ok(())
+                } else {
+                    Err(anyhow::anyhow!(
+                        "Assertion failed: `(left >= right)`: {}
+  left: `{:?}`,
+ right: `{:?}`",
+                        format!($($arg)+),
+                        left_val,
+                        right_val
+                    ))
+                }
+            }
+        }
+    };
+}
+
+/// Asserts that an expression is less than or equal to the other, propagating an `Err` if they are not.
+#[macro_export]
+macro_rules! assert_lte_prop {
+    ($left:expr, $right:expr) => {
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if *left_val <= *right_val {
+                    Ok(())
+                } else {
+                    Err(anyhow::anyhow!(
+                        "Assertion failed: `(left <= right)`
+  left: `{:?}`,
+ right: `{:?}`",
+                        left_val,
+                        right_val
+                    ))
+                }
+            }
+        }
+    };
+    ($left:expr, $right:expr, $($arg:tt)+) => {
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if *left_val <= *right_val {
+                    Ok(())
+                } else {
+                    Err(anyhow::anyhow!(
+                        "Assertion failed: `(left <= right)`: {}
+  left: `{:?}`,
+ right: `{:?}`",
+                        format!($($arg)+),
+                        left_val,
+                        right_val
+                    ))
+                }
+            }
+        }
+    };
+}

--- a/tests/integration/common/errors.rs
+++ b/tests/integration/common/errors.rs
@@ -54,3 +54,5 @@ impl fmt::Display for RpcError {
         write!(f, "{self:?}")
     }
 }
+
+impl std::error::Error for RpcError {}

--- a/tests/integration/common/mod.rs
+++ b/tests/integration/common/mod.rs
@@ -1,4 +1,7 @@
 #![cfg(test)]
+
+#[macro_use]
+pub mod assertions;
 pub mod background_anvil;
 pub mod background_devnet;
 mod background_server;

--- a/tests/integration/common/utils.rs
+++ b/tests/integration/common/utils.rs
@@ -513,10 +513,12 @@ pub fn extract_message_error(error: &ContractExecutionError) -> Result<&String, 
 }
 
 /// Extract the error that is nested inside the provided `error`.
-pub fn extract_nested_error(error: &ContractExecutionError) -> &InnerContractExecutionError {
+pub fn extract_nested_error(
+    error: &ContractExecutionError,
+) -> Result<&InnerContractExecutionError, anyhow::Error> {
     match error {
-        ContractExecutionError::Nested(nested) => nested,
-        other => panic!("Unexpected error: {other:?}"),
+        ContractExecutionError::Nested(nested) => Ok(nested),
+        other => anyhow::bail!("Unexpected error: {other:?}"),
     }
 }
 

--- a/tests/integration/common/utils.rs
+++ b/tests/integration/common/utils.rs
@@ -505,10 +505,10 @@ pub fn assert_json_rpc_errors_equal(e1: JsonRpcError, e2: JsonRpcError) {
 }
 
 /// Extract the message that is encapsulated inside the provided error.
-pub fn extract_message_error(error: &ContractExecutionError) -> &String {
+pub fn extract_message_error(error: &ContractExecutionError) -> Result<&String, anyhow::Error> {
     match error {
-        ContractExecutionError::Message(msg) => msg,
-        other => panic!("Unexpected error: {other:?}"),
+        ContractExecutionError::Message(msg) => Ok(msg),
+        other => anyhow::bail!("Unexpected error: {other:?}"),
     }
 }
 

--- a/tests/integration/common/utils.rs
+++ b/tests/integration/common/utils.rs
@@ -110,12 +110,12 @@ pub async fn assert_tx_succeeded_accepted<T: Provider>(
 
     match receipt.execution_result() {
         ExecutionResult::Succeeded => (),
-        other => anyhow::bail!("Should have succeeded; got: {other:?}"),
+        other => anyhow::bail!("Tx {tx_hash:#x} should have succeeded; got: {other:?}"),
     }
 
     match receipt.finality_status() {
         starknet_rs_core::types::TransactionFinalityStatus::AcceptedOnL2 => Ok(()),
-        other => anyhow::bail!("Should have been accepted on L2; got: {other:?}"),
+        other => anyhow::bail!("Tx {tx_hash:#x} should have been accepted on L2; got: {other:?}"),
     }
 }
 
@@ -435,7 +435,7 @@ pub async fn deploy_argent_account(
 
     let account_address = deployment.address();
     devnet.mint(account_address, u128::MAX).await;
-    let deployment_result = deployment.send().await.map_err(|e| anyhow::anyhow!("{e:?}"))?;
+    let deployment_result = deployment.send().await?;
 
     Ok((deployment_result, signer))
 }

--- a/tests/integration/common/utils.rs
+++ b/tests/integration/common/utils.rs
@@ -609,11 +609,16 @@ pub async fn receive_notification(
     Ok(notification["params"]["result"].take())
 }
 
-pub async fn assert_no_notifications(ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>) {
+pub async fn assert_no_notifications(
+    ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
+) -> Result<(), anyhow::Error> {
     match receive_rpc_via_ws(ws).await {
-        Ok(resp) => panic!("Expected no notifications; found: {resp}"),
-        Err(e) if e.to_string().contains("deadline has elapsed") => { /* expected */ }
-        Err(e) => panic!("Expected to error out due to empty channel; found: {e}"),
+        Ok(resp) => anyhow::bail!("Expected no notifications; found: {resp}"),
+        Err(e) if e.to_string().contains("deadline has elapsed") => {
+            /* expected */
+            Ok(())
+        }
+        Err(e) => anyhow::bail!("Expected to error out due to empty channel; found: {e}"),
     }
 }
 

--- a/tests/integration/common/utils.rs
+++ b/tests/integration/common/utils.rs
@@ -136,7 +136,10 @@ pub async fn assert_tx_succeeded_pre_confirmed<T: Provider>(_tx_hash: &Felt, _cl
     // }
 }
 
-pub async fn get_contract_balance(devnet: &BackgroundDevnet, contract_address: Felt) -> Felt {
+pub async fn get_contract_balance(
+    devnet: &BackgroundDevnet,
+    contract_address: Felt,
+) -> Result<Felt, anyhow::Error> {
     get_contract_balance_by_block_id(devnet, contract_address, BlockId::Tag(BlockTag::Latest)).await
 }
 
@@ -144,7 +147,7 @@ pub async fn get_contract_balance_by_block_id(
     devnet: &BackgroundDevnet,
     contract_address: Felt,
     block_id: BlockId,
-) -> Felt {
+) -> Result<Felt, anyhow::Error> {
     let contract_call = FunctionCall {
         contract_address,
         entry_point_selector: get_selector_from_name("get_balance").unwrap(),
@@ -153,9 +156,9 @@ pub async fn get_contract_balance_by_block_id(
     match devnet.json_rpc_client.call(contract_call, block_id).await {
         Ok(res) => {
             assert_eq!(res.len(), 1);
-            res[0]
+            Ok(res[0])
         }
-        Err(e) => panic!("Call failed: {e}"),
+        Err(e) => anyhow::bail!("Call failed: {e}"),
     }
 }
 

--- a/tests/integration/common/utils.rs
+++ b/tests/integration/common/utils.rs
@@ -168,7 +168,7 @@ pub async fn assert_tx_reverted<T: Provider>(
     match receipt.execution_result() {
         ExecutionResult::Reverted { reason } => {
             for expected_reason in expected_failure_reasons {
-                assert_contains(reason, expected_reason);
+                assert_contains(reason, expected_reason).unwrap();
             }
         }
         other => panic!("Should have reverted; got: {other:?}; receipt: {receipt:?}"),
@@ -679,15 +679,16 @@ impl From<FeeEstimate> for LocalFee {
 }
 
 /// Panics if `text` does not contain `pattern`
-pub fn assert_contains(text: &str, pattern: &str) {
+pub fn assert_contains(text: &str, pattern: &str) -> Result<(), anyhow::Error> {
     if !text.contains(pattern) {
-        panic!(
+        anyhow::bail!(
             "Failed content assertion!
     Pattern: '{pattern}'
     not present in
     Text: '{text}'"
         );
     }
+    Ok(())
 }
 
 /// Set time and generate a new block

--- a/tests/integration/common/utils.rs
+++ b/tests/integration/common/utils.rs
@@ -451,14 +451,22 @@ pub async fn deploy_argent_account(
 
 /// Assert that the set of elements of `iterable1` is a subset of the elements of `iterable2` and
 /// vice versa.
-pub fn assert_equal_elements<T>(iterable1: &[T], iterable2: &[T])
+pub fn assert_equal_elements<T>(iterable1: &[T], iterable2: &[T]) -> Result<(), anyhow::Error>
 where
     T: PartialEq,
 {
     assert_eq!(iterable1.len(), iterable2.len());
-    for e in iterable1 {
-        assert!(iterable2.contains(e));
+    match iterable1.len() == iterable2.len() {
+        true => (),
+        false => return Err(anyhow::anyhow!("Length mismatch")),
     }
+    for e in iterable1 {
+        match iterable2.contains(e) {
+            true => (),
+            false => return Err(anyhow::anyhow!("Element mismatch")),
+        }
+    }
+    Ok(())
 }
 
 pub fn felt_to_u256(f: Felt) -> U256 {

--- a/tests/integration/general_rpc_tests.rs
+++ b/tests/integration/general_rpc_tests.rs
@@ -88,7 +88,8 @@ async fn storage_proof_request_should_always_return_error() {
         Err(e) => assert_json_rpc_errors_equal(
             extract_json_rpc_error(e).unwrap(),
             JsonRpcError { code: 42, message: devnet_storage_proof_msg.into(), data: None },
-        ),
+        )
+        .unwrap(),
         other => panic!("Unexpected result: {other:?}"),
     }
 }

--- a/tests/integration/get_transaction_by_hash.rs
+++ b/tests/integration/get_transaction_by_hash.rs
@@ -38,7 +38,12 @@ async fn get_declare_v3_transaction_by_hash_happy_path() {
         .await
         .unwrap();
 
-    assert_tx_succeeded_accepted(&declare_result.transaction_hash, &devnet.json_rpc_client).await;
+    match assert_tx_succeeded_accepted(&declare_result.transaction_hash, &devnet.json_rpc_client)
+        .await
+    {
+        Ok(()) => (),
+        Err(err) => panic!("Transaction failed: {}", err),
+    };
 }
 
 #[tokio::test]
@@ -66,8 +71,15 @@ async fn get_deploy_account_transaction_by_hash_happy_path() {
     devnet.mint(deployment_address, mint_amount).await;
 
     let deploy_account_result = deployment.send().await.unwrap();
-    assert_tx_succeeded_accepted(&deploy_account_result.transaction_hash, &devnet.json_rpc_client)
-        .await;
+    match assert_tx_succeeded_accepted(
+        &deploy_account_result.transaction_hash,
+        &devnet.json_rpc_client,
+    )
+    .await
+    {
+        Ok(()) => (),
+        Err(err) => panic!("Transaction failed: {}", err),
+    };
 }
 
 #[tokio::test]
@@ -97,7 +109,12 @@ async fn get_invoke_v3_transaction_by_hash_happy_path() {
         .await
         .unwrap();
 
-    assert_tx_succeeded_accepted(&invoke_tx_result.transaction_hash, &devnet.json_rpc_client).await;
+    match assert_tx_succeeded_accepted(&invoke_tx_result.transaction_hash, &devnet.json_rpc_client)
+        .await
+    {
+        Ok(()) => (),
+        Err(err) => panic!("Transaction failed: {}", err),
+    };
 }
 
 #[tokio::test]

--- a/tests/integration/get_transaction_by_hash.rs
+++ b/tests/integration/get_transaction_by_hash.rs
@@ -38,12 +38,9 @@ async fn get_declare_v3_transaction_by_hash_happy_path() {
         .await
         .unwrap();
 
-    match assert_tx_succeeded_accepted(&declare_result.transaction_hash, &devnet.json_rpc_client)
+    assert_tx_succeeded_accepted(&declare_result.transaction_hash, &devnet.json_rpc_client)
         .await
-    {
-        Ok(()) => (),
-        Err(err) => panic!("Transaction failed: {}", err),
-    };
+        .unwrap();
 }
 
 #[tokio::test]
@@ -71,15 +68,9 @@ async fn get_deploy_account_transaction_by_hash_happy_path() {
     devnet.mint(deployment_address, mint_amount).await;
 
     let deploy_account_result = deployment.send().await.unwrap();
-    match assert_tx_succeeded_accepted(
-        &deploy_account_result.transaction_hash,
-        &devnet.json_rpc_client,
-    )
-    .await
-    {
-        Ok(()) => (),
-        Err(err) => panic!("Transaction failed: {}", err),
-    };
+    assert_tx_succeeded_accepted(&deploy_account_result.transaction_hash, &devnet.json_rpc_client)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -109,12 +100,9 @@ async fn get_invoke_v3_transaction_by_hash_happy_path() {
         .await
         .unwrap();
 
-    match assert_tx_succeeded_accepted(&invoke_tx_result.transaction_hash, &devnet.json_rpc_client)
+    assert_tx_succeeded_accepted(&invoke_tx_result.transaction_hash, &devnet.json_rpc_client)
         .await
-    {
-        Ok(()) => (),
-        Err(err) => panic!("Transaction failed: {}", err),
-    };
+        .unwrap();
 }
 
 #[tokio::test]

--- a/tests/integration/get_transaction_receipt_by_hash.rs
+++ b/tests/integration/get_transaction_receipt_by_hash.rs
@@ -242,7 +242,7 @@ async fn reverted_invoke_transaction_receipt() {
         TransactionReceipt::Invoke(receipt) => {
             match receipt.execution_result {
                 starknet_rs_core::types::ExecutionResult::Reverted { reason } => {
-                    assert_contains(&reason, "Insufficient max L2Gas");
+                    assert_contains(&reason, "Insufficient max L2Gas").unwrap();
                 }
                 _ => panic!("Invalid receipt {:?}", receipt),
             }

--- a/tests/integration/test_abort_blocks.rs
+++ b/tests/integration/test_abort_blocks.rs
@@ -18,7 +18,7 @@ async fn abort_blocks_error(
         .send_custom_rpc("devnet_abortBlocks", json!({ "starting_block_id" : starting_block_id }))
         .await
         .unwrap_err();
-    assert_contains(&aborted_blocks_error.message, expected_message_substring);
+    assert_contains(&aborted_blocks_error.message, expected_message_substring).unwrap();
 }
 
 async fn assert_block_aborted(devnet: &BackgroundDevnet, block_hash: &Felt) {

--- a/tests/integration/test_abort_blocks.rs
+++ b/tests/integration/test_abort_blocks.rs
@@ -33,7 +33,11 @@ async fn assert_block_aborted(
         .await
         .unwrap_err();
 
-    anyhow::ensure!(err == RpcError { code: 24, message: "Block not found".into(), data: None });
+    let expected_error = RpcError { code: 24, message: "Block not found".into(), data: None };
+    anyhow::ensure!(
+        err == expected_error,
+        format!("assertion `left == right` failed, left: {err}, right: {expected_error}")
+    );
     Ok(())
 }
 

--- a/tests/integration/test_abort_blocks.rs
+++ b/tests/integration/test_abort_blocks.rs
@@ -2,6 +2,7 @@ use serde_json::json;
 use starknet_rs_core::types::{BlockId, BlockTag, Felt, StarknetError};
 use starknet_rs_providers::{Provider, ProviderError};
 
+use crate::assert_eq_prop;
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::errors::RpcError;
 use crate::common::utils::{FeeUnit, assert_contains, to_hex_felt};
@@ -33,11 +34,7 @@ async fn assert_block_aborted(
         .await
         .unwrap_err();
 
-    let expected_error = RpcError { code: 24, message: "Block not found".into(), data: None };
-    anyhow::ensure!(
-        err == expected_error,
-        format!("assertion `left == right` failed, left: {err}, right: {expected_error}")
-    );
+    assert_eq_prop!(err, RpcError { code: 24, message: "Block not found".into(), data: None })?;
     Ok(())
 }
 

--- a/tests/integration/test_account_impersonation.rs
+++ b/tests/integration/test_account_impersonation.rs
@@ -199,7 +199,7 @@ async fn test_simulate_transaction() {
             account.execute_v3(invoke_calls.clone()).simulate(!do_validate, true).await;
         if let Some(error_msg) = expected_error_message {
             let simulation_err = simulation_result.expect_err("Expected simulation to fail");
-            assert_contains(&format!("{:?}", simulation_err).to_lowercase(), error_msg);
+            assert_contains(&format!("{:?}", simulation_err).to_lowercase(), error_msg).unwrap();
         } else {
             simulation_result.expect("Expected simulation to succeed");
         }
@@ -268,5 +268,5 @@ async fn test_invoke_transaction(
 
 fn assert_anyhow_error_contains_message(error: anyhow::Error, message: &str) {
     let error_string = format!("{:?}", error.root_cause()).to_lowercase();
-    assert_contains(&error_string, message);
+    assert_contains(&error_string, message).unwrap();
 }

--- a/tests/integration/test_account_selection.rs
+++ b/tests/integration/test_account_selection.rs
@@ -149,15 +149,9 @@ async fn can_deploy_new_argent_account_from_predeclared_class() {
 
     let account_hash = Felt::from_hex_unchecked(ARGENT_ACCOUNT_CLASS_HASH);
     let (account_deployment, signer) = deploy_argent_account(&devnet, account_hash).await.unwrap();
-    match assert_tx_succeeded_accepted(
-        &account_deployment.transaction_hash,
-        &devnet.json_rpc_client,
-    )
-    .await
-    {
-        Ok(_) => (),
-        Err(e) => panic!("Transaction failed: {}", e),
-    };
+    assert_tx_succeeded_accepted(&account_deployment.transaction_hash, &devnet.json_rpc_client)
+        .await
+        .unwrap();
 
     let account_address = account_deployment.contract_address;
     can_declare_deploy_invoke_cairo1_using_account(&devnet, &signer, account_address).await;

--- a/tests/integration/test_account_selection.rs
+++ b/tests/integration/test_account_selection.rs
@@ -77,8 +77,15 @@ async fn can_deploy_new_cairo1_oz_account() {
     let devnet = BackgroundDevnet::spawn_with_additional_args(&cli_args).await.unwrap();
 
     let (account_deployment, signer) = deploy_oz_account(&devnet).await.unwrap();
-    assert_tx_succeeded_accepted(&account_deployment.transaction_hash, &devnet.json_rpc_client)
-        .await;
+    match assert_tx_succeeded_accepted(
+        &account_deployment.transaction_hash,
+        &devnet.json_rpc_client,
+    )
+    .await
+    {
+        Ok(()) => (),
+        Err(err) => panic!("Transaction failed: {}", err),
+    };
 
     let account_address = account_deployment.contract_address;
     can_declare_deploy_invoke_cairo1_using_account(&devnet, &signer, account_address).await;
@@ -90,8 +97,15 @@ async fn can_deploy_new_cairo1_oz_account_when_cairo0_selected() {
     let devnet = BackgroundDevnet::spawn_with_additional_args(&cli_args).await.unwrap();
 
     let (account_deployment, signer) = deploy_oz_account(&devnet).await.unwrap();
-    assert_tx_succeeded_accepted(&account_deployment.transaction_hash, &devnet.json_rpc_client)
-        .await;
+    match assert_tx_succeeded_accepted(
+        &account_deployment.transaction_hash,
+        &devnet.json_rpc_client,
+    )
+    .await
+    {
+        Ok(()) => (),
+        Err(err) => panic!("Transaction failed: {}", err),
+    };
 
     let account_address = account_deployment.contract_address;
     can_declare_deploy_invoke_cairo1_using_account(&devnet, &signer, account_address).await;
@@ -103,8 +117,15 @@ async fn can_deploy_new_custom_oz_account() {
     let devnet = BackgroundDevnet::spawn_with_additional_args(&cli_args).await.unwrap();
 
     let (account_deployment, signer) = deploy_oz_account(&devnet).await.unwrap();
-    assert_tx_succeeded_accepted(&account_deployment.transaction_hash, &devnet.json_rpc_client)
-        .await;
+    match assert_tx_succeeded_accepted(
+        &account_deployment.transaction_hash,
+        &devnet.json_rpc_client,
+    )
+    .await
+    {
+        Ok(()) => (),
+        Err(err) => panic!("Transaction failed: {}", err),
+    };
 
     let account_address = account_deployment.contract_address;
     can_declare_deploy_invoke_cairo1_using_account(&devnet, &signer, account_address).await;
@@ -130,8 +151,15 @@ async fn can_deploy_instance_of_argent_account_via_fork() {
 
     let account_hash = Felt::from_hex_unchecked(ARGENT_ACCOUNT_CLASS_HASH);
     let (account_deployment, signer) = deploy_argent_account(&devnet, account_hash).await.unwrap();
-    assert_tx_succeeded_accepted(&account_deployment.transaction_hash, &devnet.json_rpc_client)
-        .await;
+    match assert_tx_succeeded_accepted(
+        &account_deployment.transaction_hash,
+        &devnet.json_rpc_client,
+    )
+    .await
+    {
+        Ok(_) => (),
+        Err(e) => panic!("Transaction failed: {}", e),
+    };
 
     let account_address = account_deployment.contract_address;
     can_declare_deploy_invoke_cairo1_using_account(&devnet, &signer, account_address).await;
@@ -144,8 +172,15 @@ async fn can_deploy_new_argent_account_from_predeclared_class() {
 
     let account_hash = Felt::from_hex_unchecked(ARGENT_ACCOUNT_CLASS_HASH);
     let (account_deployment, signer) = deploy_argent_account(&devnet, account_hash).await.unwrap();
-    assert_tx_succeeded_accepted(&account_deployment.transaction_hash, &devnet.json_rpc_client)
-        .await;
+    match assert_tx_succeeded_accepted(
+        &account_deployment.transaction_hash,
+        &devnet.json_rpc_client,
+    )
+    .await
+    {
+        Ok(_) => (),
+        Err(e) => panic!("Transaction failed: {}", e),
+    };
 
     let account_address = account_deployment.contract_address;
     can_declare_deploy_invoke_cairo1_using_account(&devnet, &signer, account_address).await;
@@ -199,7 +234,12 @@ async fn can_declare_deploy_invoke_cairo1_using_account(
 
     let invoke_result = account.execute_v3(contract_invoke.clone()).send().await.unwrap();
 
-    assert_tx_succeeded_accepted(&invoke_result.transaction_hash, &devnet.json_rpc_client).await;
+    match assert_tx_succeeded_accepted(&invoke_result.transaction_hash, &devnet.json_rpc_client)
+        .await
+    {
+        Ok(_) => (),
+        Err(e) => panic!("Transaction failed: {}", e),
+    };
 }
 
 #[tokio::test]

--- a/tests/integration/test_account_selection.rs
+++ b/tests/integration/test_account_selection.rs
@@ -77,15 +77,9 @@ async fn can_deploy_new_cairo1_oz_account() {
     let devnet = BackgroundDevnet::spawn_with_additional_args(&cli_args).await.unwrap();
 
     let (account_deployment, signer) = deploy_oz_account(&devnet).await.unwrap();
-    match assert_tx_succeeded_accepted(
-        &account_deployment.transaction_hash,
-        &devnet.json_rpc_client,
-    )
-    .await
-    {
-        Ok(()) => (),
-        Err(err) => panic!("Transaction failed: {}", err),
-    };
+    assert_tx_succeeded_accepted(&account_deployment.transaction_hash, &devnet.json_rpc_client)
+        .await
+        .unwrap();
 
     let account_address = account_deployment.contract_address;
     can_declare_deploy_invoke_cairo1_using_account(&devnet, &signer, account_address).await;
@@ -97,15 +91,9 @@ async fn can_deploy_new_cairo1_oz_account_when_cairo0_selected() {
     let devnet = BackgroundDevnet::spawn_with_additional_args(&cli_args).await.unwrap();
 
     let (account_deployment, signer) = deploy_oz_account(&devnet).await.unwrap();
-    match assert_tx_succeeded_accepted(
-        &account_deployment.transaction_hash,
-        &devnet.json_rpc_client,
-    )
-    .await
-    {
-        Ok(()) => (),
-        Err(err) => panic!("Transaction failed: {}", err),
-    };
+    assert_tx_succeeded_accepted(&account_deployment.transaction_hash, &devnet.json_rpc_client)
+        .await
+        .unwrap();
 
     let account_address = account_deployment.contract_address;
     can_declare_deploy_invoke_cairo1_using_account(&devnet, &signer, account_address).await;
@@ -117,15 +105,9 @@ async fn can_deploy_new_custom_oz_account() {
     let devnet = BackgroundDevnet::spawn_with_additional_args(&cli_args).await.unwrap();
 
     let (account_deployment, signer) = deploy_oz_account(&devnet).await.unwrap();
-    match assert_tx_succeeded_accepted(
-        &account_deployment.transaction_hash,
-        &devnet.json_rpc_client,
-    )
-    .await
-    {
-        Ok(()) => (),
-        Err(err) => panic!("Transaction failed: {}", err),
-    };
+    assert_tx_succeeded_accepted(&account_deployment.transaction_hash, &devnet.json_rpc_client)
+        .await
+        .unwrap();
 
     let account_address = account_deployment.contract_address;
     can_declare_deploy_invoke_cairo1_using_account(&devnet, &signer, account_address).await;
@@ -152,15 +134,9 @@ async fn can_deploy_instance_of_argent_account_via_fork() {
 
     let account_hash = Felt::from_hex_unchecked(ARGENT_ACCOUNT_CLASS_HASH);
     let (account_deployment, signer) = deploy_argent_account(&devnet, account_hash).await.unwrap();
-    match assert_tx_succeeded_accepted(
-        &account_deployment.transaction_hash,
-        &devnet.json_rpc_client,
-    )
-    .await
-    {
-        Ok(_) => (),
-        Err(e) => panic!("Transaction failed: {}", e),
-    };
+    assert_tx_succeeded_accepted(&account_deployment.transaction_hash, &devnet.json_rpc_client)
+        .await
+        .unwrap();
 
     let account_address = account_deployment.contract_address;
     can_declare_deploy_invoke_cairo1_using_account(&devnet, &signer, account_address).await;
@@ -235,12 +211,9 @@ async fn can_declare_deploy_invoke_cairo1_using_account(
 
     let invoke_result = account.execute_v3(contract_invoke.clone()).send().await.unwrap();
 
-    match assert_tx_succeeded_accepted(&invoke_result.transaction_hash, &devnet.json_rpc_client)
+    assert_tx_succeeded_accepted(&invoke_result.transaction_hash, &devnet.json_rpc_client)
         .await
-    {
-        Ok(_) => (),
-        Err(e) => panic!("Transaction failed: {}", e),
-    };
+        .unwrap();
 }
 
 #[tokio::test]

--- a/tests/integration/test_account_selection.rs
+++ b/tests/integration/test_account_selection.rs
@@ -140,7 +140,8 @@ async fn argent_account_undeployable_by_default() {
     assert_contains(
         &error.to_string(),
         &format!("Class with hash {ARGENT_ACCOUNT_CLASS_HASH} is not declared"),
-    );
+    )
+    .unwrap();
 }
 
 #[tokio::test]

--- a/tests/integration/test_account_selection.rs
+++ b/tests/integration/test_account_selection.rs
@@ -8,6 +8,7 @@ use starknet_rs_core::utils::{get_selector_from_name, get_udc_deployed_address};
 use starknet_rs_providers::Provider;
 use starknet_rs_signers::LocalWallet;
 
+use crate::assert_eq_prop;
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants::{
     ARGENT_ACCOUNT_CLASS_HASH, CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH,
@@ -54,24 +55,14 @@ async fn correct_artifact_test_body(
         .get_class_hash_at(BlockId::Tag(BlockTag::Latest), account_address)
         .await?;
     let expected_hash = Felt::from_hex_unchecked(expected_hash_hex);
-    anyhow::ensure!(
-        retrieved_class_hash == expected_hash,
-        format!(
-            "assertion `left == right` failed, left: {retrieved_class_hash}, right: {expected_hash}"
-        )
-    );
+    assert_eq_prop!(retrieved_class_hash, expected_hash)?;
 
     let config = devnet.get_config().await;
     let config_class_hash_hex = config["account_contract_class_hash"]
         .as_str()
         .ok_or(anyhow::anyhow!("contract class hash not found"))?;
     let config_class_hash = Felt::from_hex_unchecked(config_class_hash_hex);
-    anyhow::ensure!(
-        config_class_hash == expected_hash,
-        format!(
-            "assertion `left == right` failed, left: {config_class_hash}, right: {expected_hash}"
-        )
-    );
+    assert_eq_prop!(config_class_hash, expected_hash)?;
     Ok(())
 }
 

--- a/tests/integration/test_account_selection.rs
+++ b/tests/integration/test_account_selection.rs
@@ -54,13 +54,24 @@ async fn correct_artifact_test_body(
         .get_class_hash_at(BlockId::Tag(BlockTag::Latest), account_address)
         .await?;
     let expected_hash = Felt::from_hex_unchecked(expected_hash_hex);
-    anyhow::ensure!(retrieved_class_hash == expected_hash);
+    anyhow::ensure!(
+        retrieved_class_hash == expected_hash,
+        format!(
+            "assertion `left == right` failed, left: {retrieved_class_hash}, right: {expected_hash}"
+        )
+    );
 
     let config = devnet.get_config().await;
     let config_class_hash_hex = config["account_contract_class_hash"]
         .as_str()
         .ok_or(anyhow::anyhow!("contract class hash not found"))?;
-    anyhow::ensure!(Felt::from_hex_unchecked(config_class_hash_hex) == expected_hash);
+    let config_class_hash = Felt::from_hex_unchecked(config_class_hash_hex);
+    anyhow::ensure!(
+        config_class_hash == expected_hash,
+        format!(
+            "assertion `left == right` failed, left: {config_class_hash}, right: {expected_hash}"
+        )
+    );
     Ok(())
 }
 

--- a/tests/integration/test_advancing_time.rs
+++ b/tests/integration/test_advancing_time.rs
@@ -639,7 +639,7 @@ async fn tx_resource_estimation_fails_unless_time_incremented() {
             assert_eq!(inner_error.selector, time_check_selector);
 
             let message = extract_message_error(&inner_error.error);
-            assert_contains(message, "Wait a bit more");
+            assert_contains(message, "Wait a bit more").unwrap();
         }
         other => panic!("Invalid error: {other:?}"),
     }
@@ -686,7 +686,7 @@ async fn tx_execution_fails_unless_time_incremented() {
     match devnet.json_rpc_client.get_transaction_status(reverted_tx.transaction_hash).await {
         Ok(TransactionStatus::AcceptedOnL2(tx_details)) => {
             assert_eq!(tx_details.status(), TransactionExecutionStatus::Reverted);
-            assert_contains(tx_details.revert_reason().unwrap(), "Wait a bit more");
+            assert_contains(tx_details.revert_reason().unwrap(), "Wait a bit more").unwrap();
         }
         other => panic!("Unexpected tx: {other:?}"),
     }

--- a/tests/integration/test_advancing_time.rs
+++ b/tests/integration/test_advancing_time.rs
@@ -638,7 +638,7 @@ async fn tx_resource_estimation_fails_unless_time_incremented() {
             assert_eq!(inner_error.contract_address, contract_address);
             assert_eq!(inner_error.selector, time_check_selector);
 
-            let message = extract_message_error(&inner_error.error);
+            let message = extract_message_error(&inner_error.error).unwrap();
             assert_contains(message, "Wait a bit more").unwrap();
         }
         other => panic!("Invalid error: {other:?}"),

--- a/tests/integration/test_advancing_time.rs
+++ b/tests/integration/test_advancing_time.rs
@@ -19,6 +19,7 @@ use crate::common::utils::{
     get_timestamp_asserter_contract_artifacts, get_unix_timestamp_as_seconds, increase_time,
     send_ctrl_c_signal_and_wait, set_time,
 };
+use crate::{assert_gte_prop, assert_lte_prop};
 
 const DUMMY_ADDRESS: u128 = 1;
 const DUMMY_AMOUNT: u128 = 1;
@@ -31,16 +32,16 @@ async fn sleep_until_new_timestamp() {
 }
 
 pub fn assert_ge_with_buffer(val1: u64, val2: u64) -> Result<(), anyhow::Error> {
-    anyhow::ensure!(val1 >= val2, "Failed inequation: {val1:?} >= {val2:?}");
+    assert_gte_prop!(val1, val2)?;
     let upper_limit = val2 + BUFFER_TIME_SECONDS;
-    anyhow::ensure!(val1 <= upper_limit, "Failed inequation: {val1:?} <= {upper_limit:?}");
+    assert_lte_prop!(val1, upper_limit)?;
     Ok(())
 }
 
 pub fn assert_gt_with_buffer(val1: u64, val2: u64) -> Result<(), anyhow::Error> {
-    anyhow::ensure!(val1 > val2, "Failed inequation: {val1:?} > {val2:?}");
+    assert_gte_prop!(val1, val2)?;
     let upper_limit = val2 + BUFFER_TIME_SECONDS;
-    anyhow::ensure!(val1 <= upper_limit, "Failed inequation: {val1:?} <= {upper_limit:?}");
+    assert_lte_prop!(val1, upper_limit)?;
     Ok(())
 }
 

--- a/tests/integration/test_advancing_time.rs
+++ b/tests/integration/test_advancing_time.rs
@@ -628,13 +628,13 @@ async fn tx_resource_estimation_fails_unless_time_incremented() {
         )) => {
             assert_eq!(error_data.transaction_index, 0);
 
-            let root_error = extract_nested_error(&error_data.execution_error);
+            let root_error = extract_nested_error(&error_data.execution_error).unwrap();
             assert_eq!(root_error.contract_address, account.address());
             assert_eq!(root_error.selector, get_selector_from_name("__execute__").unwrap());
 
             // Currently the root error is twice mentioned, so we extract twice
-            let inner_error = extract_nested_error(&root_error.error);
-            let inner_error = extract_nested_error(&inner_error.error);
+            let inner_error = extract_nested_error(&root_error.error).unwrap();
+            let inner_error = extract_nested_error(&inner_error.error).unwrap();
             assert_eq!(inner_error.contract_address, contract_address);
             assert_eq!(inner_error.selector, time_check_selector);
 

--- a/tests/integration/test_advancing_time_on_fork.rs
+++ b/tests/integration/test_advancing_time_on_fork.rs
@@ -64,13 +64,13 @@ async fn tx_resource_estimation_fails_on_forked_devnet_with_impersonation_unless
         )) => {
             assert_eq!(error_data.transaction_index, 0);
 
-            let root_error = extract_nested_error(&error_data.execution_error);
+            let root_error = extract_nested_error(&error_data.execution_error).unwrap();
             assert_eq!(root_error.contract_address, fork_account.address());
             assert_eq!(root_error.selector, get_selector_from_name("__execute__").unwrap());
 
             // Currently the root error is twice mentioned, so we extract twice
-            let inner_error = extract_nested_error(&root_error.error);
-            let inner_error = extract_nested_error(&inner_error.error);
+            let inner_error = extract_nested_error(&root_error.error).unwrap();
+            let inner_error = extract_nested_error(&inner_error.error).unwrap();
             assert_eq!(inner_error.contract_address, contract_address);
             assert_eq!(inner_error.selector, time_check_selector);
 

--- a/tests/integration/test_advancing_time_on_fork.rs
+++ b/tests/integration/test_advancing_time_on_fork.rs
@@ -75,7 +75,7 @@ async fn tx_resource_estimation_fails_on_forked_devnet_with_impersonation_unless
             assert_eq!(inner_error.selector, time_check_selector);
 
             let message = extract_message_error(&inner_error.error);
-            assert_contains(message, "Wait a bit more");
+            assert_contains(message, "Wait a bit more").unwrap();
         }
         other => panic!("Invalid error: {other:?}"),
     }
@@ -139,7 +139,7 @@ async fn tx_execution_fails_on_forked_devnet_with_impersonation_unless_time_incr
     match forked_devnet.json_rpc_client.get_transaction_status(reverted_tx.transaction_hash).await {
         Ok(TransactionStatus::AcceptedOnL2(tx_details)) => {
             assert_eq!(tx_details.status(), TransactionExecutionStatus::Reverted);
-            assert_contains(tx_details.revert_reason().unwrap(), "Wait a bit more");
+            assert_contains(tx_details.revert_reason().unwrap(), "Wait a bit more").unwrap();
         }
         other => panic!("Unexpected tx: {other:?}"),
     }

--- a/tests/integration/test_advancing_time_on_fork.rs
+++ b/tests/integration/test_advancing_time_on_fork.rs
@@ -74,7 +74,7 @@ async fn tx_resource_estimation_fails_on_forked_devnet_with_impersonation_unless
             assert_eq!(inner_error.contract_address, contract_address);
             assert_eq!(inner_error.selector, time_check_selector);
 
-            let message = extract_message_error(&inner_error.error);
+            let message = extract_message_error(&inner_error.error).unwrap();
             assert_contains(message, "Wait a bit more").unwrap();
         }
         other => panic!("Invalid error: {other:?}"),

--- a/tests/integration/test_blocks_generation.rs
+++ b/tests/integration/test_blocks_generation.rs
@@ -438,16 +438,14 @@ async fn blocks_on_demand_invoke_and_call() {
     }
 
     let expected_balance = initial_value + (increment * Felt::from(increment_count));
-
-    assert_eq!(
-        get_contract_balance_by_block_id(
-            &devnet,
-            contract_address,
-            BlockId::Tag(BlockTag::PreConfirmed)
-        )
-        .await,
-        expected_balance
-    );
+    let contract_balance = get_contract_balance_by_block_id(
+        &devnet,
+        contract_address,
+        BlockId::Tag(BlockTag::PreConfirmed),
+    )
+    .await
+    .unwrap();
+    assert_eq!(contract_balance, expected_balance);
 
     let contract_call = FunctionCall {
         contract_address,
@@ -461,16 +459,16 @@ async fn blocks_on_demand_invoke_and_call() {
     devnet.create_block().await.unwrap();
 
     assert_latest_block_with_tx_hashes(&devnet, 1, tx_hashes).await;
-    assert_eq!(
-        get_contract_balance_by_block_id(
-            &devnet,
-            contract_address,
-            BlockId::Tag(BlockTag::PreConfirmed)
-        )
-        .await,
-        expected_balance
-    );
-    assert_eq!(get_contract_balance(&devnet, contract_address).await, expected_balance);
+    let contract_balance = get_contract_balance_by_block_id(
+        &devnet,
+        contract_address,
+        BlockId::Tag(BlockTag::PreConfirmed),
+    )
+    .await
+    .unwrap();
+    assert_eq!(contract_balance, expected_balance);
+    let contract_balance = get_contract_balance(&devnet, contract_address).await.unwrap();
+    assert_eq!(contract_balance, expected_balance);
 }
 
 #[tokio::test]

--- a/tests/integration/test_blocks_generation.rs
+++ b/tests/integration/test_blocks_generation.rs
@@ -101,7 +101,7 @@ async fn assert_latest_block_with_receipts(
     devnet: &BackgroundDevnet,
     block_number: u64,
     tx_count: usize,
-) {
+) -> Result<(), anyhow::Error> {
     let latest_block = &devnet
         .send_custom_rpc("starknet_getBlockWithReceipts", json!({ "block_id": "latest" }))
         .await
@@ -119,9 +119,11 @@ async fn assert_latest_block_with_receipts(
         .await
         {
             Ok(_) => {}
-            Err(e) => panic!("Transaction failed: {}", e),
+            Err(e) => anyhow::bail!("Transaction failed: {}", e),
         };
     }
+
+    Ok(())
 }
 
 async fn assert_pre_confirmed_block_with_receipts(devnet: &BackgroundDevnet, tx_count: usize) {
@@ -225,7 +227,7 @@ async fn normal_mode_states_and_blocks() {
     assert_pre_confirmed_block_with_receipts(&devnet, 0).await;
     assert_latest_block_with_tx_hashes(&devnet, 5, vec![tx_hashes.last().copied().unwrap()]).await;
     assert_latest_block_with_txs(&devnet, 5, 1).await;
-    assert_latest_block_with_receipts(&devnet, 5, 1).await;
+    assert_latest_block_with_receipts(&devnet, 5, 1).await.unwrap();
 
     assert_pre_confirmed_state_update(&devnet).await;
     assert_latest_state_update(&devnet).await;
@@ -254,7 +256,7 @@ async fn blocks_on_demand_states_and_blocks() {
 
     assert_latest_block_with_tx_hashes(&devnet, 0, vec![]).await;
     assert_latest_block_with_txs(&devnet, 0, 0).await;
-    assert_latest_block_with_receipts(&devnet, 0, 0).await;
+    assert_latest_block_with_receipts(&devnet, 0, 0).await.unwrap();
 
     // create new block from pre_confirmed block
     devnet.create_block().await.unwrap();
@@ -269,7 +271,7 @@ async fn blocks_on_demand_states_and_blocks() {
 
     assert_latest_block_with_tx_hashes(&devnet, 1, tx_hashes).await;
     assert_latest_block_with_txs(&devnet, 1, tx_count).await;
-    assert_latest_block_with_receipts(&devnet, 1, tx_count).await;
+    assert_latest_block_with_receipts(&devnet, 1, tx_count).await.unwrap();
 
     assert_pre_confirmed_state_update(&devnet).await;
     assert_latest_state_update(&devnet).await;

--- a/tests/integration/test_blocks_generation.rs
+++ b/tests/integration/test_blocks_generation.rs
@@ -30,10 +30,11 @@ async fn assert_pre_confirmed_state_update(devnet: &BackgroundDevnet) -> Result<
     let pre_confirmed_state_update =
         &devnet.json_rpc_client.get_state_update(BlockId::Tag(BlockTag::PreConfirmed)).await?;
 
-    anyhow::ensure!(matches!(
-        pre_confirmed_state_update,
-        MaybePreConfirmedStateUpdate::PreConfirmedUpdate(_)
-    ));
+    anyhow::ensure!(
+        matches!(pre_confirmed_state_update, MaybePreConfirmedStateUpdate::PreConfirmedUpdate(_)),
+        "Expected a pre-confirmed state update, but found: {:?}",
+        pre_confirmed_state_update
+    );
     Ok(())
 }
 
@@ -41,7 +42,11 @@ async fn assert_latest_state_update(devnet: &BackgroundDevnet) -> Result<(), any
     let latest_state_update =
         &devnet.json_rpc_client.get_state_update(BlockId::Tag(BlockTag::Latest)).await?;
 
-    anyhow::ensure!(matches!(latest_state_update, MaybePreConfirmedStateUpdate::Update(_)));
+    anyhow::ensure!(
+        matches!(latest_state_update, MaybePreConfirmedStateUpdate::Update(_)),
+        "Expected an update state update, but found: {:?}",
+        latest_state_update
+    );
     Ok(())
 }
 
@@ -52,9 +57,28 @@ async fn assert_latest_block_with_tx_hashes(
 ) -> Result<(), anyhow::Error> {
     let latest_block = devnet.get_latest_block_with_tx_hashes().await?;
 
-    anyhow::ensure!(latest_block.block_number == block_number);
-    anyhow::ensure!(transactions == latest_block.transactions);
-    anyhow::ensure!(latest_block.status == BlockStatus::AcceptedOnL2);
+    anyhow::ensure!(
+        latest_block.block_number == block_number,
+        format!(
+            "assertion `left == right` failed, left: {}, right: {block_number}",
+            latest_block.block_number
+        )
+    );
+    anyhow::ensure!(
+        transactions == latest_block.transactions,
+        format!(
+            "assertion `left == right` failed, left: {transactions:?}, right: {:?}",
+            latest_block.transactions
+        )
+    );
+    anyhow::ensure!(
+        latest_block.status == BlockStatus::AcceptedOnL2,
+        format!(
+            "assertion `left == right` failed, left: {:?}, right: {:?}",
+            latest_block.status,
+            BlockStatus::AcceptedOnL2
+        )
+    );
 
     for tx_hash in latest_block.transactions {
         assert_tx_succeeded_accepted(&tx_hash, &devnet.json_rpc_client).await?;
@@ -68,7 +92,13 @@ async fn assert_pre_confirmed_block_with_tx_hashes(
 ) -> Result<(), anyhow::Error> {
     let pre_confirmed_block = devnet.get_pre_confirmed_block_with_tx_hashes().await?;
 
-    anyhow::ensure!(pre_confirmed_block.transactions.len() == tx_count);
+    let pre_confirmed_block_tx_count = pre_confirmed_block.transactions.len();
+    anyhow::ensure!(
+        pre_confirmed_block_tx_count == tx_count,
+        format!(
+            "assertion `left == right` failed, left: {pre_confirmed_block_tx_count}, right: {tx_count}"
+        )
+    );
 
     for tx_hash in pre_confirmed_block.transactions {
         assert_tx_succeeded_pre_confirmed(&tx_hash, &devnet.json_rpc_client).await;
@@ -84,9 +114,28 @@ async fn assert_latest_block_with_txs(
 ) -> Result<(), anyhow::Error> {
     let latest_block = devnet.get_latest_block_with_txs().await?;
 
-    anyhow::ensure!(latest_block.block_number == block_number);
-    anyhow::ensure!(latest_block.status == BlockStatus::AcceptedOnL2);
-    anyhow::ensure!(latest_block.transactions.len() == tx_count);
+    anyhow::ensure!(
+        latest_block.block_number == block_number,
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            latest_block.block_number, block_number
+        )
+    );
+    anyhow::ensure!(
+        latest_block.status == BlockStatus::AcceptedOnL2,
+        format!(
+            "assertion `left == right` failed, left: {:?}, right: {:?}",
+            latest_block.status,
+            BlockStatus::AcceptedOnL2
+        )
+    );
+    let latest_block_tx_count = latest_block.transactions.len();
+    anyhow::ensure!(
+        latest_block_tx_count == tx_count,
+        format!(
+            "assertion `left == right` failed, left: {latest_block_tx_count}, right: {tx_count}"
+        )
+    );
 
     for tx in latest_block.transactions {
         assert_tx_succeeded_accepted(tx.transaction_hash(), &devnet.json_rpc_client).await?;
@@ -101,7 +150,13 @@ async fn assert_pre_confirmed_block_with_txs(
 ) -> Result<(), anyhow::Error> {
     let pre_confirmed_block = devnet.get_pre_confirmed_block_with_txs().await?;
 
-    anyhow::ensure!(pre_confirmed_block.transactions.len() == tx_count);
+    let pre_confirmed_block_tx_count = pre_confirmed_block.transactions.len();
+    anyhow::ensure!(
+        pre_confirmed_block_tx_count == tx_count,
+        format!(
+            "assertion `left == right` failed, left: {pre_confirmed_block_tx_count}, right: {tx_count}"
+        )
+    );
 
     for tx in pre_confirmed_block.transactions {
         assert_tx_succeeded_pre_confirmed(tx.transaction_hash(), &devnet.json_rpc_client).await;
@@ -119,9 +174,30 @@ async fn assert_latest_block_with_receipts(
         .send_custom_rpc("starknet_getBlockWithReceipts", json!({ "block_id": "latest" }))
         .await?;
 
-    anyhow::ensure!(latest_block["transactions"].as_array().unwrap().len() == tx_count);
-    anyhow::ensure!(latest_block["block_number"] == block_number);
-    anyhow::ensure!(latest_block["status"] == "ACCEPTED_ON_L2");
+    let latest_block_tx_count = latest_block["transactions"]
+        .as_array()
+        .ok_or(anyhow!("cannot convert block txs to array"))?
+        .len();
+    anyhow::ensure!(
+        latest_block_tx_count == tx_count,
+        format!(
+            "assertion `left == right` failed, left: {latest_block_tx_count}, right: {tx_count}"
+        )
+    );
+    anyhow::ensure!(
+        latest_block["block_number"] == block_number,
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            latest_block["block_number"], block_number
+        )
+    );
+    anyhow::ensure!(
+        latest_block["status"] == "ACCEPTED_ON_L2",
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            latest_block["status"], "ACCEPTED_ON_L2"
+        )
+    );
 
     for tx in latest_block["transactions"].as_array().unwrap() {
         assert_tx_succeeded_accepted(
@@ -146,8 +222,23 @@ async fn assert_pre_confirmed_block_with_receipts(
         .send_custom_rpc("starknet_getBlockWithReceipts", json!({ "block_id": "pre_confirmed" }))
         .await?;
 
-    anyhow::ensure!(pre_confirmed_block["status"].is_null());
-    anyhow::ensure!(pre_confirmed_block["transactions"].as_array().unwrap().len() == tx_count);
+    anyhow::ensure!(
+        pre_confirmed_block["status"].is_null(),
+        format!(
+            "assertion failed, expected preconfirmed block status to be null, got: {}",
+            pre_confirmed_block["status"]
+        )
+    );
+    let pre_confirmed_block_tx_count = pre_confirmed_block["transactions"]
+        .as_array()
+        .ok_or(anyhow!("failed to convert block transactions to array"))?
+        .len();
+    anyhow::ensure!(
+        pre_confirmed_block_tx_count == tx_count,
+        format!(
+            "assertion `left == right` failed, left: {pre_confirmed_block_tx_count}, right: {tx_count}"
+        )
+    );
 
     for tx in pre_confirmed_block["transactions"].as_array().unwrap() {
         let tx_hash = Felt::from_hex_unchecked(
@@ -167,7 +258,10 @@ async fn assert_balance(
     tag: BlockTag,
 ) -> Result<(), anyhow::Error> {
     let balance = devnet.get_balance_by_tag(&Felt::from(DUMMY_ADDRESS), FeeUnit::Fri, tag).await?;
-    anyhow::ensure!(balance == expected);
+    anyhow::ensure!(
+        balance == expected,
+        format!("assertion `left == right` failed, left: {balance}, right: {expected}")
+    );
     Ok(())
 }
 
@@ -178,11 +272,23 @@ async fn assert_get_nonce(devnet: &BackgroundDevnet) -> Result<(), anyhow::Error
         .json_rpc_client
         .get_nonce(BlockId::Tag(BlockTag::PreConfirmed), account_address)
         .await?;
-    anyhow::ensure!(pre_confirmed_block_nonce == Felt::ZERO);
+    anyhow::ensure!(
+        pre_confirmed_block_nonce == Felt::ZERO,
+        format!(
+            "assertion `left == right` failed, left: {pre_confirmed_block_nonce}, right: {}",
+            Felt::ZERO
+        )
+    );
 
     let latest_block_nonce =
         devnet.json_rpc_client.get_nonce(BlockId::Tag(BlockTag::Latest), account_address).await?;
-    anyhow::ensure!(latest_block_nonce == Felt::ZERO);
+    anyhow::ensure!(
+        latest_block_nonce == Felt::ZERO,
+        format!(
+            "assertion `left == right` failed, left: {latest_block_nonce}, right: {}",
+            Felt::ZERO
+        )
+    );
     Ok(())
 }
 
@@ -194,13 +300,25 @@ async fn assert_get_storage_at(devnet: &BackgroundDevnet) -> Result<(), anyhow::
         .json_rpc_client
         .get_storage_at(account_address, key, BlockId::Tag(BlockTag::PreConfirmed))
         .await?;
-    anyhow::ensure!(pre_confirmed_block_storage == Felt::ZERO);
+    anyhow::ensure!(
+        pre_confirmed_block_storage == Felt::ZERO,
+        format!(
+            "assertion `left == right` failed, left: {pre_confirmed_block_storage}, right: {}",
+            Felt::ZERO
+        )
+    );
 
     let latest_block_storage = devnet
         .json_rpc_client
         .get_storage_at(account_address, key, BlockId::Tag(BlockTag::Latest))
         .await?;
-    anyhow::ensure!(latest_block_storage == Felt::ZERO);
+    anyhow::ensure!(
+        latest_block_storage == Felt::ZERO,
+        format!(
+            "assertion `left == right` failed, left: {latest_block_storage}, right: {}",
+            Felt::ZERO
+        )
+    );
     Ok(())
 }
 
@@ -211,9 +329,12 @@ async fn assert_get_class_hash_at(devnet: &BackgroundDevnet) -> Result<(), anyho
         .json_rpc_client
         .get_class_hash_at(BlockId::Tag(BlockTag::PreConfirmed), account_address)
         .await?;
+    let sierra_hash = Felt::from_hex_unchecked(CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH);
     anyhow::ensure!(
-        pre_confirmed_block_class_hash
-            == Felt::from_hex_unchecked(CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH)
+        pre_confirmed_block_class_hash == sierra_hash,
+        format!(
+            "assertion `left == right` failed, left: {pre_confirmed_block_class_hash}, right: {sierra_hash}"
+        )
     );
 
     let latest_block_class_hash = devnet
@@ -221,7 +342,10 @@ async fn assert_get_class_hash_at(devnet: &BackgroundDevnet) -> Result<(), anyho
         .get_class_hash_at(BlockId::Tag(BlockTag::Latest), account_address)
         .await?;
     anyhow::ensure!(
-        latest_block_class_hash == Felt::from_hex_unchecked(CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH)
+        latest_block_class_hash == sierra_hash,
+        format!(
+            "assertion `left == right` failed, left: {latest_block_class_hash}, right: {sierra_hash}"
+        )
     );
     Ok(())
 }

--- a/tests/integration/test_blocks_generation.rs
+++ b/tests/integration/test_blocks_generation.rs
@@ -57,10 +57,7 @@ async fn assert_latest_block_with_tx_hashes(
     assert_eq!(latest_block.status, BlockStatus::AcceptedOnL2);
 
     for tx_hash in latest_block.transactions {
-        match assert_tx_succeeded_accepted(&tx_hash, &devnet.json_rpc_client).await {
-            Ok(_) => {}
-            Err(e) => panic!("Transaction failed: {}", e),
-        };
+        assert_tx_succeeded_accepted(&tx_hash, &devnet.json_rpc_client).await.unwrap();
     }
 }
 
@@ -86,10 +83,7 @@ async fn assert_latest_block_with_txs(
     assert_eq!(latest_block.transactions.len(), tx_count);
 
     for tx in latest_block.transactions {
-        match assert_tx_succeeded_accepted(tx.transaction_hash(), &devnet.json_rpc_client).await {
-            Ok(_) => {}
-            Err(e) => panic!("Transaction failed: {}", e),
-        };
+        assert_tx_succeeded_accepted(tx.transaction_hash(), &devnet.json_rpc_client).await.unwrap();
     }
 }
 

--- a/tests/integration/test_blocks_generation.rs
+++ b/tests/integration/test_blocks_generation.rs
@@ -57,7 +57,10 @@ async fn assert_latest_block_with_tx_hashes(
     assert_eq!(latest_block.status, BlockStatus::AcceptedOnL2);
 
     for tx_hash in latest_block.transactions {
-        assert_tx_succeeded_accepted(&tx_hash, &devnet.json_rpc_client).await;
+        match assert_tx_succeeded_accepted(&tx_hash, &devnet.json_rpc_client).await {
+            Ok(_) => {}
+            Err(e) => panic!("Transaction failed: {}", e),
+        };
     }
 }
 
@@ -83,7 +86,10 @@ async fn assert_latest_block_with_txs(
     assert_eq!(latest_block.transactions.len(), tx_count);
 
     for tx in latest_block.transactions {
-        assert_tx_succeeded_accepted(tx.transaction_hash(), &devnet.json_rpc_client).await;
+        match assert_tx_succeeded_accepted(tx.transaction_hash(), &devnet.json_rpc_client).await {
+            Ok(_) => {}
+            Err(e) => panic!("Transaction failed: {}", e),
+        };
     }
 }
 
@@ -112,11 +118,15 @@ async fn assert_latest_block_with_receipts(
     assert_eq!(latest_block["status"], "ACCEPTED_ON_L2");
 
     for tx in latest_block["transactions"].as_array().unwrap() {
-        assert_tx_succeeded_accepted(
+        match assert_tx_succeeded_accepted(
             &Felt::from_hex_unchecked(tx["receipt"]["transaction_hash"].as_str().unwrap()),
             &devnet.json_rpc_client,
         )
-        .await;
+        .await
+        {
+            Ok(_) => {}
+            Err(e) => panic!("Transaction failed: {}", e),
+        };
     }
 }
 

--- a/tests/integration/test_blocks_generation.rs
+++ b/tests/integration/test_blocks_generation.rs
@@ -107,20 +107,17 @@ async fn assert_latest_block_with_receipts(
         .await
         .unwrap();
 
-    assert_eq!(latest_block["transactions"].as_array().unwrap().len(), tx_count);
-    assert_eq!(latest_block["block_number"], block_number);
-    assert_eq!(latest_block["status"], "ACCEPTED_ON_L2");
+    anyhow::ensure!(latest_block["transactions"].as_array().unwrap().len() == tx_count);
+    anyhow::ensure!(latest_block["block_number"] == block_number);
+    anyhow::ensure!(latest_block["status"] == "ACCEPTED_ON_L2");
 
     for tx in latest_block["transactions"].as_array().unwrap() {
-        match assert_tx_succeeded_accepted(
+        assert_tx_succeeded_accepted(
             &Felt::from_hex_unchecked(tx["receipt"]["transaction_hash"].as_str().unwrap()),
             &devnet.json_rpc_client,
         )
         .await
-        {
-            Ok(_) => {}
-            Err(e) => anyhow::bail!("Transaction failed: {}", e),
-        };
+        .unwrap();
     }
 
     Ok(())

--- a/tests/integration/test_blocks_generation.rs
+++ b/tests/integration/test_blocks_generation.rs
@@ -355,8 +355,9 @@ async fn blocks_on_demand_declarations() {
     for block_id in [BlockId::Tag(BlockTag::Latest), BlockId::Hash(declaration_block_hash)] {
         match devnet.json_rpc_client.get_state_update(block_id).await {
             Ok(MaybePreConfirmedStateUpdate::Update(StateUpdate { state_diff, .. })) => {
-                assert_equal_elements(&state_diff.declared_classes, &expected_block_declarations);
-                assert_equal_elements(&state_diff.nonces, &expected_block_nonce_update)
+                assert_equal_elements(&state_diff.declared_classes, &expected_block_declarations)
+                    .unwrap();
+                assert_equal_elements(&state_diff.nonces, &expected_block_nonce_update).unwrap()
             }
             other => panic!("Unexpected response: {other:?}"),
         }

--- a/tests/integration/test_call.rs
+++ b/tests/integration/test_call.rs
@@ -150,7 +150,7 @@ async fn call_panicking_method() {
             assert_eq!(inner.class_hash, class_hash);
 
             let error_msg = extract_message_error(&inner.error);
-            assert_contains(error_msg, &panic_message.to_hex_string());
+            assert_contains(error_msg, &panic_message.to_hex_string()).unwrap();
         }
         _ => panic!("Invalid error received {err:?}"),
     }

--- a/tests/integration/test_call.rs
+++ b/tests/integration/test_call.rs
@@ -139,12 +139,12 @@ async fn call_panicking_method() {
         ProviderError::StarknetError(StarknetError::ContractError(ContractErrorData {
             revert_error,
         })) => {
-            let root = extract_nested_error(&revert_error);
+            let root = extract_nested_error(&revert_error).unwrap();
             assert_eq!(root.contract_address, contract_address);
             assert_eq!(root.class_hash, class_hash);
             assert_eq!(root.selector, top_selector);
 
-            let inner = extract_nested_error(&root.error);
+            let inner = extract_nested_error(&root.error).unwrap();
             assert_eq!(inner.contract_address, other_contract_address);
             assert_eq!(inner.selector, get_selector_from_name("create_panic").unwrap());
             assert_eq!(inner.class_hash, class_hash);

--- a/tests/integration/test_call.rs
+++ b/tests/integration/test_call.rs
@@ -149,7 +149,7 @@ async fn call_panicking_method() {
             assert_eq!(inner.selector, get_selector_from_name("create_panic").unwrap());
             assert_eq!(inner.class_hash, class_hash);
 
-            let error_msg = extract_message_error(&inner.error);
+            let error_msg = extract_message_error(&inner.error).unwrap();
             assert_contains(error_msg, &panic_message.to_hex_string()).unwrap();
         }
         _ => panic!("Invalid error received {err:?}"),

--- a/tests/integration/test_deploy.rs
+++ b/tests/integration/test_deploy.rs
@@ -78,7 +78,7 @@ async fn double_deployment_not_allowed() {
             assert_eq!(undeployed_contract_error.selector, Felt::ZERO); // constructor
 
             let msg_error = extract_message_error(&undeployed_contract_error.error);
-            assert_contains(msg_error, "contract already deployed");
+            assert_contains(msg_error, "contract already deployed").unwrap();
         }
         other => panic!("Unexpected result: {other:?}"),
     };
@@ -108,7 +108,7 @@ async fn cannot_deploy_undeclared_class() {
 
     // deployment should fail
     match contract_factory.deploy_v3(ctor_args, salt, unique).send().await {
-        Err(e) => assert_contains(&format!("{e:?}"), "not declared"),
+        Err(e) => assert_contains(&format!("{e:?}"), "not declared").unwrap(),
         other => panic!("Unexpected result: {other:?}"),
     };
 }

--- a/tests/integration/test_deploy.rs
+++ b/tests/integration/test_deploy.rs
@@ -68,12 +68,12 @@ async fn double_deployment_not_allowed() {
             );
             assert_eq!(top_error.selector, get_selector_from_name("__execute__").unwrap());
 
-            let udc_error = extract_nested_error(&top_error.error);
+            let udc_error = extract_nested_error(&top_error.error).unwrap();
             assert_eq!(udc_error.contract_address, UDC_LEGACY_CONTRACT_ADDRESS);
             assert_eq!(udc_error.class_hash, UDC_LEGACY_CONTRACT_CLASS_HASH);
             assert_eq!(udc_error.selector, get_selector_from_name("deployContract").unwrap());
 
-            let undeployed_contract_error = extract_nested_error(&udc_error.error);
+            let undeployed_contract_error = extract_nested_error(&udc_error.error).unwrap();
             assert_eq!(undeployed_contract_error.class_hash, declaration_result.class_hash);
             assert_eq!(undeployed_contract_error.selector, Felt::ZERO); // constructor
 

--- a/tests/integration/test_deploy.rs
+++ b/tests/integration/test_deploy.rs
@@ -77,7 +77,7 @@ async fn double_deployment_not_allowed() {
             assert_eq!(undeployed_contract_error.class_hash, declaration_result.class_hash);
             assert_eq!(undeployed_contract_error.selector, Felt::ZERO); // constructor
 
-            let msg_error = extract_message_error(&undeployed_contract_error.error);
+            let msg_error = extract_message_error(&undeployed_contract_error.error).unwrap();
             assert_contains(msg_error, "contract already deployed").unwrap();
         }
         other => panic!("Unexpected result: {other:?}"),

--- a/tests/integration/test_deploy.rs
+++ b/tests/integration/test_deploy.rs
@@ -136,8 +136,15 @@ async fn test_all_udc_deployment_methods_supported() {
         .send()
         .await
         .unwrap();
-    assert_tx_succeeded_accepted(&declaration_result.transaction_hash, &devnet.json_rpc_client)
-        .await;
+    match assert_tx_succeeded_accepted(
+        &declaration_result.transaction_hash,
+        &devnet.json_rpc_client,
+    )
+    .await
+    {
+        Ok(_) => {}
+        Err(e) => panic!("Transaction failed: {}", e),
+    };
 
     let mut salt = Felt::ONE;
     let legacy_deployment_method = "deployContract";
@@ -161,7 +168,11 @@ async fn test_all_udc_deployment_methods_supported() {
         salt += Felt::ONE; // iI salt not changed, error: contract already deployed
 
         let invoke_result = account.execute_v3(contract_invoke.clone()).send().await.unwrap();
-        assert_tx_succeeded_accepted(&invoke_result.transaction_hash, &devnet.json_rpc_client)
-            .await;
+        match assert_tx_succeeded_accepted(&invoke_result.transaction_hash, &devnet.json_rpc_client)
+            .await
+        {
+            Ok(_) => {}
+            Err(e) => panic!("Transaction failed: {}", e),
+        };
     }
 }

--- a/tests/integration/test_deploy.rs
+++ b/tests/integration/test_deploy.rs
@@ -136,15 +136,9 @@ async fn test_all_udc_deployment_methods_supported() {
         .send()
         .await
         .unwrap();
-    match assert_tx_succeeded_accepted(
-        &declaration_result.transaction_hash,
-        &devnet.json_rpc_client,
-    )
-    .await
-    {
-        Ok(_) => {}
-        Err(e) => panic!("Transaction failed: {}", e),
-    };
+    assert_tx_succeeded_accepted(&declaration_result.transaction_hash, &devnet.json_rpc_client)
+        .await
+        .unwrap();
 
     let mut salt = Felt::ONE;
     let legacy_deployment_method = "deployContract";
@@ -168,11 +162,8 @@ async fn test_all_udc_deployment_methods_supported() {
         salt += Felt::ONE; // iI salt not changed, error: contract already deployed
 
         let invoke_result = account.execute_v3(contract_invoke.clone()).send().await.unwrap();
-        match assert_tx_succeeded_accepted(&invoke_result.transaction_hash, &devnet.json_rpc_client)
+        assert_tx_succeeded_accepted(&invoke_result.transaction_hash, &devnet.json_rpc_client)
             .await
-        {
-            Ok(_) => {}
-            Err(e) => panic!("Transaction failed: {}", e),
-        };
+            .unwrap();
     }
 }

--- a/tests/integration/test_dump_and_load.rs
+++ b/tests/integration/test_dump_and_load.rs
@@ -19,7 +19,7 @@ use starknet_rs_core::types::{DeclareTransaction, Felt, InvokeTransaction, Trans
 
 use crate::common::utils::get_events_contract_artifacts;
 
-async fn dump_load_dump_load(mode: &str) {
+async fn dump_load_dump_load(mode: &str) -> Result<(), anyhow::Error> {
     let dump_file =
         UniqueAutoDeletableFile::new(("dump_load_dump_load_on_".to_owned() + mode).as_str());
 
@@ -30,8 +30,7 @@ async fn dump_load_dump_load(mode: &str) {
             "--dump-on",
             mode,
         ])
-        .await
-        .expect("Could not start Devnet");
+        .await?;
 
         devnet_dump.create_block().await.unwrap();
         devnet_dump.mint(DUMMY_ADDRESS, DUMMY_AMOUNT).await;
@@ -45,11 +44,11 @@ async fn dump_load_dump_load(mode: &str) {
         "--dump-on",
         mode,
     ])
-    .await
-    .expect("Could not start Devnet");
+    .await?;
 
-    let last_block = devnet_load.get_latest_block_with_tx_hashes().await.unwrap();
-    assert_eq!(last_block.block_number, 4);
+    let last_block = devnet_load.get_latest_block_with_tx_hashes().await?;
+    anyhow::ensure!(last_block.block_number == 4);
+    Ok(())
 }
 
 #[tokio::test]
@@ -85,12 +84,12 @@ async fn dump_load_dump_load_without_path() {
 
 #[tokio::test]
 async fn dump_load_dump_load_on_exit() {
-    dump_load_dump_load("exit").await;
+    dump_load_dump_load("exit").await.unwrap();
 }
 
 #[tokio::test]
 async fn dump_load_dump_load_on_transaction() {
-    dump_load_dump_load("block").await;
+    dump_load_dump_load("block").await.unwrap();
 }
 
 #[tokio::test]

--- a/tests/integration/test_dump_and_load.rs
+++ b/tests/integration/test_dump_and_load.rs
@@ -4,6 +4,7 @@ use std::time;
 use serde_json::json;
 use starknet_rs_providers::Provider;
 
+use crate::assert_eq_prop;
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants;
 use crate::common::utils::{FeeUnit, UniqueAutoDeletableFile, send_ctrl_c_signal_and_wait};
@@ -47,13 +48,7 @@ async fn dump_load_dump_load(mode: &str) -> Result<(), anyhow::Error> {
     .await?;
 
     let last_block = devnet_load.get_latest_block_with_tx_hashes().await?;
-    anyhow::ensure!(
-        last_block.block_number == 4,
-        format!(
-            "assertion `left == right` failed, left: {}, right: {}",
-            last_block.block_number, 4
-        )
-    );
+    assert_eq_prop!(last_block.block_number, 4)?;
     Ok(())
 }
 

--- a/tests/integration/test_dump_and_load.rs
+++ b/tests/integration/test_dump_and_load.rs
@@ -47,7 +47,13 @@ async fn dump_load_dump_load(mode: &str) -> Result<(), anyhow::Error> {
     .await?;
 
     let last_block = devnet_load.get_latest_block_with_tx_hashes().await?;
-    anyhow::ensure!(last_block.block_number == 4);
+    anyhow::ensure!(
+        last_block.block_number == 4,
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            last_block.block_number, 4
+        )
+    );
     Ok(())
 }
 

--- a/tests/integration/test_estimate_fee.rs
+++ b/tests/integration/test_estimate_fee.rs
@@ -276,16 +276,13 @@ async fn estimate_fee_of_invoke() {
         devnet.json_rpc_client.call(call.clone(), BlockId::Tag(BlockTag::Latest)).await.unwrap();
     assert_eq!(balance_after_insufficient, vec![Felt::ZERO]);
 
-    match assert_tx_reverted(
+    assert_tx_reverted(
         &unsuccessful_invoke_tx.transaction_hash,
         &devnet.json_rpc_client,
         &["Insufficient max L2Gas"],
     )
     .await
-    {
-        Ok(_) => {}
-        Err(e) => panic!("Transaction not reverted: {:?}", e),
-    };
+    .unwrap();
 
     // invoke with sufficient resource bounds
     let fee = LocalFee::from(fee_estimation);

--- a/tests/integration/test_estimate_fee.rs
+++ b/tests/integration/test_estimate_fee.rs
@@ -288,12 +288,16 @@ async fn estimate_fee_of_invoke() {
         devnet.json_rpc_client.call(call.clone(), BlockId::Tag(BlockTag::Latest)).await.unwrap();
     assert_eq!(balance_after_insufficient, vec![Felt::ZERO]);
 
-    assert_tx_reverted(
+    match assert_tx_reverted(
         &unsuccessful_invoke_tx.transaction_hash,
         &devnet.json_rpc_client,
         &["Insufficient max L2Gas"],
     )
-    .await;
+    .await
+    {
+        Ok(_) => {}
+        Err(e) => panic!("Transaction not reverted: {:?}", e),
+    };
 
     // invoke with sufficient resource bounds
     let fee = LocalFee::from(fee_estimation);

--- a/tests/integration/test_estimate_fee.rs
+++ b/tests/integration/test_estimate_fee.rs
@@ -379,7 +379,7 @@ async fn message_available_if_estimation_reverts() {
             let account_error = extract_nested_error(&execution_error);
             let contract_error = extract_nested_error(&account_error.error);
             let inner_error = extract_nested_error(&contract_error.error);
-            let error_msg = extract_message_error(&inner_error.error);
+            let error_msg = extract_message_error(&inner_error.error).unwrap();
             assert_contains(error_msg, &panic_reason.to_hex_string()).unwrap();
         }
         other => panic!("Invalid err: {other:?}"),

--- a/tests/integration/test_estimate_fee.rs
+++ b/tests/integration/test_estimate_fee.rs
@@ -376,9 +376,9 @@ async fn message_available_if_estimation_reverts() {
                 ..
             }),
         )) => {
-            let account_error = extract_nested_error(&execution_error);
-            let contract_error = extract_nested_error(&account_error.error);
-            let inner_error = extract_nested_error(&contract_error.error);
+            let account_error = extract_nested_error(&execution_error).unwrap();
+            let contract_error = extract_nested_error(&account_error.error).unwrap();
+            let inner_error = extract_nested_error(&contract_error.error).unwrap();
             let error_msg = extract_message_error(&inner_error.error).unwrap();
             assert_contains(error_msg, &panic_reason.to_hex_string()).unwrap();
         }

--- a/tests/integration/test_estimate_fee.rs
+++ b/tests/integration/test_estimate_fee.rs
@@ -98,8 +98,15 @@ async fn estimate_fee_of_deploy_account() {
         .send()
         .await
         .expect("Should deploy with sufficient fee");
-    assert_tx_succeeded_accepted(&successful_deployment.transaction_hash, &devnet.json_rpc_client)
-        .await;
+    match assert_tx_succeeded_accepted(
+        &successful_deployment.transaction_hash,
+        &devnet.json_rpc_client,
+    )
+    .await
+    {
+        Ok(_) => {}
+        Err(e) => panic!("Transaction failed: {}", e),
+    };
 }
 
 #[tokio::test]
@@ -199,8 +206,15 @@ async fn estimate_fee_of_declare_v3() {
         .send()
         .await
         .unwrap();
-    assert_tx_succeeded_accepted(&successful_declare_tx.transaction_hash, &devnet.json_rpc_client)
-        .await;
+    match assert_tx_succeeded_accepted(
+        &successful_declare_tx.transaction_hash,
+        &devnet.json_rpc_client,
+    )
+    .await
+    {
+        Ok(_) => {}
+        Err(e) => panic!("Transaction failed: {}", e),
+    };
 }
 
 #[tokio::test]

--- a/tests/integration/test_estimate_fee.rs
+++ b/tests/integration/test_estimate_fee.rs
@@ -136,7 +136,8 @@ async fn estimate_fee_of_invalid_deploy_account() {
                     "Class with hash {} is not declared.",
                     invalid_class_hash.to_fixed_hex_string()
                 ),
-            );
+            )
+            .unwrap();
         }
         other => panic!("Unexpected response: {other:?}"),
     }
@@ -375,7 +376,7 @@ async fn message_available_if_estimation_reverts() {
             let contract_error = extract_nested_error(&account_error.error);
             let inner_error = extract_nested_error(&contract_error.error);
             let error_msg = extract_message_error(&inner_error.error);
-            assert_contains(error_msg, &panic_reason.to_hex_string());
+            assert_contains(error_msg, &panic_reason.to_hex_string()).unwrap();
         }
         other => panic!("Invalid err: {other:?}"),
     };
@@ -645,7 +646,8 @@ async fn estimate_fee_of_multiple_txs_with_second_failing() {
             assert_contains(
                 &format!("{:?}", execution_error),
                 &ENTRYPOINT_NOT_FOUND_ERROR_ENCODED.to_hex_string(),
-            );
+            )
+            .unwrap();
         }
         _ => panic!("Unexpected error: {err}"),
     };
@@ -739,7 +741,7 @@ async fn estimate_fee_of_multiple_failing_txs_should_return_index_of_the_first_f
             TransactionExecutionErrorData { transaction_index, execution_error },
         )) => {
             assert_eq!(transaction_index, 0);
-            assert_contains(&format!("{:?}", execution_error), "invalid signature");
+            assert_contains(&format!("{:?}", execution_error), "invalid signature").unwrap();
         }
         other => panic!("Unexpected error: {:?}", other),
     }

--- a/tests/integration/test_estimate_fee.rs
+++ b/tests/integration/test_estimate_fee.rs
@@ -98,15 +98,9 @@ async fn estimate_fee_of_deploy_account() {
         .send()
         .await
         .expect("Should deploy with sufficient fee");
-    match assert_tx_succeeded_accepted(
-        &successful_deployment.transaction_hash,
-        &devnet.json_rpc_client,
-    )
-    .await
-    {
-        Ok(_) => {}
-        Err(e) => panic!("Transaction failed: {}", e),
-    };
+    assert_tx_succeeded_accepted(&successful_deployment.transaction_hash, &devnet.json_rpc_client)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -207,15 +201,9 @@ async fn estimate_fee_of_declare_v3() {
         .send()
         .await
         .unwrap();
-    match assert_tx_succeeded_accepted(
-        &successful_declare_tx.transaction_hash,
-        &devnet.json_rpc_client,
-    )
-    .await
-    {
-        Ok(_) => {}
-        Err(e) => panic!("Transaction failed: {}", e),
-    };
+    assert_tx_succeeded_accepted(&successful_declare_tx.transaction_hash, &devnet.json_rpc_client)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]

--- a/tests/integration/test_fork.rs
+++ b/tests/integration/test_fork.rs
@@ -585,9 +585,11 @@ async fn test_fork_if_origin_dies() {
             assert_contains(
                 &received_error.message,
                 "Failed to read from state: Error in communication with forking origin",
-            );
-            assert_contains(&received_error.message, "Connection refused");
-            assert_contains(&received_error.message, &format!("url: \"{}/\"", origin_devnet.url));
+            )
+            .unwrap();
+            assert_contains(&received_error.message, "Connection refused").unwrap();
+            assert_contains(&received_error.message, &format!("url: \"{}/\"", origin_devnet.url))
+                .unwrap();
             assert_eq!(received_error.data, None);
         }
         unexpected => panic!("Got unexpected resp: {unexpected:?}"),

--- a/tests/integration/test_fork.rs
+++ b/tests/integration/test_fork.rs
@@ -260,11 +260,12 @@ async fn test_origin_declare_deploy_fork_invoke() {
     );
 
     // assert correctly deployed
-    assert_eq!(get_contract_balance(&origin_devnet, contract_address).await, initial_value);
+    let origin_balance = get_contract_balance(&origin_devnet, contract_address).await.unwrap();
+    assert_eq!(origin_balance, initial_value);
 
     let fork_devnet = origin_devnet.fork().await.unwrap();
-
-    assert_eq!(get_contract_balance(&fork_devnet, contract_address).await, initial_value);
+    let fork_balance = get_contract_balance(&fork_devnet, contract_address).await.unwrap();
+    assert_eq!(fork_balance, initial_value);
 
     let fork_predeployed_account = SingleOwnerAccount::new(
         fork_devnet.clone_provider(),
@@ -302,11 +303,10 @@ async fn test_origin_declare_deploy_fork_invoke() {
     };
 
     // assert origin intact and fork changed
-    assert_eq!(get_contract_balance(&origin_devnet, contract_address).await, initial_value);
-    assert_eq!(
-        get_contract_balance(&fork_devnet, contract_address).await,
-        initial_value + increment
-    );
+    let origin_balance = get_contract_balance(&origin_devnet, contract_address).await.unwrap();
+    assert_eq!(origin_balance, initial_value);
+    let fork_balance = get_contract_balance(&fork_devnet, contract_address).await.unwrap();
+    assert_eq!(fork_balance, initial_value + increment);
 }
 
 #[tokio::test]
@@ -550,11 +550,11 @@ async fn changes_in_origin_after_forking_block_should_not_affect_fork_state() {
     .unwrap();
 
     // Assert fork intact and origin changed
-    assert_eq!(get_contract_balance(&fork_devnet, contract_address).await, initial_value);
-    assert_eq!(
-        get_contract_balance(&origin_devnet, contract_address).await,
-        initial_value + increment_value
-    );
+    let fork_balance = get_contract_balance(&fork_devnet, contract_address).await.unwrap();
+    assert_eq!(fork_balance, initial_value);
+
+    let origin_balance = get_contract_balance(&origin_devnet, contract_address).await.unwrap();
+    assert_eq!(origin_balance, initial_value + increment_value);
 }
 
 #[tokio::test]

--- a/tests/integration/test_fork.rs
+++ b/tests/integration/test_fork.rs
@@ -292,15 +292,9 @@ async fn test_origin_declare_deploy_fork_invoke() {
         .await
         .unwrap();
 
-    match assert_tx_succeeded_accepted(
-        &invoke_result.transaction_hash,
-        &fork_devnet.json_rpc_client,
-    )
-    .await
-    {
-        Ok(_) => {}
-        Err(e) => panic!("Transaction failed: {}", e),
-    };
+    assert_tx_succeeded_accepted(&invoke_result.transaction_hash, &fork_devnet.json_rpc_client)
+        .await
+        .unwrap();
 
     // assert origin intact and fork changed
     let origin_balance = get_contract_balance(&origin_devnet, contract_address).await.unwrap();
@@ -526,15 +520,9 @@ async fn changes_in_origin_after_forking_block_should_not_affect_fork_state() {
         .await
         .unwrap();
 
-    match assert_tx_succeeded_accepted(
-        &invoke_result.transaction_hash,
-        &origin_devnet.json_rpc_client,
-    )
-    .await
-    {
-        Ok(_) => (),
-        Err(e) => panic!("Transaction failed: {}", e),
-    }
+    assert_tx_succeeded_accepted(&invoke_result.transaction_hash, &origin_devnet.json_rpc_client)
+        .await
+        .unwrap();
 
     let latest_origin_block_number = origin_devnet.json_rpc_client.block_number().await.unwrap();
     assert_eq!(latest_origin_block_number, 3); // declare, deploy, invoke

--- a/tests/integration/test_fork.rs
+++ b/tests/integration/test_fork.rs
@@ -291,8 +291,15 @@ async fn test_origin_declare_deploy_fork_invoke() {
         .await
         .unwrap();
 
-    assert_tx_succeeded_accepted(&invoke_result.transaction_hash, &fork_devnet.json_rpc_client)
-        .await;
+    match assert_tx_succeeded_accepted(
+        &invoke_result.transaction_hash,
+        &fork_devnet.json_rpc_client,
+    )
+    .await
+    {
+        Ok(_) => {}
+        Err(e) => panic!("Transaction failed: {}", e),
+    };
 
     // assert origin intact and fork changed
     assert_eq!(get_contract_balance(&origin_devnet, contract_address).await, initial_value);
@@ -519,8 +526,16 @@ async fn changes_in_origin_after_forking_block_should_not_affect_fork_state() {
         .await
         .unwrap();
 
-    assert_tx_succeeded_accepted(&invoke_result.transaction_hash, &origin_devnet.json_rpc_client)
-        .await;
+    match assert_tx_succeeded_accepted(
+        &invoke_result.transaction_hash,
+        &origin_devnet.json_rpc_client,
+    )
+    .await
+    {
+        Ok(_) => (),
+        Err(e) => panic!("Transaction failed: {}", e),
+    }
+
     let latest_origin_block_number = origin_devnet.json_rpc_client.block_number().await.unwrap();
     assert_eq!(latest_origin_block_number, 3); // declare, deploy, invoke
 

--- a/tests/integration/test_gas_modification.rs
+++ b/tests/integration/test_gas_modification.rs
@@ -406,15 +406,9 @@ async fn unsuccessful_declare_set_gas_successful_declare() {
         .send()
         .await
         .unwrap();
-    match assert_tx_succeeded_accepted(
-        &successful_declare_tx.transaction_hash,
-        &devnet.json_rpc_client,
-    )
-    .await
-    {
-        Ok(_) => (),
-        Err(e) => panic!("Transaction failed: {}", e),
-    }
+    assert_tx_succeeded_accepted(&successful_declare_tx.transaction_hash, &devnet.json_rpc_client)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]

--- a/tests/integration/test_gas_modification.rs
+++ b/tests/integration/test_gas_modification.rs
@@ -406,8 +406,15 @@ async fn unsuccessful_declare_set_gas_successful_declare() {
         .send()
         .await
         .unwrap();
-    assert_tx_succeeded_accepted(&successful_declare_tx.transaction_hash, &devnet.json_rpc_client)
-        .await;
+    match assert_tx_succeeded_accepted(
+        &successful_declare_tx.transaction_hash,
+        &devnet.json_rpc_client,
+    )
+    .await
+    {
+        Ok(_) => (),
+        Err(e) => panic!("Transaction failed: {}", e),
+    }
 }
 
 #[tokio::test]

--- a/tests/integration/test_gas_modification.rs
+++ b/tests/integration/test_gas_modification.rs
@@ -117,7 +117,12 @@ async fn set_gas_scenario(
     };
 
     let chain_id = devnet.json_rpc_client.chain_id().await?;
-    anyhow::ensure!(chain_id == expected_chain_id, "Chain ID mismatch");
+    anyhow::ensure!(
+        chain_id == expected_chain_id,
+        format!(
+            "Chain ID mismatch: assertion `left == right` failed, left: {chain_id}, right: {expected_chain_id}"
+        )
+    );
 
     let params_skip_fee_charge = get_params(&["SKIP_FEE_CHARGE"]);
     let resp_no_flags = &devnet
@@ -126,18 +131,45 @@ async fn set_gas_scenario(
         .map_err(|err| anyhow::anyhow!("failed to simulate transactions {:?}", err))?[0];
     anyhow::ensure!(
         resp_no_flags["fee_estimation"]["l1_gas_price"]
-            == to_hex_felt(&DEVNET_DEFAULT_L1_GAS_PRICE)
+            == to_hex_felt(&DEVNET_DEFAULT_L1_GAS_PRICE),
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            resp_no_flags["fee_estimation"]["l1_gas_price"],
+            to_hex_felt(&DEVNET_DEFAULT_L1_GAS_PRICE)
+        )
     );
     anyhow::ensure!(
         resp_no_flags["fee_estimation"]["l1_data_gas_price"]
-            == to_hex_felt(&DEVNET_DEFAULT_L1_DATA_GAS_PRICE)
+            == to_hex_felt(&DEVNET_DEFAULT_L1_DATA_GAS_PRICE),
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            resp_no_flags["fee_estimation"]["l1_data_gas_price"],
+            to_hex_felt(&DEVNET_DEFAULT_L1_DATA_GAS_PRICE)
+        )
     );
     anyhow::ensure!(
         resp_no_flags["fee_estimation"]["l2_gas_price"]
-            == to_hex_felt(&DEVNET_DEFAULT_L2_GAS_PRICE)
+            == to_hex_felt(&DEVNET_DEFAULT_L2_GAS_PRICE),
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            resp_no_flags["fee_estimation"]["l2_gas_price"],
+            to_hex_felt(&DEVNET_DEFAULT_L2_GAS_PRICE)
+        )
     );
-    anyhow::ensure!(resp_no_flags["transaction_trace"]["execution_resources"]["l1_gas"] == 0);
-    anyhow::ensure!(resp_no_flags["fee_estimation"]["overall_fee"] == "0x99cb411f968000");
+    anyhow::ensure!(
+        resp_no_flags["transaction_trace"]["execution_resources"]["l1_gas"] == 0,
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            resp_no_flags["transaction_trace"]["execution_resources"]["l1_gas"], 0
+        )
+    );
+    anyhow::ensure!(
+        resp_no_flags["fee_estimation"]["overall_fee"] == "0x99cb411f968000",
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            resp_no_flags["fee_estimation"]["overall_fee"], "0x99cb411f968000"
+        )
+    );
 
     let params_skip_validation_and_fee_charge = get_params(&["SKIP_VALIDATE", "SKIP_FEE_CHARGE"]);
     let resp_skip_validation = &devnet
@@ -150,18 +182,45 @@ async fn set_gas_scenario(
 
     anyhow::ensure!(
         resp_skip_validation["fee_estimation"]["l1_gas_price"]
-            == to_hex_felt(&DEVNET_DEFAULT_L1_GAS_PRICE)
+            == to_hex_felt(&DEVNET_DEFAULT_L1_GAS_PRICE),
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            resp_skip_validation["fee_estimation"]["l1_gas_price"],
+            to_hex_felt(&DEVNET_DEFAULT_L1_GAS_PRICE)
+        )
     );
     anyhow::ensure!(
         resp_skip_validation["fee_estimation"]["l1_data_gas_price"]
-            == to_hex_felt(&DEVNET_DEFAULT_L1_DATA_GAS_PRICE)
+            == to_hex_felt(&DEVNET_DEFAULT_L1_DATA_GAS_PRICE),
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            resp_skip_validation["fee_estimation"]["l1_data_gas_price"],
+            to_hex_felt(&DEVNET_DEFAULT_L1_DATA_GAS_PRICE)
+        )
     );
     anyhow::ensure!(
         resp_skip_validation["fee_estimation"]["l2_gas_price"]
-            == to_hex_felt(&DEVNET_DEFAULT_L2_GAS_PRICE)
+            == to_hex_felt(&DEVNET_DEFAULT_L2_GAS_PRICE),
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            resp_skip_validation["fee_estimation"]["l2_gas_price"],
+            to_hex_felt(&DEVNET_DEFAULT_L2_GAS_PRICE)
+        )
     );
-    anyhow::ensure!(resp_no_flags["transaction_trace"]["execution_resources"]["l1_gas"] == 0);
-    anyhow::ensure!(resp_skip_validation["fee_estimation"]["overall_fee"] == "0x995e1d72370000");
+    anyhow::ensure!(
+        resp_no_flags["transaction_trace"]["execution_resources"]["l1_gas"] == 0,
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            resp_no_flags["transaction_trace"]["execution_resources"]["l1_gas"], 0
+        )
+    );
+    anyhow::ensure!(
+        resp_skip_validation["fee_estimation"]["overall_fee"] == "0x995e1d72370000",
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            resp_skip_validation["fee_estimation"]["overall_fee"], "0x995e1d72370000"
+        )
+    );
 
     let should_skip_fee_invocation = true;
     assert_difference_if_validation(
@@ -184,36 +243,86 @@ async fn set_gas_scenario(
     });
     let gas_response = &devnet.set_gas_price(&gas_request, true).await?;
 
-    anyhow::ensure!(gas_response == &gas_request);
+    anyhow::ensure!(
+        gas_response == &gas_request,
+        format!("assertion `left == right` failed, left: {gas_response}, right: {}", &gas_request)
+    );
 
     let chain_id = devnet.json_rpc_client.chain_id().await?;
-    anyhow::ensure!(chain_id == expected_chain_id);
+    anyhow::ensure!(
+        chain_id == expected_chain_id,
+        format!("assertion `left == right` failed, left: {chain_id}, right: {expected_chain_id}")
+    );
 
     let resp_no_flags =
         &devnet.send_custom_rpc("starknet_simulateTransactions", params_skip_fee_charge).await?[0];
 
-    anyhow::ensure!(resp_no_flags["fee_estimation"]["l1_gas_price"] == to_hex_felt(&l1_fri_price));
     anyhow::ensure!(
-        resp_no_flags["fee_estimation"]["l1_data_gas_price"] == to_hex_felt(&l1_data_fri_price)
+        resp_no_flags["fee_estimation"]["l1_gas_price"] == to_hex_felt(&l1_fri_price),
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            resp_no_flags["fee_estimation"]["l1_gas_price"],
+            to_hex_felt(&l1_fri_price)
+        )
     );
-    anyhow::ensure!(resp_no_flags["fee_estimation"]["l2_gas_price"] == to_hex_felt(&l2_fri_price));
-    anyhow::ensure!(resp_no_flags["fee_estimation"]["overall_fee"] == "0xe8c077047881faf1800000");
+    anyhow::ensure!(
+        resp_no_flags["fee_estimation"]["l1_data_gas_price"] == to_hex_felt(&l1_data_fri_price),
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            resp_no_flags["fee_estimation"]["l1_data_gas_price"],
+            to_hex_felt(&l1_data_fri_price)
+        )
+    );
+    anyhow::ensure!(
+        resp_no_flags["fee_estimation"]["l2_gas_price"] == to_hex_felt(&l2_fri_price),
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            resp_no_flags["fee_estimation"]["l2_gas_price"],
+            to_hex_felt(&l2_fri_price)
+        )
+    );
+    anyhow::ensure!(
+        resp_no_flags["fee_estimation"]["overall_fee"] == "0xe8c077047881faf1800000",
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            resp_no_flags["fee_estimation"]["overall_fee"], "0xe8c077047881faf1800000"
+        )
+    );
 
     let resp_skip_validation = &devnet
         .send_custom_rpc("starknet_simulateTransactions", params_skip_validation_and_fee_charge)
         .await?[0];
     anyhow::ensure!(
-        resp_skip_validation["fee_estimation"]["l1_gas_price"] == to_hex_felt(&l1_fri_price)
+        resp_skip_validation["fee_estimation"]["l1_gas_price"] == to_hex_felt(&l1_fri_price),
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            resp_skip_validation["fee_estimation"]["l1_gas_price"],
+            to_hex_felt(&l1_fri_price)
+        )
     );
     anyhow::ensure!(
         resp_skip_validation["fee_estimation"]["l1_data_gas_price"]
-            == to_hex_felt(&l1_data_fri_price)
+            == to_hex_felt(&l1_data_fri_price),
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            resp_skip_validation["fee_estimation"]["l1_data_gas_price"],
+            to_hex_felt(&l1_data_fri_price)
+        )
     );
     anyhow::ensure!(
-        resp_skip_validation["fee_estimation"]["l2_gas_price"] == to_hex_felt(&l2_fri_price)
+        resp_skip_validation["fee_estimation"]["l2_gas_price"] == to_hex_felt(&l2_fri_price),
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            resp_skip_validation["fee_estimation"]["l2_gas_price"],
+            to_hex_felt(&l2_fri_price)
+        )
     );
     anyhow::ensure!(
-        resp_skip_validation["fee_estimation"]["overall_fee"] == "0xe81b4b21fb0b18a2000000"
+        resp_skip_validation["fee_estimation"]["overall_fee"] == "0xe81b4b21fb0b18a2000000",
+        format!(
+            "assertion `left == right` failed, left: {}, right: {}",
+            resp_skip_validation["fee_estimation"]["overall_fee"], "0xe81b4b21fb0b18a2000000"
+        )
     );
 
     assert_difference_if_validation(

--- a/tests/integration/test_gas_modification.rs
+++ b/tests/integration/test_gas_modification.rs
@@ -11,6 +11,7 @@ use starknet_rs_core::utils::cairo_short_string_to_felt;
 use starknet_rs_providers::{Provider, ProviderError};
 use starknet_rs_signers::Signer;
 
+use crate::assert_eq_prop;
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants::{
     self, CAIRO_1_CONTRACT_PATH, INTEGRATION_SAFE_BLOCK, INTEGRATION_SEPOLIA_HTTP_URL,
@@ -117,59 +118,27 @@ async fn set_gas_scenario(
     };
 
     let chain_id = devnet.json_rpc_client.chain_id().await?;
-    anyhow::ensure!(
-        chain_id == expected_chain_id,
-        format!(
-            "Chain ID mismatch: assertion `left == right` failed, left: {chain_id}, right: {expected_chain_id}"
-        )
-    );
+    assert_eq_prop!(chain_id, expected_chain_id)?;
 
     let params_skip_fee_charge = get_params(&["SKIP_FEE_CHARGE"]);
     let resp_no_flags = &devnet
         .send_custom_rpc("starknet_simulateTransactions", params_skip_fee_charge.clone())
         .await
         .map_err(|err| anyhow::anyhow!("failed to simulate transactions {:?}", err))?[0];
-    anyhow::ensure!(
-        resp_no_flags["fee_estimation"]["l1_gas_price"]
-            == to_hex_felt(&DEVNET_DEFAULT_L1_GAS_PRICE),
-        format!(
-            "assertion `left == right` failed, left: {}, right: {}",
-            resp_no_flags["fee_estimation"]["l1_gas_price"],
-            to_hex_felt(&DEVNET_DEFAULT_L1_GAS_PRICE)
-        )
-    );
-    anyhow::ensure!(
-        resp_no_flags["fee_estimation"]["l1_data_gas_price"]
-            == to_hex_felt(&DEVNET_DEFAULT_L1_DATA_GAS_PRICE),
-        format!(
-            "assertion `left == right` failed, left: {}, right: {}",
-            resp_no_flags["fee_estimation"]["l1_data_gas_price"],
-            to_hex_felt(&DEVNET_DEFAULT_L1_DATA_GAS_PRICE)
-        )
-    );
-    anyhow::ensure!(
-        resp_no_flags["fee_estimation"]["l2_gas_price"]
-            == to_hex_felt(&DEVNET_DEFAULT_L2_GAS_PRICE),
-        format!(
-            "assertion `left == right` failed, left: {}, right: {}",
-            resp_no_flags["fee_estimation"]["l2_gas_price"],
-            to_hex_felt(&DEVNET_DEFAULT_L2_GAS_PRICE)
-        )
-    );
-    anyhow::ensure!(
-        resp_no_flags["transaction_trace"]["execution_resources"]["l1_gas"] == 0,
-        format!(
-            "assertion `left == right` failed, left: {}, right: {}",
-            resp_no_flags["transaction_trace"]["execution_resources"]["l1_gas"], 0
-        )
-    );
-    anyhow::ensure!(
-        resp_no_flags["fee_estimation"]["overall_fee"] == "0x99cb411f968000",
-        format!(
-            "assertion `left == right` failed, left: {}, right: {}",
-            resp_no_flags["fee_estimation"]["overall_fee"], "0x99cb411f968000"
-        )
-    );
+    assert_eq_prop!(
+        resp_no_flags["fee_estimation"]["l1_gas_price"],
+        to_hex_felt(&DEVNET_DEFAULT_L1_GAS_PRICE)
+    )?;
+    assert_eq_prop!(
+        resp_no_flags["fee_estimation"]["l1_data_gas_price"],
+        to_hex_felt(&DEVNET_DEFAULT_L1_DATA_GAS_PRICE)
+    )?;
+    assert_eq_prop!(
+        resp_no_flags["fee_estimation"]["l2_gas_price"],
+        to_hex_felt(&DEVNET_DEFAULT_L2_GAS_PRICE)
+    )?;
+    assert_eq_prop!(resp_no_flags["transaction_trace"]["execution_resources"]["l1_gas"], 0)?;
+    assert_eq_prop!(resp_no_flags["fee_estimation"]["overall_fee"], "0x99cb411f968000")?;
 
     let params_skip_validation_and_fee_charge = get_params(&["SKIP_VALIDATE", "SKIP_FEE_CHARGE"]);
     let resp_skip_validation = &devnet
@@ -180,47 +149,20 @@ async fn set_gas_scenario(
         .await
         .map_err(|err| anyhow::anyhow!("failed to simulate transactions {:?}", err))?[0];
 
-    anyhow::ensure!(
-        resp_skip_validation["fee_estimation"]["l1_gas_price"]
-            == to_hex_felt(&DEVNET_DEFAULT_L1_GAS_PRICE),
-        format!(
-            "assertion `left == right` failed, left: {}, right: {}",
-            resp_skip_validation["fee_estimation"]["l1_gas_price"],
-            to_hex_felt(&DEVNET_DEFAULT_L1_GAS_PRICE)
-        )
-    );
-    anyhow::ensure!(
-        resp_skip_validation["fee_estimation"]["l1_data_gas_price"]
-            == to_hex_felt(&DEVNET_DEFAULT_L1_DATA_GAS_PRICE),
-        format!(
-            "assertion `left == right` failed, left: {}, right: {}",
-            resp_skip_validation["fee_estimation"]["l1_data_gas_price"],
-            to_hex_felt(&DEVNET_DEFAULT_L1_DATA_GAS_PRICE)
-        )
-    );
-    anyhow::ensure!(
-        resp_skip_validation["fee_estimation"]["l2_gas_price"]
-            == to_hex_felt(&DEVNET_DEFAULT_L2_GAS_PRICE),
-        format!(
-            "assertion `left == right` failed, left: {}, right: {}",
-            resp_skip_validation["fee_estimation"]["l2_gas_price"],
-            to_hex_felt(&DEVNET_DEFAULT_L2_GAS_PRICE)
-        )
-    );
-    anyhow::ensure!(
-        resp_no_flags["transaction_trace"]["execution_resources"]["l1_gas"] == 0,
-        format!(
-            "assertion `left == right` failed, left: {}, right: {}",
-            resp_no_flags["transaction_trace"]["execution_resources"]["l1_gas"], 0
-        )
-    );
-    anyhow::ensure!(
-        resp_skip_validation["fee_estimation"]["overall_fee"] == "0x995e1d72370000",
-        format!(
-            "assertion `left == right` failed, left: {}, right: {}",
-            resp_skip_validation["fee_estimation"]["overall_fee"], "0x995e1d72370000"
-        )
-    );
+    assert_eq_prop!(
+        resp_skip_validation["fee_estimation"]["l1_gas_price"],
+        to_hex_felt(&DEVNET_DEFAULT_L1_GAS_PRICE)
+    )?;
+    assert_eq_prop!(
+        resp_skip_validation["fee_estimation"]["l1_data_gas_price"],
+        to_hex_felt(&DEVNET_DEFAULT_L1_DATA_GAS_PRICE)
+    )?;
+    assert_eq_prop!(
+        resp_skip_validation["fee_estimation"]["l2_gas_price"],
+        to_hex_felt(&DEVNET_DEFAULT_L2_GAS_PRICE)
+    )?;
+    assert_eq_prop!(resp_no_flags["transaction_trace"]["execution_resources"]["l1_gas"], 0)?;
+    assert_eq_prop!(resp_skip_validation["fee_estimation"]["overall_fee"], "0x995e1d72370000")?;
 
     let should_skip_fee_invocation = true;
     assert_difference_if_validation(
@@ -243,87 +185,41 @@ async fn set_gas_scenario(
     });
     let gas_response = &devnet.set_gas_price(&gas_request, true).await?;
 
-    anyhow::ensure!(
-        gas_response == &gas_request,
-        format!("assertion `left == right` failed, left: {gas_response}, right: {}", &gas_request)
-    );
+    assert_eq_prop!(gas_response, &gas_request)?;
 
     let chain_id = devnet.json_rpc_client.chain_id().await?;
-    anyhow::ensure!(
-        chain_id == expected_chain_id,
-        format!("assertion `left == right` failed, left: {chain_id}, right: {expected_chain_id}")
-    );
+    assert_eq_prop!(chain_id, expected_chain_id)?;
 
     let resp_no_flags =
         &devnet.send_custom_rpc("starknet_simulateTransactions", params_skip_fee_charge).await?[0];
 
-    anyhow::ensure!(
-        resp_no_flags["fee_estimation"]["l1_gas_price"] == to_hex_felt(&l1_fri_price),
-        format!(
-            "assertion `left == right` failed, left: {}, right: {}",
-            resp_no_flags["fee_estimation"]["l1_gas_price"],
-            to_hex_felt(&l1_fri_price)
-        )
-    );
-    anyhow::ensure!(
-        resp_no_flags["fee_estimation"]["l1_data_gas_price"] == to_hex_felt(&l1_data_fri_price),
-        format!(
-            "assertion `left == right` failed, left: {}, right: {}",
-            resp_no_flags["fee_estimation"]["l1_data_gas_price"],
-            to_hex_felt(&l1_data_fri_price)
-        )
-    );
-    anyhow::ensure!(
-        resp_no_flags["fee_estimation"]["l2_gas_price"] == to_hex_felt(&l2_fri_price),
-        format!(
-            "assertion `left == right` failed, left: {}, right: {}",
-            resp_no_flags["fee_estimation"]["l2_gas_price"],
-            to_hex_felt(&l2_fri_price)
-        )
-    );
-    anyhow::ensure!(
-        resp_no_flags["fee_estimation"]["overall_fee"] == "0xe8c077047881faf1800000",
-        format!(
-            "assertion `left == right` failed, left: {}, right: {}",
-            resp_no_flags["fee_estimation"]["overall_fee"], "0xe8c077047881faf1800000"
-        )
-    );
+    assert_eq_prop!(resp_no_flags["fee_estimation"]["l1_gas_price"], to_hex_felt(&l1_fri_price))?;
+    assert_eq_prop!(
+        resp_no_flags["fee_estimation"]["l1_data_gas_price"],
+        to_hex_felt(&l1_data_fri_price)
+    )?;
+    assert_eq_prop!(resp_no_flags["fee_estimation"]["l2_gas_price"], to_hex_felt(&l2_fri_price))?;
+    assert_eq_prop!(resp_no_flags["fee_estimation"]["overall_fee"], "0xe8c077047881faf1800000")?;
 
     let resp_skip_validation = &devnet
         .send_custom_rpc("starknet_simulateTransactions", params_skip_validation_and_fee_charge)
         .await?[0];
-    anyhow::ensure!(
-        resp_skip_validation["fee_estimation"]["l1_gas_price"] == to_hex_felt(&l1_fri_price),
-        format!(
-            "assertion `left == right` failed, left: {}, right: {}",
-            resp_skip_validation["fee_estimation"]["l1_gas_price"],
-            to_hex_felt(&l1_fri_price)
-        )
-    );
-    anyhow::ensure!(
-        resp_skip_validation["fee_estimation"]["l1_data_gas_price"]
-            == to_hex_felt(&l1_data_fri_price),
-        format!(
-            "assertion `left == right` failed, left: {}, right: {}",
-            resp_skip_validation["fee_estimation"]["l1_data_gas_price"],
-            to_hex_felt(&l1_data_fri_price)
-        )
-    );
-    anyhow::ensure!(
-        resp_skip_validation["fee_estimation"]["l2_gas_price"] == to_hex_felt(&l2_fri_price),
-        format!(
-            "assertion `left == right` failed, left: {}, right: {}",
-            resp_skip_validation["fee_estimation"]["l2_gas_price"],
-            to_hex_felt(&l2_fri_price)
-        )
-    );
-    anyhow::ensure!(
-        resp_skip_validation["fee_estimation"]["overall_fee"] == "0xe81b4b21fb0b18a2000000",
-        format!(
-            "assertion `left == right` failed, left: {}, right: {}",
-            resp_skip_validation["fee_estimation"]["overall_fee"], "0xe81b4b21fb0b18a2000000"
-        )
-    );
+    assert_eq_prop!(
+        resp_skip_validation["fee_estimation"]["l1_gas_price"],
+        to_hex_felt(&l1_fri_price)
+    )?;
+    assert_eq_prop!(
+        resp_skip_validation["fee_estimation"]["l1_data_gas_price"],
+        to_hex_felt(&l1_data_fri_price)
+    )?;
+    assert_eq_prop!(
+        resp_skip_validation["fee_estimation"]["l2_gas_price"],
+        to_hex_felt(&l2_fri_price)
+    )?;
+    assert_eq_prop!(
+        resp_skip_validation["fee_estimation"]["overall_fee"],
+        "0xe81b4b21fb0b18a2000000"
+    )?;
 
     assert_difference_if_validation(
         resp_no_flags,

--- a/tests/integration/test_messaging.rs
+++ b/tests/integration/test_messaging.rs
@@ -440,7 +440,7 @@ async fn setup_anvil_incorrect_eth_private_key() {
         .send_custom_rpc("devnet_postmanLoad", json!({ "network_url": anvil.url }))
         .await
         .unwrap_err();
-    assert_contains(&body.message, "CallGasCostMoreThanGasLimit");
+    assert_contains(&body.message, "CallGasCostMoreThanGasLimit").unwrap();
 
     let body = devnet
         .send_custom_rpc(
@@ -452,7 +452,7 @@ async fn setup_anvil_incorrect_eth_private_key() {
         )
         .await
         .unwrap_err();
-    assert_contains(&body.message, "CallGasCostMoreThanGasLimit");
+    assert_contains(&body.message, "CallGasCostMoreThanGasLimit").unwrap();
 }
 
 #[tokio::test]
@@ -765,8 +765,8 @@ async fn test_dumpability_of_messaging_contract_loading() {
     send_ctrl_c_signal_and_wait(&anvil.process).await;
     match devnet.send_custom_rpc("devnet_load", json!({ "path": dump_file.path })).await {
         Err(RpcError { message, .. }) => {
-            assert_contains(&message, "error sending request for url");
-            assert_contains(&message, &anvil.url);
+            assert_contains(&message, "error sending request for url").unwrap();
+            assert_contains(&message, &anvil.url).unwrap();
         }
         other => panic!("Unexpected response: {other:?}"),
     };
@@ -1040,7 +1040,7 @@ async fn withdrawing_should_incur_l1_gas_cost() {
         TransactionReceipt::Invoke(InvokeTransactionReceipt {
             execution_result: ExecutionResult::Reverted { reason },
             ..
-        }) => assert_contains(&reason, "Insufficient max L1Gas"),
+        }) => assert_contains(&reason, "Insufficient max L1Gas").unwrap(),
         other => panic!("Unexpected receipt: {other:?}"),
     }
 }

--- a/tests/integration/test_messaging.rs
+++ b/tests/integration/test_messaging.rs
@@ -303,10 +303,7 @@ async fn mock_message_to_l2_creates_a_tx_with_desired_effect() {
         .await.unwrap();
     let tx_hash_hex = body.get("transaction_hash").unwrap().as_str().unwrap();
     let tx_hash = Felt::from_hex_unchecked(tx_hash_hex);
-    match assert_tx_succeeded_accepted(&tx_hash, &devnet.json_rpc_client).await {
-        Ok(_) => (),
-        Err(e) => panic!("Transaction failed: {}", e),
-    };
+    assert_tx_succeeded_accepted(&tx_hash, &devnet.json_rpc_client).await.unwrap();
 
     // assert state changed
     assert_eq!(

--- a/tests/integration/test_minting.rs
+++ b/tests/integration/test_minting.rs
@@ -5,6 +5,7 @@ use starknet_rs_core::types::Felt;
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants::{PREDEPLOYED_ACCOUNT_ADDRESS, PREDEPLOYED_ACCOUNT_INITIAL_BALANCE};
 use crate::common::utils::FeeUnit;
+use crate::{assert_eq_prop, assert_prop};
 
 static DUMMY_ADDRESS: &str = "0x42";
 static DUMMY_AMOUNT: u128 = 42;
@@ -34,7 +35,7 @@ async fn increase_balance_happy_path(
         .as_str()
         .ok_or(anyhow!("failed to parse transaction hash"))?
         .starts_with("0x");
-    anyhow::ensure!(tx_hash, "Transaction hash does not start with '0x'");
+    assert_prop!(tx_hash, "Transaction hash does not start with '0x'")?;
 
     let final_balance = Felt::from(init_amount) + Felt::from(mint_amount);
     let expected_resp_body = json!({
@@ -42,17 +43,11 @@ async fn increase_balance_happy_path(
         "unit": unit,
         "tx_hash": null
     });
-    anyhow::ensure!(
-        resp_body == expected_resp_body,
-        format!("assertion `left == right` failed, left: {resp_body}, right: {expected_resp_body}")
-    );
+    assert_eq_prop!(resp_body, expected_resp_body)?;
 
     let new_balance =
         devnet.get_balance_latest(&Felt::from_hex_unchecked(address), unit).await.unwrap();
-    anyhow::ensure!(
-        final_balance == new_balance,
-        format!("assertion `left == right` failed, left: {final_balance}, right: {new_balance}")
-    );
+    assert_eq_prop!(final_balance, new_balance)?;
     Ok(())
 }
 

--- a/tests/integration/test_minting.rs
+++ b/tests/integration/test_minting.rs
@@ -13,7 +13,7 @@ async fn increase_balance_happy_path(
     init_amount: u128,
     mint_amount: u128,
     unit: FeeUnit,
-) {
+) -> Result<(), anyhow::Error> {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
 
     let mut resp_body: serde_json::Value = devnet
@@ -25,36 +25,36 @@ async fn increase_balance_happy_path(
                 "unit": unit,
             }),
         )
-        .await
-        .unwrap();
+        .await?;
 
     // tx hash is not constant so we just assert its general form
     let tx_hash_value = resp_body["tx_hash"].take();
-    assert!(tx_hash_value.as_str().unwrap().starts_with("0x"));
+    anyhow::ensure!(tx_hash_value.as_str().unwrap().starts_with("0x"));
 
     let final_balance = Felt::from(init_amount) + Felt::from(mint_amount);
-    assert_eq!(
-        resp_body,
-        json!({
-            "new_balance": final_balance.to_biguint().to_string(),
-            "unit": unit,
-            "tx_hash": null
-        })
+    anyhow::ensure!(
+        resp_body
+            == json!({
+                "new_balance": final_balance.to_biguint().to_string(),
+                "unit": unit,
+                "tx_hash": null
+            })
     );
 
     let new_balance =
         devnet.get_balance_latest(&Felt::from_hex_unchecked(address), unit).await.unwrap();
-    assert_eq!(final_balance, new_balance);
+    anyhow::ensure!(final_balance == new_balance);
+    Ok(())
 }
 
 #[tokio::test]
 async fn increase_balance_of_undeployed_address_wei() {
-    increase_balance_happy_path(DUMMY_ADDRESS, 0, DUMMY_AMOUNT, FeeUnit::Wei).await;
+    increase_balance_happy_path(DUMMY_ADDRESS, 0, DUMMY_AMOUNT, FeeUnit::Wei).await.unwrap();
 }
 
 #[tokio::test]
 async fn increase_balance_of_undeployed_address_fri() {
-    increase_balance_happy_path(DUMMY_ADDRESS, 0, DUMMY_AMOUNT, FeeUnit::Fri).await;
+    increase_balance_happy_path(DUMMY_ADDRESS, 0, DUMMY_AMOUNT, FeeUnit::Fri).await.unwrap();
 }
 
 #[tokio::test]
@@ -89,6 +89,7 @@ async fn increase_balance_of_predeployed_account() {
         FeeUnit::Wei,
     )
     .await
+    .unwrap()
 }
 
 #[tokio::test]
@@ -100,6 +101,7 @@ async fn increase_balance_of_predeployed_account_u256() {
         FeeUnit::Wei,
     )
     .await
+    .unwrap()
 }
 
 #[tokio::test]

--- a/tests/integration/test_old_state.rs
+++ b/tests/integration/test_old_state.rs
@@ -234,7 +234,7 @@ async fn fee_estimation_and_simulation_of_deployment_at_old_block_should_not_yie
             assert_eq!(error_at_to_be_deployed_address.class_hash, class_hash);
             assert_eq!(error_at_to_be_deployed_address.selector, Felt::ZERO);
 
-            let error_msg = extract_message_error(&error_at_to_be_deployed_address.error);
+            let error_msg = extract_message_error(&error_at_to_be_deployed_address.error).unwrap();
             assert_eq!(error_msg.trim(), &expected_error_msg)
         }
         other => panic!("Unexpected error: {other:?}"),

--- a/tests/integration/test_old_state.rs
+++ b/tests/integration/test_old_state.rs
@@ -213,7 +213,7 @@ async fn fee_estimation_and_simulation_of_deployment_at_old_block_should_not_yie
         ProviderError::StarknetError(StarknetError::TransactionExecutionError(
             TransactionExecutionErrorData { execution_error, .. },
         )) => {
-            let account_error = extract_nested_error(&execution_error);
+            let account_error = extract_nested_error(&execution_error).unwrap();
 
             assert_eq!(account_error.selector, get_selector_from_name("__execute__").unwrap());
             assert_eq!(account_error.contract_address, account.address());
@@ -225,12 +225,12 @@ async fn fee_estimation_and_simulation_of_deployment_at_old_block_should_not_yie
                 .unwrap();
             assert_eq!(account_error.class_hash, account_class_hash);
 
-            let udc_error = extract_nested_error(&account_error.error);
+            let udc_error = extract_nested_error(&account_error.error).unwrap();
             assert_eq!(udc_error.contract_address, UDC_LEGACY_CONTRACT_ADDRESS);
             assert_eq!(udc_error.selector, udc_selector);
             assert_eq!(udc_error.class_hash, UDC_LEGACY_CONTRACT_CLASS_HASH);
 
-            let error_at_to_be_deployed_address = extract_nested_error(&udc_error.error);
+            let error_at_to_be_deployed_address = extract_nested_error(&udc_error.error).unwrap();
             assert_eq!(error_at_to_be_deployed_address.class_hash, class_hash);
             assert_eq!(error_at_to_be_deployed_address.selector, Felt::ZERO);
 

--- a/tests/integration/test_restart.rs
+++ b/tests/integration/test_restart.rs
@@ -93,7 +93,13 @@ async fn assert_account_deployment_reverted() {
     let deployment_tx = deployment.send().await.unwrap();
 
     // assert deployment successful and class associated with deployment address is present
-    assert_tx_succeeded_accepted(&deployment_tx.transaction_hash, &devnet.json_rpc_client).await;
+    match assert_tx_succeeded_accepted(&deployment_tx.transaction_hash, &devnet.json_rpc_client)
+        .await
+    {
+        Ok(_) => (),
+        Err(e) => panic!("Transaction failed: {}", e),
+    };
+
     devnet
         .json_rpc_client
         .get_class_at(BlockId::Tag(BlockTag::Latest), deployment_address)

--- a/tests/integration/test_restart.rs
+++ b/tests/integration/test_restart.rs
@@ -93,12 +93,9 @@ async fn assert_account_deployment_reverted() {
     let deployment_tx = deployment.send().await.unwrap();
 
     // assert deployment successful and class associated with deployment address is present
-    match assert_tx_succeeded_accepted(&deployment_tx.transaction_hash, &devnet.json_rpc_client)
+    assert_tx_succeeded_accepted(&deployment_tx.transaction_hash, &devnet.json_rpc_client)
         .await
-    {
-        Ok(_) => (),
-        Err(e) => panic!("Transaction failed: {}", e),
-    };
+        .unwrap();
 
     devnet
         .json_rpc_client

--- a/tests/integration/test_simulate_transactions.rs
+++ b/tests/integration/test_simulate_transactions.rs
@@ -485,7 +485,7 @@ async fn test_simulation_of_panicking_invoke() {
             execute_invocation: ExecuteInvocation::Reverted(reverted_invocation),
             ..
         }) => {
-            assert_contains(&reverted_invocation.revert_reason, panic_message_text);
+            assert_contains(&reverted_invocation.revert_reason, panic_message_text).unwrap();
         }
         other_trace => panic!("Unexpected trace {other_trace:?}"),
     }
@@ -577,7 +577,7 @@ async fn simulate_of_multiple_txs_shouldnt_return_an_error_if_invoke_transaction
         TransactionTrace::Invoke(InvokeTransactionTrace {
             execute_invocation: ExecuteInvocation::Reverted(reverted_invocation),
             ..
-        }) => assert_contains(&reverted_invocation.revert_reason, "ENTRYPOINT_NOT_FOUND"),
+        }) => assert_contains(&reverted_invocation.revert_reason, "ENTRYPOINT_NOT_FOUND").unwrap(),
         other_trace => panic!("Unexpected trace {:?}", other_trace),
     }
 }
@@ -709,7 +709,7 @@ async fn simulate_with_gas_bounds_exceeding_balance_returns_error_if_charging_no
                 execution_error,
                 ..
             }),
-        )) => assert_contains(&format!("{:?}", execution_error), "exceed balance"),
+        )) => assert_contains(&format!("{:?}", execution_error), "exceed balance").unwrap(),
         other => panic!("Unexpected error {other:?}"),
     }
 
@@ -936,7 +936,7 @@ async fn simulate_invoke_v3_with_fee_just_below_estimated_should_return_a_trace_
         TransactionTrace::Invoke(InvokeTransactionTrace {
             execute_invocation: ExecuteInvocation::Reverted(reverted_invocation),
             ..
-        }) => assert_contains(&reverted_invocation.revert_reason, "Insufficient"),
+        }) => assert_contains(&reverted_invocation.revert_reason, "Insufficient").unwrap(),
         other => panic!("Unexpected trace {other:?}"),
     }
 }
@@ -1117,7 +1117,7 @@ async fn simulate_invoke_v3_with_failing_execution_should_return_a_trace_of_reve
         TransactionTrace::Invoke(InvokeTransactionTrace {
             execute_invocation: ExecuteInvocation::Reverted(reverted_invocation),
             ..
-        }) => assert_contains(&reverted_invocation.revert_reason, panic_reason),
+        }) => assert_contains(&reverted_invocation.revert_reason, panic_reason).unwrap(),
         other => panic!("Unexpected trace {other:?}"),
     }
 }

--- a/tests/integration/test_subscription_to_blocks.rs
+++ b/tests/integration/test_subscription_to_blocks.rs
@@ -43,7 +43,7 @@ async fn should_not_receive_block_notification_if_not_subscribed() {
     let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
 
     devnet.create_block().await.unwrap();
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -89,7 +89,7 @@ async fn subscription_to_an_old_block_by_number_should_notify_of_all_blocks_up_t
         assert_eq!(notification_block["block_number"], json!(block_i));
     }
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -116,7 +116,7 @@ async fn subscription_to_an_old_block_by_hash_should_notify_of_all_blocks_up_to_
         assert_eq!(notification_block["block_number"], json!(block_i));
     }
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -137,11 +137,11 @@ async fn assert_latest_block_is_default() {
 
     let notification_block_latest =
         receive_block(&mut ws_latest, subscription_id_latest).await.unwrap();
-    assert_no_notifications(&mut ws_latest).await;
+    assert_no_notifications(&mut ws_latest).await.unwrap();
 
     let notification_block_default =
         receive_block(&mut ws_default, subscription_id_default).await.unwrap();
-    assert_no_notifications(&mut ws_default).await;
+    assert_no_notifications(&mut ws_default).await.unwrap();
 
     assert_eq!(notification_block_latest, notification_block_default);
 }
@@ -177,7 +177,7 @@ async fn test_multiple_subscribers_one_unsubscribes() {
         assert_eq!(notification_block["block_hash"], json!(created_block_hash));
     }
 
-    assert_no_notifications(&mut unsubscriber_ws).await;
+    assert_no_notifications(&mut unsubscriber_ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -213,7 +213,7 @@ async fn read_only_methods_do_not_generate_notifications() {
         .await
         .unwrap();
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -227,7 +227,7 @@ async fn test_notifications_in_block_on_demand_mode() {
     let dummy_address = 0x1;
     devnet.mint(dummy_address, 1).await;
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 
     let created_block_hash = devnet.create_block().await.unwrap();
 

--- a/tests/integration/test_subscription_to_events.rs
+++ b/tests/integration/test_subscription_to_events.rs
@@ -103,12 +103,12 @@ async fn event_subscription_with_no_params_until_unsubscription() {
     );
 
     receive_rpc_via_ws(&mut ws).await.unwrap(); // erc20 - fee charge
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 
     unsubscribe(&mut ws, subscription_id).await.unwrap();
 
     emit_static_event(&account, contract_address).await.unwrap();
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -139,7 +139,7 @@ async fn should_notify_only_from_filtered_address() {
         })
     );
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -170,7 +170,7 @@ async fn should_notify_of_new_events_only_from_filtered_key() {
         })
     );
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -200,7 +200,7 @@ async fn should_notify_if_already_in_latest_block_in_on_tx_mode() {
         })
     );
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -245,8 +245,8 @@ async fn should_notify_only_once_for_pre_confirmed_in_on_demand_mode() {
 
     // Should not re-notify on pre_confirmed->latest
     devnet.create_block().await.unwrap();
-    assert_no_notifications(&mut ws_before).await;
-    assert_no_notifications(&mut ws_after).await;
+    assert_no_notifications(&mut ws_before).await.unwrap();
+    assert_no_notifications(&mut ws_after).await.unwrap();
 }
 
 #[tokio::test]
@@ -311,8 +311,8 @@ async fn should_notify_only_once_for_accepted_on_l2_in_on_demand_mode(
         subscribe_events(&mut ws_after, subscription_request).await.unwrap();
 
     // No notifications before block creation and conversion from pre-confirmed to accepted_on_l2
-    assert_no_notifications(&mut ws_before).await;
-    assert_no_notifications(&mut ws_after).await;
+    assert_no_notifications(&mut ws_before).await.unwrap();
+    assert_no_notifications(&mut ws_after).await.unwrap();
     let created_block_hash = devnet.create_block().await.unwrap();
 
     for (ws, subscription_id) in
@@ -335,8 +335,8 @@ async fn should_notify_only_once_for_accepted_on_l2_in_on_demand_mode(
 
     // Should not re-notify on next block
     devnet.create_block().await.unwrap();
-    assert_no_notifications(&mut ws_before).await;
-    assert_no_notifications(&mut ws_after).await;
+    assert_no_notifications(&mut ws_before).await.unwrap();
+    assert_no_notifications(&mut ws_after).await.unwrap();
 }
 
 #[tokio::test]
@@ -389,7 +389,7 @@ async fn should_notify_of_events_in_old_blocks_with_no_filters() {
     assert_eq!(invocation_fee_event["block_number"], latest_block.block_number);
     assert_eq!(invocation_fee_event["from_address"], json!(STRK_ERC20_CONTRACT_ADDRESS));
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -422,7 +422,7 @@ async fn should_notify_of_old_and_new_events_with_address_filter() {
             "finality_status": TransactionFinalityStatus::AcceptedOnL2,
         })
     );
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 
     // new event (after subscription)
     let new_invocation = emit_static_event(&account, contract_address).await.unwrap();
@@ -440,7 +440,7 @@ async fn should_notify_of_old_and_new_events_with_address_filter() {
             "finality_status": TransactionFinalityStatus::AcceptedOnL2,
         })
     );
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -473,7 +473,7 @@ async fn should_notify_of_old_and_new_events_with_key_filter() {
             "finality_status": TransactionFinalityStatus::AcceptedOnL2,
         })
     );
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 
     // new event (after subscription)
     let new_invocation = emit_static_event(&account, contract_address).await.unwrap();
@@ -491,7 +491,7 @@ async fn should_notify_of_old_and_new_events_with_key_filter() {
             "finality_status": TransactionFinalityStatus::AcceptedOnL2,
         })
     );
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -507,7 +507,7 @@ async fn should_not_notify_of_events_in_too_old_blocks() {
 
     subscribe_events(&mut ws, json!({ "block_id": BlockId::Hash(last_block_hash) })).await.unwrap();
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -550,5 +550,5 @@ async fn should_notify_of_events_in_old_blocks() {
 
     assert_eq!(received_tx_hashes_from_events, txs_with_invocation_events);
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }

--- a/tests/integration/test_subscription_to_new_tx_receipts.rs
+++ b/tests/integration/test_subscription_to_new_tx_receipts.rs
@@ -48,7 +48,7 @@ async fn should_not_notify_in_block_on_demand_mode_if_default_subscription_param
     // No notifications because default finality_status is ACCEPTED_ON_L2
     subscribe_new_tx_receipts(&mut ws, json!({})).await.unwrap();
     send_dummy_mint_tx(&devnet).await;
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -69,7 +69,7 @@ async fn should_notify_of_pre_confirmed_txs_with_block_generation_on_demand() {
     assert_eq!(extracted_receipt.transaction_hash, tx_hash);
     assert_eq!(extracted_receipt.finality_status, finality_status);
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -100,7 +100,7 @@ async fn should_notify_of_accepted_on_l2_with_block_generation_on_tx() {
             serde_json::from_value(receipt_notification).unwrap();
         assert_eq!(extracted_receipt.transaction_hash, tx_hash);
         assert_eq!(extracted_receipt.finality_status, finality_status);
-        assert_no_notifications(&mut ws).await;
+        assert_no_notifications(&mut ws).await.unwrap();
     }
 }
 
@@ -125,7 +125,7 @@ async fn should_notify_for_multiple_subscribers_with_default_params() {
         assert_eq!(extracted_receipt.transaction_hash, tx_hash);
         assert_eq!(extracted_receipt.finality_status, finality_status);
 
-        assert_no_notifications(&mut ws).await;
+        assert_no_notifications(&mut ws).await.unwrap();
     }
 }
 
@@ -150,7 +150,7 @@ async fn should_stop_notifying_after_unsubscription() {
     send_dummy_mint_tx(&devnet).await;
 
     for (mut ws, _) in subscribers {
-        assert_no_notifications(&mut ws).await;
+        assert_no_notifications(&mut ws).await.unwrap();
     }
 }
 
@@ -174,7 +174,7 @@ async fn should_work_with_subscription_to_receipts_and_txs() {
         assert_eq!(receipt.transaction_hash(), &tx_hash);
     }
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -213,7 +213,7 @@ async fn should_notify_for_filtered_address() {
         serde_json::from_value(deployment_notification).unwrap();
     assert_eq!(deployment_receipt.finality_status, TransactionFinalityStatus::AcceptedOnL2);
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -227,7 +227,7 @@ async fn should_not_notify_if_filtered_address_not_matched() {
     send_dummy_mint_tx(&devnet).await;
 
     // nothing matched since minting is done via the Chargeable account
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -246,7 +246,7 @@ async fn should_not_notify_if_tx_by_filtered_address_already_in_pre_confirmed_bl
     ] {
         let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
         subscribe_new_tx_receipts(&mut ws, subscription_params).await.unwrap();
-        assert_no_notifications(&mut ws).await;
+        assert_no_notifications(&mut ws).await.unwrap();
     }
 }
 
@@ -268,7 +268,7 @@ async fn should_not_notify_if_tx_by_filtered_address_in_latest_block_in_on_deman
     .await
     .unwrap();
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -289,7 +289,7 @@ async fn should_not_notify_if_tx_by_filtered_address_in_latest_block_in_on_tx_mo
     .await
     .unwrap();
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -306,7 +306,7 @@ async fn should_not_notify_if_tx_already_in_latest_block_in_on_demand_mode() {
     subscribe_new_tx_receipts(&mut ws, json!({ "finality_status": [finality_status] }))
         .await
         .unwrap();
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -324,7 +324,7 @@ async fn should_not_notify_if_tx_already_in_latest_block_in_on_tx_mode() {
         subscribe_new_tx_receipts(&mut ws, json!({ "finality_status": [finality_status] }))
             .await
             .unwrap();
-        assert_no_notifications(&mut ws).await;
+        assert_no_notifications(&mut ws).await.unwrap();
     }
 }
 
@@ -347,7 +347,7 @@ async fn should_not_notify_on_read_request_if_txs_in_pre_confirmed_block() {
     let dummy_address = Felt::ONE;
     devnet.get_balance_latest(&dummy_address, FeeUnit::Wei).await.unwrap();
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -373,11 +373,11 @@ async fn should_notify_twice_if_subscribed_to_both_finality_statuses() {
         assert_eq!(extracted_receipt.transaction_hash, tx_hash);
         assert_eq!(extracted_receipt.finality_status, finality_status);
 
-        assert_no_notifications(&mut ws).await;
+        assert_no_notifications(&mut ws).await.unwrap();
         devnet.create_block().await.unwrap(); // On first loop iteration, this changes tx status
     }
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -400,5 +400,5 @@ async fn test_deploy_account_receipt_notification() {
         &deployment_result.transaction_hash
     );
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }

--- a/tests/integration/test_subscription_to_new_txs.rs
+++ b/tests/integration/test_subscription_to_new_txs.rs
@@ -24,7 +24,7 @@ async fn should_not_notify_in_block_on_demand_mode_if_default_subscription_param
     // No notifications because default finality_status is ACCEPTED_ON_L2
     subscribe_new_txs(&mut ws, json!({})).await.unwrap();
     send_dummy_mint_tx(&devnet).await;
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -44,7 +44,7 @@ async fn should_notify_of_pre_confirmed_txs_with_block_generation_on_demand() {
     let extracted_tx: Transaction = serde_json::from_value(notification_tx).unwrap();
     assert_eq!(extracted_tx.transaction_hash(), &tx_hash);
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -71,7 +71,7 @@ async fn should_notify_of_accepted_on_l2_with_block_generation_on_tx() {
         assert_eq!(notification_tx["finality_status"].take(), json!(finality_status));
         let extracted_tx: Transaction = serde_json::from_value(notification_tx).unwrap();
         assert_eq!(extracted_tx.transaction_hash(), &tx_hash);
-        assert_no_notifications(&mut ws).await;
+        assert_no_notifications(&mut ws).await.unwrap();
     }
 }
 
@@ -95,7 +95,7 @@ async fn should_notify_for_multiple_subscribers_with_default_params() {
         let extracted_tx: Transaction = serde_json::from_value(notification_tx).unwrap();
         assert_eq!(extracted_tx.transaction_hash(), &tx_hash);
 
-        assert_no_notifications(&mut ws).await;
+        assert_no_notifications(&mut ws).await.unwrap();
     }
 }
 
@@ -120,7 +120,7 @@ async fn should_stop_notifying_after_unsubscription() {
     send_dummy_mint_tx(&devnet).await;
 
     for (mut ws, _) in subscribers {
-        assert_no_notifications(&mut ws).await;
+        assert_no_notifications(&mut ws).await.unwrap();
     }
 }
 
@@ -158,7 +158,7 @@ async fn should_notify_for_filtered_address() {
         serde_json::from_value(deployment_notification).unwrap();
     assert_eq!(deployment_tx.nonce, Felt::ONE);
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -172,7 +172,7 @@ async fn should_not_notify_if_filtered_address_not_matched() {
     send_dummy_mint_tx(&devnet).await;
 
     // nothing matched since minting is done via the Chargeable account
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -191,7 +191,7 @@ async fn should_not_notify_if_tx_by_filtered_address_already_in_pre_confirmed_bl
     ] {
         let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
         subscribe_new_txs(&mut ws, subscription_params).await.unwrap();
-        assert_no_notifications(&mut ws).await;
+        assert_no_notifications(&mut ws).await.unwrap();
     }
 }
 
@@ -213,7 +213,7 @@ async fn should_not_notify_if_tx_by_filtered_address_in_latest_block_in_on_deman
     .await
     .unwrap();
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -234,7 +234,7 @@ async fn should_not_notify_if_tx_by_filtered_address_in_latest_block_in_on_tx_mo
     .await
     .unwrap();
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -249,7 +249,7 @@ async fn should_not_notify_if_tx_already_in_latest_block_in_on_demand_mode() {
     // Subscribe AFTER the tx and block creation.
     let finality_status = TransactionFinalityStatus::PreConfirmed;
     subscribe_new_txs(&mut ws, json!({ "finality_status": [finality_status] })).await.unwrap();
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -265,7 +265,7 @@ async fn should_not_notify_if_tx_already_in_latest_block_in_on_tx_mode() {
         [TransactionFinalityStatus::PreConfirmed, TransactionFinalityStatus::AcceptedOnL2]
     {
         subscribe_new_txs(&mut ws, json!({ "finality_status": [finality_status] })).await.unwrap();
-        assert_no_notifications(&mut ws).await;
+        assert_no_notifications(&mut ws).await.unwrap();
     }
 }
 
@@ -286,7 +286,7 @@ async fn should_not_notify_on_read_request_if_txs_in_pre_confirmed_block() {
     let dummy_address = Felt::ONE;
     devnet.get_balance_latest(&dummy_address, FeeUnit::Wei).await.unwrap();
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -308,11 +308,11 @@ async fn should_notify_twice_if_subscribed_to_both_finality_statuses() {
         let extracted_tx: Transaction = serde_json::from_value(notification_tx).unwrap();
         assert_eq!(extracted_tx.transaction_hash(), &tx_hash);
 
-        assert_no_notifications(&mut ws).await;
+        assert_no_notifications(&mut ws).await.unwrap();
         devnet.create_block().await.unwrap(); // On first loop iteration, this changes tx status
     }
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -331,5 +331,5 @@ async fn test_deploy_account_tx_notification() {
     // assert_eq!(tx.transaction_hash, deployment_result.transaction_hash);
     assert_eq!(notification["transaction_hash"], json!(deployment_result.transaction_hash));
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }

--- a/tests/integration/test_subscription_to_reorg.rs
+++ b/tests/integration/test_subscription_to_reorg.rs
@@ -59,7 +59,7 @@ async fn reorg_notification_for_all_subscriptions() {
     let additional_block_hash = devnet.create_block().await.unwrap();
     devnet.abort_blocks(&BlockId::Hash(additional_block_hash)).await.unwrap();
     for (_, mut ws) in notifiable_subscribers {
-        assert_no_notifications(&mut ws).await;
+        assert_no_notifications(&mut ws).await.unwrap();
     }
 }
 
@@ -121,5 +121,5 @@ async fn socket_with_n_subscriptions_should_get_n_reorg_notifications() {
 
     assert_eq!(notification_ids, HashSet::from_iter(subscription_ids));
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }

--- a/tests/integration/test_subscription_to_tx_status.rs
+++ b/tests/integration/test_subscription_to_tx_status.rs
@@ -3,6 +3,7 @@ use starknet_rs_core::types::{BlockId, Felt};
 use tokio::net::TcpStream;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
 
+use crate::assert_eq_prop;
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::utils::{
     SubscriptionId, assert_no_notifications, receive_rpc_via_ws, subscribe, subscribe_new_heads,
@@ -47,10 +48,7 @@ fn assert_mint_notification_succeeded(
             "subscription_id": subscription_id,
         }
     });
-    anyhow::ensure!(
-        notification == expected_resp,
-        format!("assertion `left == right` failed, left: {notification}, right: {expected_resp}")
-    );
+    assert_eq_prop!(notification, expected_resp)?;
     Ok(())
 }
 
@@ -150,7 +148,7 @@ async fn should_notify_if_subscribed_before_and_after_tx(
     let subscription_id_before = subscribe_tx_status(ws_before_tx, &expected_tx_hash).await?;
 
     let tx_hash = devnet.mint(address, mint_amount).await;
-    anyhow::ensure!(tx_hash == expected_tx_hash);
+    assert_eq_prop!(tx_hash, expected_tx_hash)?;
 
     {
         let notification = receive_rpc_via_ws(ws_before_tx).await.unwrap();

--- a/tests/integration/test_subscription_to_tx_status.rs
+++ b/tests/integration/test_subscription_to_tx_status.rs
@@ -32,23 +32,24 @@ fn assert_mint_notification_succeeded(
     subscription_id: SubscriptionId,
     expected_finality_status: &str,
 ) -> Result<(), anyhow::Error> {
+    let expected_resp = json!({
+        "jsonrpc": "2.0",
+        "method": "starknet_subscriptionTransactionStatus",
+        "params": {
+            "result": {
+                "transaction_hash": tx_hash,
+                "status": {
+                    "finality_status": expected_finality_status,
+                    "failure_reason": null,
+                    "execution_status": "SUCCEEDED",
+                },
+            },
+            "subscription_id": subscription_id,
+        }
+    });
     anyhow::ensure!(
-        notification
-            == json!({
-                "jsonrpc": "2.0",
-                "method": "starknet_subscriptionTransactionStatus",
-                "params": {
-                    "result": {
-                        "transaction_hash": tx_hash,
-                        "status": {
-                            "finality_status": expected_finality_status,
-                            "failure_reason": null,
-                            "execution_status": "SUCCEEDED",
-                        },
-                    },
-                    "subscription_id": subscription_id,
-                }
-            })
+        notification == expected_resp,
+        format!("assertion `left == right` failed, left: {notification}, right: {expected_resp}")
     );
     Ok(())
 }

--- a/tests/integration/test_subscription_to_tx_status.rs
+++ b/tests/integration/test_subscription_to_tx_status.rs
@@ -81,7 +81,7 @@ async fn should_stop_notifying_after_unsubscription() {
     assert_eq!(unsubscription, json!({ "jsonrpc": "2.0", "id": 0, "result": true }));
 
     devnet.mint(address, mint_amount).await;
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -90,7 +90,7 @@ async fn should_not_receive_notification_if_not_subscribed() {
     let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
 
     devnet.mint(0x1, 1).await;
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -106,7 +106,7 @@ async fn should_not_receive_notification_if_subscribed_to_another_tx() {
     assert_eq!(tx_hash, expected_tx_hash);
     assert_ne!(tx_hash, dummy_tx_hash);
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -121,7 +121,7 @@ async fn should_not_receive_tx_notification_if_subscribed_to_blocks() {
     // there should only be a single new block notification since minting is a block-adding tx
     let notification = receive_rpc_via_ws(&mut ws).await.unwrap();
     assert_eq!(notification["method"], "starknet_subscriptionNewHeads");
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -132,7 +132,7 @@ async fn should_not_receive_block_notification_if_subscribed_to_tx() {
     subscribe_tx_status(&mut ws, &Felt::ONE).await.unwrap();
 
     devnet.create_block().await.unwrap();
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 async fn should_notify_if_subscribed_before_and_after_tx(
@@ -158,7 +158,7 @@ async fn should_notify_if_subscribed_before_and_after_tx(
             subscription_id_before.clone(),
             expected_finality_status,
         );
-        assert_no_notifications(ws_before_tx).await;
+        assert_no_notifications(ws_before_tx).await.unwrap();
     }
 
     // should work even if subscribing after the tx was sent
@@ -171,7 +171,7 @@ async fn should_notify_if_subscribed_before_and_after_tx(
             subscription_id_after.clone(),
             expected_finality_status,
         );
-        assert_no_notifications(ws_after_tx).await;
+        assert_no_notifications(ws_after_tx).await.unwrap();
     }
 
     (tx_hash, subscription_id_before, subscription_id_after)
@@ -207,7 +207,7 @@ async fn should_notify_in_on_demand_mode() {
             subscription_id,
             "ACCEPTED_ON_L2",
         );
-        assert_no_notifications(&mut ws).await;
+        assert_no_notifications(&mut ws).await.unwrap();
     }
 }
 
@@ -226,11 +226,11 @@ async fn should_notify_only_once_in_on_demand_mode() {
 
     let notification = receive_rpc_via_ws(&mut ws).await.unwrap();
     assert_mint_notification_succeeded(notification, tx_hash, subscription_id, "PRE_CONFIRMED");
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 
     let another_tx_hash = devnet.mint(address, mint_amount).await;
     assert_ne!(another_tx_hash, tx_hash);
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -252,8 +252,8 @@ async fn should_notify_in_on_transaction_mode() {
     // Expect no new notifications on creating a new empty block
     devnet.create_block().await.unwrap();
 
-    assert_no_notifications(&mut ws_before_tx).await;
-    assert_no_notifications(&mut ws_after_tx).await;
+    assert_no_notifications(&mut ws_before_tx).await.unwrap();
+    assert_no_notifications(&mut ws_after_tx).await.unwrap();
 }
 
 #[tokio::test]
@@ -272,7 +272,7 @@ async fn should_notify_if_already_in_latest() {
     assert_mint_notification_succeeded(notification, tx_hash, subscription_id, "ACCEPTED_ON_L2");
 
     devnet.mint(address, mint_amount).await;
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -295,7 +295,7 @@ async fn should_notify_if_already_in_an_old_block() {
     assert_mint_notification_succeeded(notification, tx_hash, subscription_id, "ACCEPTED_ON_L2");
 
     devnet.mint(address, mint_amount).await;
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -317,5 +317,5 @@ async fn should_not_notify_of_status_change_when_block_aborted() {
     // only expect reorg subscription
     let notification = receive_rpc_via_ws(&mut ws).await.unwrap();
     assert_eq!(notification["method"], "starknet_subscriptionReorg");
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }

--- a/tests/integration/test_subscription_with_invalid_block_id.rs
+++ b/tests/integration/test_subscription_with_invalid_block_id.rs
@@ -34,7 +34,7 @@ async fn test_subscribing_to_non_existent_block() {
         }
     }
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]
@@ -58,7 +58,7 @@ async fn test_aborted_blocks_not_subscribable() {
         }
     }
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]

--- a/tests/integration/test_transaction_handling.rs
+++ b/tests/integration/test_transaction_handling.rs
@@ -45,7 +45,7 @@ async fn test_failed_validation_with_expected_message() {
     match declaration_result {
         Err(AccountError::Provider(ProviderError::StarknetError(
             StarknetError::ValidationFailure(message),
-        ))) => assert_contains(&message, "FAILED VALIDATE DECLARE"),
+        ))) => assert_contains(&message, "FAILED VALIDATE DECLARE").unwrap(),
         other => panic!("Unexpected result: {other:?}"),
     }
 }
@@ -123,6 +123,7 @@ async fn test_tx_status_content_of_failed_invoke() {
         .unwrap();
 
     assert_eq!(tx_status["finality_status"], "ACCEPTED_ON_L2");
-    assert_contains(tx_status["failure_reason"].as_str().unwrap(), "Error in the called contract");
+    assert_contains(tx_status["failure_reason"].as_str().unwrap(), "Error in the called contract")
+        .unwrap();
     assert_eq!(tx_status["execution_status"], "REVERTED");
 }

--- a/tests/integration/test_v3_transactions.rs
+++ b/tests/integration/test_v3_transactions.rs
@@ -71,8 +71,15 @@ async fn declare_deploy_happy_path() {
     let declare_transaction =
         account.declare_v3(Arc::new(sierra_artifact), casm_hash).send().await.unwrap();
 
-    assert_tx_succeeded_accepted(&declare_transaction.transaction_hash, &devnet.json_rpc_client)
-        .await;
+    match assert_tx_succeeded_accepted(
+        &declare_transaction.transaction_hash,
+        &devnet.json_rpc_client,
+    )
+    .await
+    {
+        Ok(_) => (),
+        Err(e) => panic!("Transaction failed: {}", e),
+    };
 
     devnet
         .json_rpc_client
@@ -100,8 +107,15 @@ async fn declare_deploy_happy_path() {
         &[constructor_arg],
     );
     let deploy_transaction = account.execute_v3(deploy_call).send().await.unwrap();
-    assert_tx_succeeded_accepted(&deploy_transaction.transaction_hash, &devnet.json_rpc_client)
-        .await;
+    match assert_tx_succeeded_accepted(
+        &deploy_transaction.transaction_hash,
+        &devnet.json_rpc_client,
+    )
+    .await
+    {
+        Ok(_) => (),
+        Err(e) => panic!("Transaction failed: {}", e),
+    };
 
     let class_hash_of_contract = devnet
         .json_rpc_client
@@ -152,8 +166,12 @@ async fn declare_from_an_account_with_insufficient_strk_tokens_balance() {
         .await
         .unwrap();
 
-    assert_tx_succeeded_accepted(&invoke_txn_result.transaction_hash, &devnet.json_rpc_client)
-        .await;
+    match assert_tx_succeeded_accepted(&invoke_txn_result.transaction_hash, &devnet.json_rpc_client)
+        .await
+    {
+        Ok(_) => (),
+        Err(e) => panic!("Transaction failed: {}", e),
+    };
 
     let account_strk_balance =
         devnet.get_balance_by_tag(&account_address, FeeUnit::Fri, BlockTag::Latest).await.unwrap();
@@ -302,7 +320,10 @@ async fn deploy_account_happy_path() {
     devnet.mint_unit(account_address, 1e18 as u128, FeeUnit::Fri).await;
 
     let result = deploy_v3.send().await.unwrap();
-    assert_tx_succeeded_accepted(&result.transaction_hash, &devnet.json_rpc_client).await;
+    match assert_tx_succeeded_accepted(&result.transaction_hash, &devnet.json_rpc_client).await {
+        Ok(_) => (),
+        Err(e) => panic!("Transaction failed: {}", e),
+    };
 }
 
 /// This function sets the gas price and/or gas units to a value that is less than the estimated

--- a/tests/integration/test_v3_transactions.rs
+++ b/tests/integration/test_v3_transactions.rs
@@ -71,15 +71,9 @@ async fn declare_deploy_happy_path() {
     let declare_transaction =
         account.declare_v3(Arc::new(sierra_artifact), casm_hash).send().await.unwrap();
 
-    match assert_tx_succeeded_accepted(
-        &declare_transaction.transaction_hash,
-        &devnet.json_rpc_client,
-    )
-    .await
-    {
-        Ok(_) => (),
-        Err(e) => panic!("Transaction failed: {}", e),
-    };
+    assert_tx_succeeded_accepted(&declare_transaction.transaction_hash, &devnet.json_rpc_client)
+        .await
+        .unwrap();
 
     devnet
         .json_rpc_client
@@ -107,15 +101,9 @@ async fn declare_deploy_happy_path() {
         &[constructor_arg],
     );
     let deploy_transaction = account.execute_v3(deploy_call).send().await.unwrap();
-    match assert_tx_succeeded_accepted(
-        &deploy_transaction.transaction_hash,
-        &devnet.json_rpc_client,
-    )
-    .await
-    {
-        Ok(_) => (),
-        Err(e) => panic!("Transaction failed: {}", e),
-    };
+    assert_tx_succeeded_accepted(&deploy_transaction.transaction_hash, &devnet.json_rpc_client)
+        .await
+        .unwrap();
 
     let class_hash_of_contract = devnet
         .json_rpc_client
@@ -166,12 +154,9 @@ async fn declare_from_an_account_with_insufficient_strk_tokens_balance() {
         .await
         .unwrap();
 
-    match assert_tx_succeeded_accepted(&invoke_txn_result.transaction_hash, &devnet.json_rpc_client)
+    assert_tx_succeeded_accepted(&invoke_txn_result.transaction_hash, &devnet.json_rpc_client)
         .await
-    {
-        Ok(_) => (),
-        Err(e) => panic!("Transaction failed: {}", e),
-    };
+        .unwrap();
 
     let account_strk_balance =
         devnet.get_balance_by_tag(&account_address, FeeUnit::Fri, BlockTag::Latest).await.unwrap();

--- a/tests/integration/test_v3_transactions.rs
+++ b/tests/integration/test_v3_transactions.rs
@@ -305,10 +305,7 @@ async fn deploy_account_happy_path() {
     devnet.mint_unit(account_address, 1e18 as u128, FeeUnit::Fri).await;
 
     let result = deploy_v3.send().await.unwrap();
-    match assert_tx_succeeded_accepted(&result.transaction_hash, &devnet.json_rpc_client).await {
-        Ok(_) => (),
-        Err(e) => panic!("Transaction failed: {}", e),
-    };
+    assert_tx_succeeded_accepted(&result.transaction_hash, &devnet.json_rpc_client).await.unwrap();
 }
 
 /// This function sets the gas price and/or gas units to a value that is less than the estimated

--- a/tests/integration/test_v3_transactions.rs
+++ b/tests/integration/test_v3_transactions.rs
@@ -418,7 +418,7 @@ async fn transaction_with_less_gas_units_and_or_less_gas_price_should_return_err
                         let execution_result = receipt.receipt.execution_result();
                         match execution_result {
                             ExecutionResult::Reverted { reason } => {
-                                assert_contains(reason.as_str(), "Insufficient max L2Gas");
+                                assert_contains(reason.as_str(), "Insufficient max L2Gas").unwrap();
                             }
                             other => panic!("Unexpected result: {:?}", other),
                         }

--- a/tests/integration/test_websocket.rs
+++ b/tests/integration/test_websocket.rs
@@ -106,7 +106,7 @@ async fn restarting_should_forget_all_websocket_subscriptions() {
 
     devnet.restart().await;
 
-    assert_no_notifications(&mut ws).await;
+    assert_no_notifications(&mut ws).await.unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Usage related changes

N/A

## Development related changes

Custom assertion methods now return results instead of panicking. This change improves debugging as the stack trace is more intuitive to reason about.

The following custom assertion methods were modified to return a result instead of panicking:
- `assert_tx_succeeded_accepted`
- `assert_tx_succeeded_pre_confirmed`
- `assert_tx_reverted`
- `assert_equal_elements`
- `assert_no_notifications`
- `assert_contains`
- `extract_message_error`
- `extract_nested_error`
- `get_contract_balance`
- `get_contract_balance_by_block_id`
- `assert_tx_aborted`

closes #845 

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Test helpers now propagate explicit errors instead of panicking, with typed receipt handling for clearer outcomes.
- Tests
  - Integration tests updated to enforce and unwrap helper results, making assertions stricter and failures immediate.
  - Strengthened nested error/message checks and notification validations for websockets/subscriptions.
  - Overall improves test robustness, diagnostics, and determinism without changing product behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->