### PR TITLE
Improve ApiError variants

### DIFF
--- a/crates/starknet-devnet-core/src/constants.rs
+++ b/crates/starknet-devnet-core/src/constants.rs
@@ -25,17 +25,16 @@ pub const CAIRO_1_ACCOUNT_CONTRACT_SIERRA: &str = include_str!(concat!(
 pub const CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH: &str =
     "0x05b4b537eaa2399e3aa99c4e2e0208ebd6c71bc1467938cd52c798c601e43564";
 
+// Re-export ERC20 contract addresses from starknet-types
+pub use starknet_types::constants::{ETH_ERC20_CONTRACT_ADDRESS, STRK_ERC20_CONTRACT_ADDRESS};
+
 pub const ETH_ERC20_CONTRACT_CLASS_HASH: Felt =
     Felt::from_hex_unchecked("0x9524a94b41c4440a16fd96d7c1ef6ad6f44c1c013e96662734502cd4ee9b1f");
-pub const ETH_ERC20_CONTRACT_ADDRESS: Felt =
-    Felt::from_hex_unchecked("0x49D36570D4E46F48E99674BD3FCC84644DDD6B96F7C741B1562B82F9E004DC7");
 pub const ETH_ERC20_CONTRACT_CLASS: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/contracts/system_artifacts/erc20_eth.sierra"
 ));
 
