### PR TITLE
Add tests for old block rejection on subscription 

### DIFF
--- a/tests/integration/common/utils.rs
+++ b/tests/integration/common/utils.rs
@@ -567,11 +567,10 @@ pub async fn subscribe(
     let subscription_confirmation = send_text_rpc_via_ws(ws, subscription_method, params).await?;
 
     if let Some(error) = subscription_confirmation.get("error") {
-        let err_msg = error.to_string();
-        if let Ok(rpc_error) = serde_json::from_str::<RpcError>(&err_msg) {
-            return Err(anyhow::Error::new(rpc_error));
+        match serde_json::from_value::<RpcError>(error.clone()) {
+            Ok(rpc_error) => return Err(anyhow::Error::new(rpc_error)),
+            Err(_) => return Err(anyhow::Error::msg(error.to_string())),
         }
-        return Err(anyhow::Error::msg(err_msg));
     }
 
     Ok(subscription_confirmation["result"]

--- a/tests/integration/test_subscription_to_blocks.rs
+++ b/tests/integration/test_subscription_to_blocks.rs
@@ -404,9 +404,16 @@ async fn test_fork_subscription_to_old_blocks_should_fail() {
     let latest_block_number =
         fork_devnet.get_latest_block_with_tx_hashes().await.unwrap().block_number;
 
+    // Ensure we have enough blocks to properly test the out-of-range condition
+    assert!(
+        latest_block_number >= 1025,
+        "Test requires at least 1025 blocks to validate out-of-range behavior, but got {}",
+        latest_block_number
+    );
+
     let (mut ws, _) = connect_async(fork_devnet.ws_url()).await.unwrap();
 
-    // Pick a block outside range
+    // Pick a block outside range (1025 blocks back from latest)
     let subscription_error = subscribe_new_heads(
         &mut ws,
         json!({ "block_id": BlockId::Number(latest_block_number - 1025) }),


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

## Development related changes

<!-- How these changes affect the developers of this project. E.g. changes in dev tools, testing, CI/CD... -->

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subscriptions now properly detect and report RPC errors on confirmation instead of continuing with failed operations.
  * Block range validation prevents subscription attempts beyond the maximum allowed depth.

* **Tests**
  * Added comprehensive test coverage for subscription error handling and block range constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->