### PR TITLE
Use `--locked` with `cargo install`

### DIFF
--- a/scripts/check_spelling.sh
+++ b/scripts/check_spelling.sh
@@ -3,6 +3,6 @@
 set -euo pipefail
 
 # should skip if already installed
-cargo +nightly-2025-02-20 install typos-cli --version 1.36.2
+cargo +nightly-2025-02-20 install typos-cli --version 1.36.2 --locked
 
 typos && echo "No spelling errors!"

--- a/scripts/check_unused_deps.sh
+++ b/scripts/check_unused_deps.sh
@@ -3,6 +3,6 @@
 set -eu
 
 # should skip if already installed
-cargo install cargo-machete --version 0.7.0
+cargo install cargo-machete --version 0.7.0 --locked
 
 cargo machete


### PR DESCRIPTION
## Usage related changes

None

## Development related changes

Some tools, like `typos-cli`, will behave strangely if the `--locked` flag is not used. Described here: https://github.com/crate-ci/typos/issues/1376

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)
