### PR TITLE
Test minting overflow behavior

### DIFF
--- a/tests/integration/test_minting.rs
+++ b/tests/integration/test_minting.rs
@@ -170,6 +170,7 @@ async fn reject_invalid_unit_when_querying() {
 async fn test_overflow_behavior() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
 
+    // Sending a random too big value to a random address
     let mint_err = devnet
         .send_custom_rpc(
             "devnet_mint",
@@ -181,6 +182,8 @@ async fn test_overflow_behavior() {
         )
         .await
         .unwrap_err();
+
+    // The complete error also contains the tx hash, which cannot be asserted in a stable way.
     assert_eq!(
         (
             mint_err.code,


### PR DESCRIPTION
## Usage related changes

None

## Development related changes

I've realized that an unstable `if-else` is untested in:
https://github.com/0xSpaceShard/starknet-devnet/blob/f3fed84fe67681d5e7bdb66743a60da8170decad/crates/starknet-devnet-server/src/api/write_endpoints.rs#L335-L340

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)