-pub const STRK_ERC20_CONTRACT_ADDRESS: Felt =
-    Felt::from_hex_unchecked("0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d");
 pub const STRK_ERC20_CONTRACT_CLASS_HASH: Felt =
     Felt::from_hex_unchecked("0x76791ef97c042f81fbf352ad95f39a22554ee8d7927b2ce3c681f3418b5206a");
 pub const STRK_ERC20_CONTRACT_CLASS: &str = include_str!(concat!(

--- a/crates/starknet-devnet-server/src/api/error.rs
+++ b/crates/starknet-devnet-server/src/api/error.rs
@@ -13,8 +13,6 @@ use crate::rpc_core::error::RpcError;
 #[allow(unused)]
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("{0}")]
-    GeneralError(String),
     #[error(transparent)]
     StarknetDevnetError(#[from] starknet_core::error::Error),
     #[error("Types error")]
@@ -86,19 +84,14 @@ pub enum ApiError {
     DumpError { msg: String },
     #[error("Messaging error: {msg}")]
     MessagingError { msg: String },
-    #[error("Invalid value: {msg}")]
-    InvalidValueError { msg: String },
+    #[error("Invalid address: {msg}")]
+    InvalidAddress { msg: String },
 }
 
 impl ApiError {
     pub fn api_error_to_rpc_error(self) -> RpcError {
         let error_message = self.to_string();
         match self {
-            ApiError::GeneralError(err) => RpcError {
-                code: crate::rpc_core::error::ErrorCode::ServerError(WILDCARD_RPC_ERROR_CODE),
-                message: err.into(),
-                data: None,
-            },
             ApiError::RpcError(rpc_error) => rpc_error,
             ApiError::BlockNotFound => RpcError {
                 code: crate::rpc_core::error::ErrorCode::ServerError(24),
@@ -291,7 +284,7 @@ impl ApiError {
                 message: msg.into(),
                 data: None,
             },
-            ApiError::InvalidValueError { msg } => RpcError {
+            ApiError::InvalidAddress { msg } => RpcError {
                 code: crate::rpc_core::error::ErrorCode::ServerError(WILDCARD_RPC_ERROR_CODE),
                 message: msg.into(),
                 data: None,
@@ -306,8 +299,7 @@ impl ApiError {
             | Self::TransactionNotFound
             | Self::NoStateAtBlock { .. }
             | Self::ClassHashNotFound => true,
-            Self::GeneralError {..}
-            | Self::StarknetDevnetError(_)
+            Self::StarknetDevnetError(_)
             | Self::NoTraceAvailable
             | Self::TypesError(_)
             | Self::RpcError(_)
@@ -335,7 +327,7 @@ impl ApiError {
             | Self::CompiledClassHashMismatch
             | Self::DumpError { .. }
             | Self::MessagingError { .. }
-            | Self::InvalidValueError { .. } => false,
+            | Self::InvalidAddress { .. } => false,
         }
     }
 }

--- a/crates/starknet-devnet-server/src/api/write_endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/write_endpoints.rs
@@ -17,7 +17,7 @@ use super::models::{
     StarknetResponse, TransactionHashOutput,
 };
 use crate::api::JsonRpcHandler;
-use crate::api::account_helpers::{get_balance, get_erc20_address};
+use crate::api::account_helpers::get_balance;
 use crate::api::models::{
     AbortedBlocks, AbortingBlocks, AcceptOnL1Request, AcceptedOnL1Blocks, CreatedBlock, DumpPath,
     FlushParameters, FlushedMessages, IncreaseTime, IncreaseTimeResponse, MessageHash,
@@ -310,7 +310,7 @@ impl JsonRpcHandler {
     pub async fn mint(&self, request: MintTokensRequest) -> StrictRpcResult {
         let mut starknet = self.api.starknet.lock().await;
         let unit = request.unit.unwrap_or(FeeUnit::FRI);
-        let erc20_address = get_erc20_address(&unit)?;
+        let erc20_address = ContractAddress::from_feeunit(&unit);
 
         // increase balance
         let tx_hash = starknet.mint(request.address, request.amount, erc20_address).await?;

--- a/crates/starknet-devnet-types/src/constants.rs
+++ b/crates/starknet-devnet-types/src/constants.rs
@@ -19,3 +19,8 @@ pub(crate) const PREFIX_L1_HANDLER: Felt = Felt::from_raw([
     18446744073708665300,
     1365666230910873368,
 ]);
+
+pub const ETH_ERC20_CONTRACT_ADDRESS: Felt =
+    Felt::from_hex_unchecked("0x49D36570D4E46F48E99674BD3FCC84644DDD6B96F7C741B1562B82F9E004DC7");
+pub const STRK_ERC20_CONTRACT_ADDRESS: Felt =
+    Felt::from_hex_unchecked("0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d");

--- a/crates/starknet-devnet-types/src/patricia_key.rs
+++ b/crates/starknet-devnet-types/src/patricia_key.rs
@@ -19,7 +19,11 @@ impl PatriciaKey {
                 string: format!("[0x0, {PATRICIA_KEY_UPPER_BOUND})"),
             }));
         }
-        Ok(PatriciaKey(felt))
+        Ok(Self(felt))
+    }
+
+    pub(crate) fn new_unchecked(felt: Felt) -> Self {
+        Self(felt)
     }
 
     pub fn to_felt(&self) -> Felt {

--- a/crates/starknet-devnet-types/src/rpc/contract_address.rs
+++ b/crates/starknet-devnet-types/src/rpc/contract_address.rs
@@ -3,8 +3,10 @@ use std::fmt::LowerHex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use starknet_rs_core::types::Felt;
 
+use crate::constants::{ETH_ERC20_CONTRACT_ADDRESS, STRK_ERC20_CONTRACT_ADDRESS};
 use crate::error::DevnetResult;
 use crate::patricia_key::{PATRICIA_KEY_ZERO, PatriciaKey};
+use crate::rpc::transaction_receipt::FeeUnit;
 use crate::serde_helpers::hex_string::{
     deserialize_to_prefixed_contract_address, serialize_contract_address_to_prefixed_hex,
 };
@@ -24,6 +26,16 @@ impl ContractAddress {
 
     pub fn to_fixed_hex_string(&self) -> String {
         self.0.0.to_fixed_hex_string()
+    }
+
+    pub fn from_feeunit(unit: &FeeUnit) -> Self {
+        let erc20_contract_address = match unit {
+            FeeUnit::WEI => ETH_ERC20_CONTRACT_ADDRESS,
+            FeeUnit::FRI => STRK_ERC20_CONTRACT_ADDRESS,
+        };
+
+        // We can safely use unchecked here because these addresses are known to be valid
+        Self(PatriciaKey::new_unchecked(erc20_contract_address))
     }
 }
 
@@ -66,5 +78,30 @@ impl From<ContractAddress> for Felt {
 impl LowerHex for ContractAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.0.0.to_hex_string().as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_new_unchecked_vs_new_for_feeaddress() {
+        // For ETH address
+        let patricia_key_checked = PatriciaKey::new(ETH_ERC20_CONTRACT_ADDRESS).unwrap();
+        let patricia_key_unchecked = PatriciaKey::new_unchecked(ETH_ERC20_CONTRACT_ADDRESS);
+        assert_eq!(
+            patricia_key_checked, patricia_key_unchecked,
+            "PatriciaKey::new and PatriciaKey::new_unchecked should produce the same result for \
+             valid ETH address"
+        );
+
+        // For STRK address
+        let patricia_key_checked = PatriciaKey::new(STRK_ERC20_CONTRACT_ADDRESS).unwrap();
+        let patricia_key_unchecked = PatriciaKey::new_unchecked(STRK_ERC20_CONTRACT_ADDRESS);
+        assert_eq!(
+            patricia_key_checked, patricia_key_unchecked,
+            "PatriciaKey::new and PatriciaKey::new_unchecked should produce the same result for \
+             valid STRK address"
+        );
     }
 }


### PR DESCRIPTION
## Usage related changes

Better UX when Errors are printed out 

## Development related changes

Small change in ApiError enum, resolves #850.

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [ ] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] No spelling errors - `./scripts/check_spelling.sh`
- [ ] Performed code self-review
- [ ] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [ ] Updated the docs if needed - `./website/README.md`
- [ ] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)
