### PR TITLE
Update tracing to disable cairo runner target logs

### DIFF
--- a/crates/starknet-devnet/src/main.rs
+++ b/crates/starknet-devnet/src/main.rs
@@ -69,9 +69,13 @@ fn configure_tracing() {
         .collect::<Vec<&str>>()
         .join(",");
 
-    let level_filter_layer = EnvFilter::builder()
+    let mut level_filter_layer = EnvFilter::builder()
         .with_default_directive(tracing::Level::INFO.into())
         .parse_lossy(log_env_var);
+
+    if let Ok(cairo_runner_directive) = "cairo_vm::vm::runners::cairo_runner=off".parse() {
+        level_filter_layer = level_filter_layer.add_directive(cairo_runner_directive);
+    }
 
     tracing_subscriber::fmt().with_env_filter(level_filter_layer).init();
 }


### PR DESCRIPTION
## Usage related changes

- Updated tracing configuration to explicitly disable logs from the cairo runner target while retaining the existing environment-driven filtering behavior.

## Development related changes

- Switched the local tracing filter variable to mutable and added a typed directive via `EnvFilter::add_directive` for `cairo_vm::vm::runners::cairo_runner=off`.

## Checklist:

- [x] Checked out the [contribution guidelines](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)
