### PR TITLE
chore: upgrade RC dependencies to stable releases

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -42,7 +42,7 @@ jobs:
       previous_version: ${{ steps.version_info.outputs.previous_version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           
@@ -103,7 +103,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Load common configuration
         id: config
@@ -160,7 +160,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Load common configuration
         id: config
@@ -313,7 +313,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
           
       - name: Load common configuration
         id: config

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Load common configuration
         id: config
@@ -48,7 +48,7 @@ jobs:
       TABLEGEN_190_PREFIX: /usr/lib/llvm-19
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install LLVM 19 (required for cairo_native)
         run: |
@@ -88,7 +88,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Load common configuration
         id: config

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e9e31d834fe25fe991b8884e4b9f0e59db4a97d86e05d1464d6899c013cd62"
+checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -356,13 +356,13 @@ dependencies = [
  "derive_more",
  "foldhash 0.2.0",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "k256",
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rapidhash",
  "ruint",
  "rustc-hash 2.1.2",
@@ -396,7 +396,7 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
- "lru 0.16.3",
+ "lru 0.16.4",
  "parking_lot 0.12.5",
  "pin-project",
  "reqwest",
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93e50f64a77ad9c5470bf2ad0ca02f228da70c792a8f06634801e202579f35e"
+checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -422,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
+checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -564,7 +564,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -752,9 +752,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a67f3331354ca1f12d0e020ca49f4e7186b7608de0839e47c721282fd5729dd8"
 dependencies = [
  "apollo_infra_utils",
- "cairo-lang-sierra 2.17.0-rc.4",
+ "cairo-lang-sierra 2.17.0",
  "cairo-lang-starknet-classes",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-utils 2.17.0",
  "rlimit",
  "serde",
  "serde_json",
@@ -838,7 +838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "779a12979955eae309c494d9736f38cb64c723ed24aa457fb9b045fb89ef1026"
 dependencies = [
  "apollo_time",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "metrics",
  "num-traits",
  "paste",
@@ -1313,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "base64 0.22.1",
@@ -1340,7 +1340,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1415,7 +1415,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -1483,9 +1483,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitvec"
@@ -1536,15 +1536,15 @@ dependencies = [
  "ark-secp256r1",
  "blockifier_test_utils",
  "cached",
- "cairo-lang-casm 2.17.0-rc.4",
+ "cairo-lang-casm 2.17.0",
  "cairo-lang-runner",
  "cairo-lang-starknet-classes",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-utils 2.17.0",
  "cairo-native",
  "cairo-vm",
  "dashmap",
  "derive_more",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.12.1",
  "keccak",
  "log",
@@ -1555,7 +1555,7 @@ dependencies = [
  "num-traits",
  "paste",
  "phf",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "sha2",
@@ -1764,11 +1764,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5851c5a1f0feebbf29a2b1697629c071333a6cf3ad2a36be1edc4da2864cefe1"
+checksum = "e8ba7355bf81c515c65e2359593deef373678e719f4847e2a7de82e5cde7a042"
 dependencies = [
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-utils 2.17.0",
  "indoc",
  "num-bigint",
  "num-traits",
@@ -1804,27 +1804,27 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7dfa6cff06eda927981b78acbf578711e66c528183f604a62b4d08b1420d0c"
+checksum = "182d276f24abb11a44f5cec4901bac2199b140cfae71b93d85a07cd0c10f537c"
 dependencies = [
  "anyhow",
- "cairo-lang-defs 2.17.0-rc.4",
- "cairo-lang-diagnostics 2.17.0-rc.4",
- "cairo-lang-filesystem 2.17.0-rc.4",
- "cairo-lang-lowering 2.17.0-rc.4",
- "cairo-lang-parser 2.17.0-rc.4",
- "cairo-lang-project 2.17.0-rc.4",
+ "cairo-lang-defs 2.17.0",
+ "cairo-lang-diagnostics 2.17.0",
+ "cairo-lang-filesystem 2.17.0",
+ "cairo-lang-lowering 2.17.0",
+ "cairo-lang-parser 2.17.0",
+ "cairo-lang-project 2.17.0",
  "cairo-lang-runnable-utils",
- "cairo-lang-semantic 2.17.0-rc.4",
- "cairo-lang-sierra 2.17.0-rc.4",
- "cairo-lang-sierra-generator 2.17.0-rc.4",
- "cairo-lang-syntax 2.17.0-rc.4",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-semantic 2.17.0",
+ "cairo-lang-sierra 2.17.0",
+ "cairo-lang-sierra-generator 2.17.0",
+ "cairo-lang-syntax 2.17.0",
+ "cairo-lang-utils 2.17.0",
  "indoc",
  "rayon",
  "salsa 0.26.0",
- "semver 1.0.27",
+ "semver 1.0.28",
  "smol_str 0.3.6",
  "thiserror 2.0.18",
 ]
@@ -1837,11 +1837,11 @@ checksum = "c99d41a14f98521c617c0673a0faa41fd00029d32106a4643e1291a1813340a7"
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a3e014149f4cb0ab1eff9aec22b85d6a5502f0fc608a31bc281fe2a4fb4e4a"
+checksum = "dbaa4c21675465a5bec4ac520e0f1e13e5ff182825037943094c070745586fe9"
 dependencies = [
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-utils 2.17.0",
  "id-arena",
  "salsa 0.26.0",
 ]
@@ -1866,17 +1866,17 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdb053cf9298bd4b608c21794e3ff217a875c2b4bc369ef597235364174eb4e"
+checksum = "231520c12962c5941763a0606b47630e1836d5bd5fcaf1798b10e2cbdd86432c"
 dependencies = [
- "cairo-lang-debug 2.17.0-rc.4",
- "cairo-lang-diagnostics 2.17.0-rc.4",
- "cairo-lang-filesystem 2.17.0-rc.4",
- "cairo-lang-parser 2.17.0-rc.4",
- "cairo-lang-proc-macros 2.17.0-rc.4",
- "cairo-lang-syntax 2.17.0-rc.4",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-debug 2.17.0",
+ "cairo-lang-diagnostics 2.17.0",
+ "cairo-lang-filesystem 2.17.0",
+ "cairo-lang-parser 2.17.0",
+ "cairo-lang-proc-macros 2.17.0",
+ "cairo-lang-syntax 2.17.0",
+ "cairo-lang-utils 2.17.0",
  "itertools 0.14.0",
  "postcard",
  "salsa 0.26.0",
@@ -1899,14 +1899,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7b10e940c523b16650ae01564ec61e45e3260e5dcfcda4a8a9549d7aecca45"
+checksum = "968661e3604c14410da8025ac8e7f3e2c74d3e9bba74e860ccb8651bb13d943e"
 dependencies = [
- "cairo-lang-debug 2.17.0-rc.4",
- "cairo-lang-filesystem 2.17.0-rc.4",
- "cairo-lang-proc-macros 2.17.0-rc.4",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-debug 2.17.0",
+ "cairo-lang-filesystem 2.17.0",
+ "cairo-lang-proc-macros 2.17.0",
+ "cairo-lang-utils 2.17.0",
  "itertools 0.14.0",
  "salsa 0.26.0",
 ]
@@ -1925,11 +1925,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9feb66fa1e080f43df3ca40844906be124a63d3fb8b6d1c8ec90626d991b0013"
+checksum = "e3898ff7b4c1cdb0bb1b126985e900421cbdb829b4a0282e3cf5980a3925c186"
 dependencies = [
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-utils 2.17.0",
  "good_lp",
 ]
 
@@ -1949,17 +1949,17 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3fbf0cda59f1e78440e91ebf249a8aa66c13684153cf05408353fa55fa8364"
+checksum = "4d83c3699ff1b638fd6570473597df6a2a7d0281cb3ae2773a8077f099e314dc"
 dependencies = [
- "cairo-lang-debug 2.17.0-rc.4",
- "cairo-lang-proc-macros 2.17.0-rc.4",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-debug 2.17.0",
+ "cairo-lang-proc-macros 2.17.0",
+ "cairo-lang-utils 2.17.0",
  "itertools 0.14.0",
  "path-clean 1.0.1",
  "salsa 0.26.0",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "smol_str 0.3.6",
  "toml 0.9.12+spec-1.1.0",
@@ -1967,16 +1967,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-formatter"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c45fa9248c0fcae74282bcdf5579d474508f8e4c7e29c88eb5a9bc787714ad55"
+checksum = "1303aacadc15a44084b9dd1fba84cdb1ee3ac100266fa00274e656bad71f52e8"
 dependencies = [
  "anyhow",
- "cairo-lang-diagnostics 2.17.0-rc.4",
- "cairo-lang-filesystem 2.17.0-rc.4",
- "cairo-lang-parser 2.17.0-rc.4",
- "cairo-lang-syntax 2.17.0-rc.4",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-diagnostics 2.17.0",
+ "cairo-lang-filesystem 2.17.0",
+ "cairo-lang-parser 2.17.0",
+ "cairo-lang-syntax 2.17.0",
+ "cairo-lang-utils 2.17.0",
  "diffy",
  "ignore",
  "itertools 0.14.0",
@@ -2012,19 +2012,19 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d383663b556f344f1305296d6c042fda50091d28931df207925c4ba4303c07e"
+checksum = "3028797a71790b7762199f518c445fd6eb7f1b918f8b2d8a5c97bff462e61624"
 dependencies = [
  "assert_matches",
- "cairo-lang-debug 2.17.0-rc.4",
- "cairo-lang-defs 2.17.0-rc.4",
- "cairo-lang-diagnostics 2.17.0-rc.4",
- "cairo-lang-filesystem 2.17.0-rc.4",
- "cairo-lang-proc-macros 2.17.0-rc.4",
- "cairo-lang-semantic 2.17.0-rc.4",
- "cairo-lang-syntax 2.17.0-rc.4",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-debug 2.17.0",
+ "cairo-lang-defs 2.17.0",
+ "cairo-lang-diagnostics 2.17.0",
+ "cairo-lang-filesystem 2.17.0",
+ "cairo-lang-proc-macros 2.17.0",
+ "cairo-lang-semantic 2.17.0",
+ "cairo-lang-syntax 2.17.0",
+ "cairo-lang-utils 2.17.0",
  "id-arena",
  "indent",
  "itertools 0.14.0",
@@ -2063,16 +2063,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e00f86c34523b5ad1cb9bc43540e9de1a82e873523a81963c77f63682dca25d"
+checksum = "310b37965b67bd56007a62d62374d6f7cfd68705df727a4abe3f61b02ca76225"
 dependencies = [
- "cairo-lang-diagnostics 2.17.0-rc.4",
- "cairo-lang-filesystem 2.17.0-rc.4",
+ "cairo-lang-diagnostics 2.17.0",
+ "cairo-lang-filesystem 2.17.0",
  "cairo-lang-primitive-token",
- "cairo-lang-syntax 2.17.0-rc.4",
- "cairo-lang-syntax-codegen 2.17.0-rc.4",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-syntax 2.17.0",
+ "cairo-lang-syntax-codegen 2.17.0",
+ "cairo-lang-utils 2.17.0",
  "colored 3.1.1",
  "itertools 0.14.0",
  "num-bigint",
@@ -2102,16 +2102,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138dd3d415c141a1234000c5a60f17b2a4c8650969e2877e93018ce482dc5725"
+checksum = "410e88faa8a6f8a6695ef07f0cb292d021b6253d4d3022bfe32b73b071467af1"
 dependencies = [
- "cairo-lang-defs 2.17.0-rc.4",
- "cairo-lang-diagnostics 2.17.0-rc.4",
- "cairo-lang-filesystem 2.17.0-rc.4",
- "cairo-lang-parser 2.17.0-rc.4",
- "cairo-lang-syntax 2.17.0-rc.4",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-defs 2.17.0",
+ "cairo-lang-diagnostics 2.17.0",
+ "cairo-lang-filesystem 2.17.0",
+ "cairo-lang-parser 2.17.0",
+ "cairo-lang-syntax 2.17.0",
+ "cairo-lang-utils 2.17.0",
  "indent",
  "indoc",
  "itertools 0.14.0",
@@ -2137,11 +2137,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a35a488185d450ac00964aba9e449f15dba03c4f9f49d0af5b7aae35a02b6b"
+checksum = "ab6242fb69a4333e69387720f3e1ecc10292c42449ff6ae2587dfb310fd48346"
 dependencies = [
- "cairo-lang-debug 2.17.0-rc.4",
+ "cairo-lang-debug 2.17.0",
  "proc-macro2",
  "quote",
  "salsa 0.26.0",
@@ -2163,12 +2163,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c766f8045cdda7d4037302eda499c9e227837685b3a9d618baf2fb5f8b562c"
+checksum = "a60e0855b8f2956d5873d4acca0147882c99ca283ae2b8deed364cd298314e65"
 dependencies = [
- "cairo-lang-filesystem 2.17.0-rc.4",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-filesystem 2.17.0",
+ "cairo-lang-utils 2.17.0",
  "serde",
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
@@ -2176,38 +2176,38 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runnable-utils"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4e9452504d2f146dd9b47e6654111d2ad081e2dff0b19edff5d0fd36748d67"
+checksum = "56ece337212dc333bf6886200447aa8a23d6e3c9dd9e47427cf17fe8f758fd30"
 dependencies = [
- "cairo-lang-casm 2.17.0-rc.4",
- "cairo-lang-sierra 2.17.0-rc.4",
- "cairo-lang-sierra-ap-change 2.17.0-rc.4",
- "cairo-lang-sierra-gas 2.17.0-rc.4",
- "cairo-lang-sierra-to-casm 2.17.0-rc.4",
+ "cairo-lang-casm 2.17.0",
+ "cairo-lang-sierra 2.17.0",
+ "cairo-lang-sierra-ap-change 2.17.0",
+ "cairo-lang-sierra-gas 2.17.0",
+ "cairo-lang-sierra-to-casm 2.17.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-utils 2.17.0",
  "cairo-vm",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f973b5848f89e1afcaa9b11abd03d3e15b0530c49b34e45fc601590b0a4b65ba"
+checksum = "1b4be6e8debecd1db3777ea781938da250f7a148ffba60400a35cee3e711d5ec"
 dependencies = [
  "ark-ff 0.5.0",
  "ark-secp256k1",
  "ark-secp256r1",
- "cairo-lang-casm 2.17.0-rc.4",
- "cairo-lang-lowering 2.17.0-rc.4",
+ "cairo-lang-casm 2.17.0",
+ "cairo-lang-lowering 2.17.0",
  "cairo-lang-runnable-utils",
- "cairo-lang-sierra 2.17.0-rc.4",
- "cairo-lang-sierra-generator 2.17.0-rc.4",
- "cairo-lang-sierra-to-casm 2.17.0-rc.4",
- "cairo-lang-starknet 2.17.0-rc.4",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-sierra 2.17.0",
+ "cairo-lang-sierra-generator 2.17.0",
+ "cairo-lang-sierra-to-casm 2.17.0",
+ "cairo-lang-starknet 2.17.0",
+ "cairo-lang-utils 2.17.0",
  "cairo-vm",
  "clap",
  "itertools 0.14.0",
@@ -2215,7 +2215,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "salsa 0.26.0",
  "serde",
  "sha2",
@@ -2248,20 +2248,20 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b59bb17344fbdd66115c040663a0e70f1613bfcee4a15fd3ee9b5a62c8f4ed1"
+checksum = "3db81fec05c8ad0565f7392826491ebbec3b133c7b8395af0aa717eb6ac6e238"
 dependencies = [
- "cairo-lang-debug 2.17.0-rc.4",
- "cairo-lang-defs 2.17.0-rc.4",
- "cairo-lang-diagnostics 2.17.0-rc.4",
- "cairo-lang-filesystem 2.17.0-rc.4",
- "cairo-lang-parser 2.17.0-rc.4",
- "cairo-lang-plugins 2.17.0-rc.4",
- "cairo-lang-proc-macros 2.17.0-rc.4",
- "cairo-lang-syntax 2.17.0-rc.4",
+ "cairo-lang-debug 2.17.0",
+ "cairo-lang-defs 2.17.0",
+ "cairo-lang-diagnostics 2.17.0",
+ "cairo-lang-filesystem 2.17.0",
+ "cairo-lang-parser 2.17.0",
+ "cairo-lang-plugins 2.17.0",
+ "cairo-lang-proc-macros 2.17.0",
+ "cairo-lang-syntax 2.17.0",
  "cairo-lang-test-utils",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-utils 2.17.0",
  "id-arena",
  "indoc",
  "itertools 0.14.0",
@@ -2301,12 +2301,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b870a259cdbe4870d4c1012ec7177951e24c4ac722f9d005fde2523e1ee3fe6b"
+checksum = "502621e024cee958383911a0f452dd5ca9f28fb38a19af1c5495959e37a3eb61"
 dependencies = [
  "anyhow",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-utils 2.17.0",
  "const-fnv1a-hash",
  "convert_case 0.11.0",
  "derivative",
@@ -2340,14 +2340,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12eda47418f539da02df223437d22a5b802bf5621df191c47c4abc08c033125e"
+checksum = "1c66ee91c74c1904ef34baa459ba15f6a0862a512bbb21bd31d28c74adeded0d"
 dependencies = [
- "cairo-lang-eq-solver 2.17.0-rc.4",
- "cairo-lang-sierra 2.17.0-rc.4",
+ "cairo-lang-eq-solver 2.17.0",
+ "cairo-lang-sierra 2.17.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-utils 2.17.0",
  "itertools 0.14.0",
  "num-bigint",
  "num-traits",
@@ -2369,14 +2369,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683dc16f1983afc0061331e48259e0add0bd31cbe1aed4fc28e9cfcb8c7455df"
+checksum = "4edc5decd268d87cfb6b1216f97a19251f61036766f86e54e60c28875aa1981b"
 dependencies = [
- "cairo-lang-eq-solver 2.17.0-rc.4",
- "cairo-lang-sierra 2.17.0-rc.4",
+ "cairo-lang-eq-solver 2.17.0",
+ "cairo-lang-sierra 2.17.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-utils 2.17.0",
  "itertools 0.14.0",
  "num-bigint",
  "num-traits",
@@ -2411,20 +2411,20 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcae17f00ac91a26ab049068fd34e5d7f0d062bd45db7fb97ca8d1056ce6df4d"
+checksum = "478bb115f2e9163d07b66875afe43eafac48c631f77a242ccddb4fa82f939ef7"
 dependencies = [
- "cairo-lang-debug 2.17.0-rc.4",
- "cairo-lang-defs 2.17.0-rc.4",
- "cairo-lang-diagnostics 2.17.0-rc.4",
- "cairo-lang-filesystem 2.17.0-rc.4",
- "cairo-lang-lowering 2.17.0-rc.4",
- "cairo-lang-proc-macros 2.17.0-rc.4",
- "cairo-lang-semantic 2.17.0-rc.4",
- "cairo-lang-sierra 2.17.0-rc.4",
- "cairo-lang-syntax 2.17.0-rc.4",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-debug 2.17.0",
+ "cairo-lang-defs 2.17.0",
+ "cairo-lang-diagnostics 2.17.0",
+ "cairo-lang-filesystem 2.17.0",
+ "cairo-lang-lowering 2.17.0",
+ "cairo-lang-proc-macros 2.17.0",
+ "cairo-lang-semantic 2.17.0",
+ "cairo-lang-sierra 2.17.0",
+ "cairo-lang-syntax 2.17.0",
+ "cairo-lang-utils 2.17.0",
  "itertools 0.14.0",
  "num-traits",
  "rayon",
@@ -2459,17 +2459,17 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6c02d7c7b256cfbee7af138b5ada564498e36d4c59abaa4ec15e0d4d8b307d"
+checksum = "383614515e62d7b4cbf57ee957c856cb74f41cdca8d39fd91d4b6167fe7d5205"
 dependencies = [
  "assert_matches",
- "cairo-lang-casm 2.17.0-rc.4",
- "cairo-lang-sierra 2.17.0-rc.4",
- "cairo-lang-sierra-ap-change 2.17.0-rc.4",
- "cairo-lang-sierra-gas 2.17.0-rc.4",
+ "cairo-lang-casm 2.17.0",
+ "cairo-lang-sierra 2.17.0",
+ "cairo-lang-sierra-ap-change 2.17.0",
+ "cairo-lang-sierra-gas 2.17.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-utils 2.17.0",
  "indoc",
  "itertools 0.14.0",
  "num-bigint",
@@ -2480,12 +2480,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9f01e4a110a5493d3794c06dcc08e1a8c0c0cee6436db40c6216ae0b0a847d"
+checksum = "baf49a0eea70720f60a3c62b739e102e731898ab6b86b9137128cb6675b2946f"
 dependencies = [
- "cairo-lang-sierra 2.17.0-rc.4",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-sierra 2.17.0",
+ "cairo-lang-utils 2.17.0",
 ]
 
 [[package]]
@@ -2531,24 +2531,24 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a9faa4b3349e9899972d9ef37bb08904e0c2c802278b2afc4b3e51d87f6f1c"
+checksum = "e0ac5834c14d9f63ee47f5a7014f55868a104472b264d50a18c1d3e6087d9b23"
 dependencies = [
  "anyhow",
- "cairo-lang-compiler 2.17.0-rc.4",
- "cairo-lang-defs 2.17.0-rc.4",
- "cairo-lang-diagnostics 2.17.0-rc.4",
- "cairo-lang-filesystem 2.17.0-rc.4",
- "cairo-lang-lowering 2.17.0-rc.4",
- "cairo-lang-parser 2.17.0-rc.4",
- "cairo-lang-plugins 2.17.0-rc.4",
- "cairo-lang-semantic 2.17.0-rc.4",
- "cairo-lang-sierra 2.17.0-rc.4",
- "cairo-lang-sierra-generator 2.17.0-rc.4",
+ "cairo-lang-compiler 2.17.0",
+ "cairo-lang-defs 2.17.0",
+ "cairo-lang-diagnostics 2.17.0",
+ "cairo-lang-filesystem 2.17.0",
+ "cairo-lang-lowering 2.17.0",
+ "cairo-lang-parser 2.17.0",
+ "cairo-lang-plugins 2.17.0",
+ "cairo-lang-semantic 2.17.0",
+ "cairo-lang-sierra 2.17.0",
+ "cairo-lang-sierra-generator 2.17.0",
  "cairo-lang-starknet-classes",
- "cairo-lang-syntax 2.17.0-rc.4",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-syntax 2.17.0",
+ "cairo-lang-utils 2.17.0",
  "const_format",
  "indent",
  "indoc",
@@ -2564,15 +2564,15 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d9733079428e92c16c67de32ff329140c47e979c1e0a399115454429159fbd"
+checksum = "68338c5f1c1b35ff83e813f2e03c76fff3aa225e623a175339b95c8c8d097752"
 dependencies = [
- "cairo-lang-casm 2.17.0-rc.4",
- "cairo-lang-sierra 2.17.0-rc.4",
- "cairo-lang-sierra-to-casm 2.17.0-rc.4",
+ "cairo-lang-casm 2.17.0",
+ "cairo-lang-sierra 2.17.0",
+ "cairo-lang-sierra-to-casm 2.17.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-utils 2.17.0",
  "convert_case 0.11.0",
  "itertools 0.14.0",
  "num-bigint",
@@ -2605,15 +2605,15 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1e3372dc7dae119038822b8e697f3ad5db32610c7edf6ef9bcf5ba0efbacd4"
+checksum = "3a78fd0ee5fe06c1cefa753013ae4c5131366db03bda0118b771a72f2249ae05"
 dependencies = [
- "cairo-lang-debug 2.17.0-rc.4",
- "cairo-lang-filesystem 2.17.0-rc.4",
+ "cairo-lang-debug 2.17.0",
+ "cairo-lang-filesystem 2.17.0",
  "cairo-lang-primitive-token",
- "cairo-lang-proc-macros 2.17.0-rc.4",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-proc-macros 2.17.0",
+ "cairo-lang-utils 2.17.0",
  "itertools 0.14.0",
  "num-bigint",
  "num-traits",
@@ -2636,9 +2636,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be894f3cff1edb12b8b76e6c0db361a422c14528d015dd9792b06a0fe62da513"
+checksum = "1156d7e1f15e5ddcc0bdbd1fc30c2fbf9572c53155a8b0c6a42cee6da8751db6"
 dependencies = [
  "genco 0.19.0",
  "xshell",
@@ -2646,13 +2646,13 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-utils"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53237008d9bcd9ed9aaf71b77b0252895f928a26565b2ab4d0cbe78613f42850"
+checksum = "56b1327c8628766d28458acaa1ce3b063de15dca16bd985f0fe366c9fc974003"
 dependencies = [
  "cairo-lang-formatter",
- "cairo-lang-proc-macros 2.17.0-rc.4",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-proc-macros 2.17.0",
+ "cairo-lang-utils 2.17.0",
  "colored 3.1.1",
  "log",
  "pretty_assertions",
@@ -2677,12 +2677,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.17.0-rc.4"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fae6863d3e0768a860a7e60208f7bc2caae2cd5eec103eed5993e08c9351d28"
+checksum = "0a7b5af507f42080931a1562560736a09ba934226189cc6d7404a966d0313cfb"
 dependencies = [
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "num-bigint",
  "num-traits",
@@ -2709,16 +2709,16 @@ dependencies = [
  "ark-secp256k1",
  "ark-secp256r1",
  "bumpalo",
- "cairo-lang-lowering 2.17.0-rc.4",
+ "cairo-lang-lowering 2.17.0",
  "cairo-lang-runner",
- "cairo-lang-sierra 2.17.0-rc.4",
- "cairo-lang-sierra-ap-change 2.17.0-rc.4",
- "cairo-lang-sierra-gas 2.17.0-rc.4",
- "cairo-lang-sierra-to-casm 2.17.0-rc.4",
+ "cairo-lang-sierra 2.17.0",
+ "cairo-lang-sierra-ap-change 2.17.0",
+ "cairo-lang-sierra-gas 2.17.0",
+ "cairo-lang-sierra-to-casm 2.17.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-starknet 2.17.0-rc.4",
+ "cairo-lang-starknet 2.17.0",
  "cairo-lang-starknet-classes",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-utils 2.17.0",
  "educe 0.5.11",
  "itertools 0.14.0",
  "keccak",
@@ -2732,7 +2732,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "sha2",
@@ -2794,9 +2794,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2914,6 +2914,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "cobs"
@@ -3112,6 +3118,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3204,13 +3216,14 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.6.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96272c2ff28b807e09250b180ad1fb7889a3258f7455759b5c3c58b719467130"
+checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
 dependencies = [
+ "cpubits",
+ "ctutils",
  "hybrid-array",
  "num-traits",
- "subtle",
  "zeroize",
 ]
 
@@ -3231,6 +3244,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -3752,9 +3774,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fastrlp"
@@ -3872,9 +3894,12 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "fs_extra"
@@ -4098,9 +4123,9 @@ dependencies = [
 
 [[package]]
 name = "good_lp"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c071f15f0c38eb6445a8100660c5806f4c597b611f24442de1b31b87d41da5c"
+checksum = "cf53d2a05420f562c917615b80018647ca03766aa58376de077034627da0fb10"
 dependencies = [
  "fnv",
  "microlp",
@@ -4129,7 +4154,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -4186,6 +4211,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -4323,9 +4354,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.3"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "typenum",
 ]
@@ -4354,15 +4385,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -4419,12 +4449,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -4432,9 +4463,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -4445,9 +4476,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -4459,15 +4490,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -4479,15 +4510,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -4641,12 +4672,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -4690,7 +4721,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "listeners",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reqwest",
  "serde",
  "serde_json",
@@ -4703,7 +4734,7 @@ dependencies = [
  "starknet_api",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "universal-sierra-compiler",
  "url",
 ]
@@ -4857,9 +4888,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5031,9 +5062,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -5052,10 +5083,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libredox"
-version = "0.1.15"
+name = "libmimalloc-sys"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
@@ -5086,9 +5127,9 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llvm-sys"
@@ -5101,7 +5142,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "regex-lite",
- "semver 1.0.27",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -5130,9 +5171,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -5239,6 +5280,15 @@ dependencies = [
  "log",
  "sprs",
  "web-time",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -5526,11 +5576,11 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -5558,18 +5608,18 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.5+3.5.5"
+version = "300.6.0+3.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
@@ -5704,7 +5754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -5714,7 +5764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset 0.5.7",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -5809,9 +5859,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -5843,9 +5893,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -6005,9 +6055,9 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.10",
@@ -6058,7 +6108,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -6125,9 +6175,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -6188,7 +6238,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04db2e382d13679a1e42400e90e306cdbb79dc5cd41bb035ba4eae72e78cdf37"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex-syntax 0.8.10",
 ]
 
@@ -6218,9 +6268,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -6251,7 +6301,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -6445,7 +6495,7 @@ dependencies = [
  "primitive-types 0.12.2",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rlp 0.5.2",
  "ruint-macro",
  "serde_core",
@@ -6502,7 +6552,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.27",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -6511,7 +6561,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -6524,7 +6574,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -6533,9 +6583,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -6596,9 +6646,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -6658,7 +6708,7 @@ dependencies = [
  "crossbeam-utils",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "intrusive-collections",
  "inventory",
  "parking_lot 0.12.5",
@@ -6841,7 +6891,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -6869,9 +6919,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -6933,7 +6983,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -6994,7 +7044,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -7021,7 +7071,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -7265,7 +7315,7 @@ dependencies = [
  "flate2",
  "foldhash 0.1.5",
  "hex",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "num-traits",
  "serde",
  "serde_json",
@@ -7351,15 +7401,15 @@ dependencies = [
  "cargo-platform",
  "clap",
  "hex",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "lazy_static",
- "lru 0.16.3",
+ "lru 0.16.4",
  "nonzero_ext",
  "once_cell",
  "openssl",
  "parking_lot 0.12.5",
  "prometheus",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_mt",
  "reqwest",
  "serde",
@@ -7387,7 +7437,7 @@ dependencies = [
  "http-body-util",
  "lazy_static",
  "prometheus",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_regex",
  "reqwest",
@@ -7414,22 +7464,22 @@ dependencies = [
  "base64 0.22.1",
  "bigdecimal",
  "blockifier",
- "cairo-lang-casm 2.17.0-rc.4",
- "cairo-lang-compiler 2.17.0-rc.4",
- "cairo-lang-defs 2.17.0-rc.4",
- "cairo-lang-diagnostics 2.17.0-rc.4",
- "cairo-lang-filesystem 2.17.0-rc.4",
- "cairo-lang-lowering 2.17.0-rc.4",
- "cairo-lang-semantic 2.17.0-rc.4",
- "cairo-lang-sierra 2.17.0-rc.4",
- "cairo-lang-sierra-generator 2.17.0-rc.4",
- "cairo-lang-sierra-to-casm 2.17.0-rc.4",
+ "cairo-lang-casm 2.17.0",
+ "cairo-lang-compiler 2.17.0",
+ "cairo-lang-defs 2.17.0",
+ "cairo-lang-diagnostics 2.17.0",
+ "cairo-lang-filesystem 2.17.0",
+ "cairo-lang-lowering 2.17.0",
+ "cairo-lang-semantic 2.17.0",
+ "cairo-lang-sierra 2.17.0",
+ "cairo-lang-sierra-generator 2.17.0",
+ "cairo-lang-sierra-to-casm 2.17.0",
  "cairo-lang-starknet-classes",
- "cairo-lang-syntax 2.17.0-rc.4",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-syntax 2.17.0",
+ "cairo-lang-utils 2.17.0",
  "cairo-vm",
  "flate2",
- "lru 0.16.3",
+ "lru 0.16.4",
  "num-bigint",
  "parity-scale-codec",
  "parity-scale-codec-derive",
@@ -7446,9 +7496,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-rust-accounts"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b44a478beea593433568033ddf98652c82c40964f184d5538227fa62b73bb44"
+checksum = "23552b3f35b8535bade1e7d151071ec00216f1eb7ef7d2dec4d5fa732728edd8"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -7461,9 +7511,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-rust-contract"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9823c26cb78c4e6df65f9f6ee59cd299f85a93694dc8322fe1fe3b868af065e"
+checksum = "93364bcf91df50f95c4a31230a629a68b0f51960bae0247eb10493c7efe36c76"
 dependencies = [
  "serde_json",
  "starknet-rust-accounts",
@@ -7473,18 +7523,18 @@ dependencies = [
 
 [[package]]
 name = "starknet-rust-core"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "569226367a40cddf07f7f14383f5be9f4c1fa52cef7be2d905fa2a897f981809"
+checksum = "c3df45149a385127210bbd9bd06cbf5cee09b0e7c17ba65829eec64c6eff37b2"
 dependencies = [
  "base64 0.22.1",
- "crypto-bigint 0.6.1",
+ "crypto-bigint 0.7.3",
  "flate2",
  "foldhash 0.2.0",
  "hex",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "num-traits",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "serde_json_pythonic",
@@ -7497,9 +7547,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-rust-core-derive"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d911d1ca1ed6ecebe90d124d12b61f16739e25fa6687485815beaa7f81ea3e"
+checksum = "8500b18bdc6e7db3c012ee2a04bd134c23290e04a6d08b4d2c8e976be793d639"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7508,12 +7558,12 @@ dependencies = [
 
 [[package]]
 name = "starknet-rust-crypto"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf77ef1ab88a77d148667c04fe4861cd781c69d3ce1d46c1feeef9fb9cacba5"
+checksum = "d2d8000df55d98f3910ef66e8e0cfeac398dd5f335613a497b0e2c905cb728fa"
 dependencies = [
  "blake2",
- "crypto-bigint 0.6.1",
+ "crypto-bigint 0.7.3",
  "digest 0.10.7",
  "hex",
  "hmac",
@@ -7529,18 +7579,18 @@ dependencies = [
 
 [[package]]
 name = "starknet-rust-curve"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d622cdfeafddcd71fe264b091182b5b4b346b2facd77633cd84d6583ea3903c"
+checksum = "3ee2272de9f1fd3c41c32238500fab9c377571e706db87e1d96d60379536cd7d"
 dependencies = [
  "starknet-types-core",
 ]
 
 [[package]]
 name = "starknet-rust-providers"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4b352ab86502a900bbe0c532979a48c09b8416732a8e947335bea409e3af81"
+checksum = "c176e31616e2768129fa0b13adf8325b28f2ae2afb4f1a34e5abd21477caa276"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -7559,13 +7609,13 @@ dependencies = [
 
 [[package]]
 name = "starknet-rust-signers"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a2d55bc378e906cf8855e328071ed8ace79dba340a4224ffa0d834f1b99bda"
+checksum = "20c3115dbe415b97eefa39f1176831bfcc4717360ceb25ac5cfdb1349bf16aff"
 dependencies = [
  "async-trait",
  "auto_impl",
- "crypto-bigint 0.6.1",
+ "crypto-bigint 0.7.3",
  "eth-keystore",
  "getrandom 0.2.17",
  "rand 0.8.5",
@@ -7590,7 +7640,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "zeroize",
 ]
@@ -7608,12 +7658,12 @@ dependencies = [
  "cached",
  "cairo-lang-runner",
  "cairo-lang-starknet-classes",
- "cairo-lang-utils 2.17.0-rc.4",
+ "cairo-lang-utils 2.17.0",
  "derive_more",
  "expect-test",
  "flate2",
  "hex",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.12.1",
  "json-patch",
  "num-bigint",
@@ -7621,7 +7671,7 @@ dependencies = [
  "pretty_assertions",
  "primitive-types 0.12.2",
  "rand 0.8.5",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "sha3",
@@ -7751,7 +7801,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -7834,9 +7884,9 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thin-vec"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 
 [[package]]
 name = "thiserror"
@@ -7940,9 +7990,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -7965,9 +8015,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -7982,9 +8032,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8022,7 +8072,19 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.28.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -8053,7 +8115,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -8082,11 +8144,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.9+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da053d28fe57e2c9d21b48261e14e7b4c8b670b54d2c684847b91feaf4c7dac5"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.1",
@@ -8094,9 +8156,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.1",
 ]
@@ -8131,7 +8193,7 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -8246,10 +8308,26 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8392,18 +8470,19 @@ checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "universal-sierra-compiler"
-version = "2.8.0-rc.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f8d249fe0a037e862ebde081e1cb1bb7210986d199970f3cb5c21687f21d757"
+checksum = "e0ff36d1120fdf2718fd261f07b2350f148fcd54f9dabb9bb7a8fe6762889594"
 dependencies = [
  "anyhow",
- "cairo-lang-sierra 2.17.0-rc.4",
- "cairo-lang-sierra-to-casm 2.17.0-rc.4",
+ "cairo-lang-sierra 2.17.0",
+ "cairo-lang-sierra-to-casm 2.17.0",
  "cairo-lang-sierra-type-size",
  "cairo-lang-starknet 1.0.0-rc0",
  "cairo-lang-starknet-classes",
  "clap",
  "console",
+ "mimalloc",
  "serde_core",
  "serde_json",
  "tracing",
@@ -8603,9 +8682,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8616,9 +8695,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8626,9 +8705,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8636,9 +8715,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -8649,9 +8728,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -8673,7 +8752,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -8684,10 +8763,10 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver 1.0.27",
+ "indexmap 2.14.0",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -8706,9 +8785,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9175,7 +9254,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -9205,8 +9284,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -9225,9 +9304,9 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_derive",
  "serde_json",
@@ -9237,9 +9316,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -9279,9 +9358,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -9290,9 +9369,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9322,18 +9401,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9363,9 +9442,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -9374,9 +9453,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -9385,9 +9464,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ rand_mt = "5.0.0"
 rand_regex = "0.18.1"
 reqwest = { version = "0.13.2", features = ["json"] }
 url = "2.5"
-usc = { version = "2.8.0-rc.0", package = "universal-sierra-compiler" }
+usc = { version = "2.8.0", package = "universal-sierra-compiler" }
 num-bigint = { version = "0.4" }
 bigdecimal = { version = "0.4.9" }
 enum-helper-macros = "0.0.1"
@@ -87,28 +87,28 @@ blockifier = { version = "0.18.0-rc.1" }
 
 apollo_compilation_utils = { version = "0.18.0-rc.1"}
 
-starknet-rs-signers = { version = "0.19.0-rc.2", package = "starknet-rust-signers" }
-starknet-rs-core = { version = "0.19.0-rc.2", package = "starknet-rust-core" }
-starknet-rs-providers = { version = "0.19.0-rc.2", package = "starknet-rust-providers" }
-starknet-rs-accounts = { version = "0.19.0-rc.2", package = "starknet-rust-accounts" }
-starknet-rs-contract = { version = "0.19.0-rc.2", package = "starknet-rust-contract" }
+starknet-rs-signers = { version = "0.19.0", package = "starknet-rust-signers" }
+starknet-rs-core = { version = "0.19.0", package = "starknet-rust-core" }
+starknet-rs-providers = { version = "0.19.0", package = "starknet-rust-providers" }
+starknet-rs-accounts = { version = "0.19.0", package = "starknet-rust-accounts" }
+starknet-rs-contract = { version = "0.19.0", package = "starknet-rust-contract" }
 
 cairo-vm = "=3.2.0"
 
 # Cairo-lang dependencies
-cairo-lang-starknet-classes = "=2.17.0-rc.4"
-cairo-lang-compiler = "=2.17.0-rc.4"
-cairo-lang-casm = "=2.17.0-rc.4"
-cairo-lang-defs = "=2.17.0-rc.4"
-cairo-lang-diagnostics = "=2.17.0-rc.4"
-cairo-lang-filesystem = "=2.17.0-rc.4"
-cairo-lang-lowering = "=2.17.0-rc.4"
-cairo-lang-semantic = "=2.17.0-rc.4"
-cairo-lang-sierra = "=2.17.0-rc.4"
-cairo-lang-sierra-generator = "=2.17.0-rc.4"
-cairo-lang-sierra-to-casm = "=2.17.0-rc.4"
-cairo-lang-syntax = "=2.17.0-rc.4"
-cairo-lang-utils = "=2.17.0-rc.4"
+cairo-lang-starknet-classes = "=2.17.0"
+cairo-lang-compiler = "=2.17.0"
+cairo-lang-casm = "=2.17.0"
+cairo-lang-defs = "=2.17.0"
+cairo-lang-diagnostics = "=2.17.0"
+cairo-lang-filesystem = "=2.17.0"
+cairo-lang-lowering = "=2.17.0"
+cairo-lang-semantic = "=2.17.0"
+cairo-lang-sierra = "=2.17.0"
+cairo-lang-sierra-generator = "=2.17.0"
+cairo-lang-sierra-to-casm = "=2.17.0"
+cairo-lang-syntax = "=2.17.0"
+cairo-lang-utils = "=2.17.0"
 
 # Inner dependencies
 starknet-types = { version = "0.8.0-rc.3", path = "crates/starknet-devnet-types", package = "starknet-devnet-types" }


### PR DESCRIPTION
## Usage related changes

Upgrades all RC-pinned dependencies to their stable releases:
- `cairo-lang-*`: `2.17.0-rc.4` → `2.17.0`
- `starknet-rs-*`: `0.19.0-rc.2` → `0.19.0`
- `usc`: `2.8.0-rc.0` → `2.8.0`

No user-facing API changes. Users benefit from final bug fixes included in stable releases.

## Development related changes

`Cargo.toml` version pins updated and `Cargo.lock` regenerated. No code changes required.

## Checklist:

- [x] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
- [ ] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)

Closes #919