### PR TITLE
feat: Add starknetfoundation Docker namespace and migrate docs

### DIFF
--- a/.github/actions/load-config/action.yml
+++ b/.github/actions/load-config/action.yml
@@ -14,6 +14,9 @@ outputs:
   docker_namespace:
     description: 'Docker namespace to use'
     value: 'shardlabs'
+  docker_namespace_secondary:
+    description: 'Secondary Docker namespace to push to'
+    value: 'starknetfoundation'
   image_name:
     description: 'Docker image name to use'
     value: 'starknet-devnet-rs'

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -185,14 +185,19 @@ jobs:
         run: |
           DOCKER_REGISTRY="${{ steps.config.outputs.docker_registry }}"
           DOCKER_NAMESPACE="${{ steps.config.outputs.docker_namespace }}"
+          DOCKER_NAMESPACE_SECONDARY="${{ steps.config.outputs.docker_namespace_secondary }}"
           IMAGE_NAME="${{ steps.config.outputs.image_name }}"
           SHA="${{ needs.prepare.outputs.sha }}"
           
           SHA_TAG="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$IMAGE_NAME:sha-$SHA"
           SHA_SEED0_TAG="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$IMAGE_NAME:sha-$SHA-seed0"
+          SHA_TAG_SECONDARY="$DOCKER_REGISTRY/$DOCKER_NAMESPACE_SECONDARY/$IMAGE_NAME:sha-$SHA"
+          SHA_SEED0_TAG_SECONDARY="$DOCKER_REGISTRY/$DOCKER_NAMESPACE_SECONDARY/$IMAGE_NAME:sha-$SHA-seed0"
           
           echo "sha_tag=$SHA_TAG" >> $GITHUB_OUTPUT
           echo "sha_seed0_tag=$SHA_SEED0_TAG" >> $GITHUB_OUTPUT
+          echo "sha_tag_secondary=$SHA_TAG_SECONDARY" >> $GITHUB_OUTPUT
+          echo "sha_seed0_tag_secondary=$SHA_SEED0_TAG_SECONDARY" >> $GITHUB_OUTPUT
 
       - name: Prepare version tags
         id: version_tags
@@ -200,14 +205,19 @@ jobs:
         run: |
           DOCKER_REGISTRY="${{ steps.config.outputs.docker_registry }}"
           DOCKER_NAMESPACE="${{ steps.config.outputs.docker_namespace }}"
+          DOCKER_NAMESPACE_SECONDARY="${{ steps.config.outputs.docker_namespace_secondary }}"
           IMAGE_NAME="${{ steps.config.outputs.image_name }}"
           VERSION="${{ needs.prepare.outputs.version }}"
           
           VERSION_TAG="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$IMAGE_NAME:$VERSION"
           VERSION_SEED0_TAG="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$IMAGE_NAME:$VERSION-seed0"
+          VERSION_TAG_SECONDARY="$DOCKER_REGISTRY/$DOCKER_NAMESPACE_SECONDARY/$IMAGE_NAME:$VERSION"
+          VERSION_SEED0_TAG_SECONDARY="$DOCKER_REGISTRY/$DOCKER_NAMESPACE_SECONDARY/$IMAGE_NAME:$VERSION-seed0"
           
           echo "version_tag=$VERSION_TAG" >> $GITHUB_OUTPUT
           echo "version_seed0_tag=$VERSION_SEED0_TAG" >> $GITHUB_OUTPUT
+          echo "version_tag_secondary=$VERSION_TAG_SECONDARY" >> $GITHUB_OUTPUT
+          echo "version_seed0_tag_secondary=$VERSION_SEED0_TAG_SECONDARY" >> $GITHUB_OUTPUT
       
       - name: Prepare latest tags
         id: latest_tags
@@ -215,25 +225,33 @@ jobs:
         run: |
           DOCKER_REGISTRY="${{ steps.config.outputs.docker_registry }}"
           DOCKER_NAMESPACE="${{ steps.config.outputs.docker_namespace }}"
+          DOCKER_NAMESPACE_SECONDARY="${{ steps.config.outputs.docker_namespace_secondary }}"
           IMAGE_NAME="${{ steps.config.outputs.image_name }}"
           
           LATEST_TAG="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$IMAGE_NAME:latest"
           LATEST_SEED0_TAG="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$IMAGE_NAME:latest-seed0"
+          LATEST_TAG_SECONDARY="$DOCKER_REGISTRY/$DOCKER_NAMESPACE_SECONDARY/$IMAGE_NAME:latest"
+          LATEST_SEED0_TAG_SECONDARY="$DOCKER_REGISTRY/$DOCKER_NAMESPACE_SECONDARY/$IMAGE_NAME:latest-seed0"
           
           echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
           echo "latest_seed0_tag=$LATEST_SEED0_TAG" >> $GITHUB_OUTPUT
+          echo "latest_tag_secondary=$LATEST_TAG_SECONDARY" >> $GITHUB_OUTPUT
+          echo "latest_seed0_tag_secondary=$LATEST_SEED0_TAG_SECONDARY" >> $GITHUB_OUTPUT
           
       - name: Combine tags for standard image
         id: combined_tags
         run: |
           TAGS=("${{ steps.sha_tags.outputs.sha_tag }}")
+          TAGS+=("${{ steps.sha_tags.outputs.sha_tag_secondary }}")
           
           if [[ -n "${{ steps.version_tags.outputs.version_tag }}" ]]; then
             TAGS+=("${{ steps.version_tags.outputs.version_tag }}")
+            TAGS+=("${{ steps.version_tags.outputs.version_tag_secondary }}")
           fi
           
           if [[ -n "${{ steps.latest_tags.outputs.latest_tag }}" ]]; then
             TAGS+=("${{ steps.latest_tags.outputs.latest_tag }}")
+            TAGS+=("${{ steps.latest_tags.outputs.latest_tag_secondary }}")
           fi
           
           echo "tags=$(IFS=,; echo "${TAGS[*]}")" >> $GITHUB_OUTPUT
@@ -242,13 +260,16 @@ jobs:
         id: combined_seed0_tags
         run: |
           SEED0_TAGS=("${{ steps.sha_tags.outputs.sha_seed0_tag }}")
+          SEED0_TAGS+=("${{ steps.sha_tags.outputs.sha_seed0_tag_secondary }}")
           
           if [[ -n "${{ steps.version_tags.outputs.version_seed0_tag }}" ]]; then
             SEED0_TAGS+=("${{ steps.version_tags.outputs.version_seed0_tag }}")
+            SEED0_TAGS+=("${{ steps.version_tags.outputs.version_seed0_tag_secondary }}")
           fi
           
           if [[ -n "${{ steps.latest_tags.outputs.latest_seed0_tag }}" ]]; then
             SEED0_TAGS+=("${{ steps.latest_tags.outputs.latest_seed0_tag }}")
+            SEED0_TAGS+=("${{ steps.latest_tags.outputs.latest_seed0_tag_secondary }}")
           fi
           
           echo "tags=$(IFS=,; echo "${SEED0_TAGS[*]}")" >> $GITHUB_OUTPUT

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://crates.io/crates/starknet-devnet" target="_blank">
     <img src="https://img.shields.io/crates/v/starknet-devnet?color=yellow" style="max-width: 100%;">
   </a>
-  <a href="https://hub.docker.com/r/shardlabs/starknet-devnet-rs/tags" target="_blank">
+  <a href="https://hub.docker.com/r/starknetfoundation/starknet-devnet-rs/tags" target="_blank">
     <img src="https://img.shields.io/badge/dockerhub-images-important.svg?logo=Docker" style="max-width: 100%;">
   </a>
   <a href="https://starkware.co/" target="_blank">

--- a/website/docs/dump-load-restart.md
+++ b/website/docs/dump-load-restart.md
@@ -129,7 +129,7 @@ If there is `mydump` inside `/path/to/dumpdir`, you can load it with:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-path /path/to/dumpdir/mydump
 ```
 
@@ -139,6 +139,6 @@ To dump to `/path/to/dumpdir/mydump` on Devnet shutdown, run:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-on exit --dump-path /path/to/dumpdir/mydump
 ```

--- a/website/docs/metrics.md
+++ b/website/docs/metrics.md
@@ -25,7 +25,7 @@ $ METRICS_HOST=127.0.0.1 METRICS_PORT=8080 starknet-devnet
 If running with Docker:
 
 ```bash
-$ docker run -e METRICS_HOST=0.0.0.0 -e METRICS_PORT=9090 -p 9090:9090 shardlabs/starknet-devnet-rs
+$ docker run -e METRICS_HOST=0.0.0.0 -e METRICS_PORT=9090 -p 9090:9090 starknetfoundation/starknet-devnet-rs
 ```
 
 ## Accessing Metrics

--- a/website/docs/proofs.md
+++ b/website/docs/proofs.md
@@ -55,7 +55,7 @@ PROOF_MODE=devnet starknet-devnet
 ```bash
 docker run --rm -p 5050:5050 \
   -e PROOF_MODE=devnet \
-  shardlabs/starknet-devnet-rs
+  starknetfoundation/starknet-devnet-rs
 ```
 
 ## RPC: `starknet_proveTransaction`

--- a/website/docs/running/cli.md
+++ b/website/docs/running/cli.md
@@ -17,7 +17,7 @@ $ starknet-devnet --help
 Or if using dockerized Devnet:
 
 ```
-$ docker run --rm shardlabs/starknet-devnet-rs --help
+$ docker run --rm starknetfoundation/starknet-devnet-rs --help
 ```
 
 ## Environment variables
@@ -47,7 +47,7 @@ $ docker run \
     -e <VAR1>=<VALUE> \
     -e <VAR2>=<VALUE> \
     ... \
-    shardlabs/starknet-devnet-rs
+    starknetfoundation/starknet-devnet-rs
 ```
 
 ## Load configuration from a file
@@ -85,7 +85,7 @@ ACCOUNTS=3
 Then run:
 
 ```
-$ docker run --env-file .my-env-file shardlabs/starknet-devnet-rs
+$ docker run --env-file .my-env-file starknetfoundation/starknet-devnet-rs
 ```
 
 ## Proof-related configuration

--- a/website/docs/running/docker.md
+++ b/website/docs/running/docker.md
@@ -4,10 +4,10 @@ sidebar_position: 2.2
 
 # Run with Docker
 
-Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/shardlabs/starknet-devnet-rs/)). To download the `latest` image, run:
+Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/starknetfoundation/starknet-devnet-rs/)). To download the `latest` image, run:
 
 ```text
-$ docker pull shardlabs/starknet-devnet-rs
+$ docker pull starknetfoundation/starknet-devnet-rs
 ```
 
 Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm64).
@@ -15,7 +15,7 @@ Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm6
 Running a container is done like this (see [port publishing](#container-port-publishing) for more info):
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs [OPTIONS]
 ```
 
 ## Docker image tags
@@ -23,7 +23,7 @@ $ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
 All of the versions published on crates.io for starknet-devnet are available as docker images, which can be used via:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<CRATES_IO_VERSION>
+$ docker pull starknetfoundation/starknet-devnet-rs:<CRATES_IO_VERSION>
 ```
 
 :::note
@@ -37,7 +37,7 @@ The `latest` docker image tag corresponds to the last published version on crate
 Commits to the `main` branch of this repository are mostly available as images tagged with their commit hash (the full 40-lowercase-hex-digits SHA1 digest):
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<COMMIT_HASH>
+$ docker pull starknetfoundation/starknet-devnet-rs:<COMMIT_HASH>
 ```
 
 If a fix has been merged into the `main` branch of Devnet's code repository, you can access it before its inclusion in an official release. Just inspect the [`main` commit list](https://github.com/starknet-io/starknet-devnet/commits/main) and copy the full SHA digest of the commit containing the fix (or preferably the latest commit) which has a green check ✔️ symbol next to the commit date (which indicates the image indeed exists). Some revisions may not have a corresponding Docker image, but these are not supposed to be bugfixes.
@@ -47,8 +47,8 @@ If a fix has been merged into the `main` branch of Devnet's code repository, you
 By appending the `-seed0` suffix, you can use images which [predeploy funded accounts](../predeployed) with `--seed 0`, thus always predeploying the same set of accounts:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<VERSION>-seed0
-$ docker pull shardlabs/starknet-devnet-rs:latest-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:<VERSION>-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:latest-seed0
 ```
 
 ## Container port publishing
@@ -58,7 +58,7 @@ $ docker pull shardlabs/starknet-devnet-rs:latest-seed0
 If on a Linux host machine, you can use [`--network host`](https://docs.docker.com/network/host/). This way, the port used internally by the container is also available on your host machine. The `--port` option can be used (as well as other CLI options).
 
 ```text
-$ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
+$ docker run --network host starknetfoundation/starknet-devnet-rs [--port <PORT>]
 ```
 
 ### Mac and Windows
@@ -66,13 +66,13 @@ $ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
 If not on Linux, you need to publish the container's internally used port to a desired `<PORT>` on your host machine. The internal port is `5050` by default (probably not your concern, but can be overridden with `--port`).
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 E.g. if you want to use your host machine's `127.0.0.1:5050`, you need to run:
 
 ```text
-$ docker run -p 127.0.0.1:5050:5050 shardlabs/starknet-devnet-rs
+$ docker run -p 127.0.0.1:5050:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 You may ignore any address-related output logged on container startup (e.g. `Starknet Devnet listening on 0.0.0.0:5050`). What you will use is what you specified with the `-p` argument.
@@ -85,7 +85,7 @@ Due to internal needs, images with arch suffix are built and pushed to Docker Hu
 
 This is what happens under the hood on `main`:
 
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-amd`
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-arm`
-- create and push joint docker manifest called `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-amd`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-arm`
+- create and push joint docker manifest called `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>`
   - same for `latest`

--- a/website/docs/server-config.md
+++ b/website/docs/server-config.md
@@ -21,7 +21,7 @@ $ RUST_LOG=<LEVEL> starknet-devnet
 or if using dockerized Devnet:
 
 ```
-$ docker run -e RUST_LOG=<LEVEL> shardlabs/starknet-devnet-rs
+$ docker run -e RUST_LOG=<LEVEL> starknetfoundation/starknet-devnet-rs
 ```
 
 By default, logging of request and response data is turned off.

--- a/website/versioned_docs/version-0.3.0/dump-load-restart.md
+++ b/website/versioned_docs/version-0.3.0/dump-load-restart.md
@@ -142,7 +142,7 @@ If there is `mydump` inside `/path/to/dumpdir`, you can load it with:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-path /path/to/dumpdir/mydump
 ```
 
@@ -152,6 +152,6 @@ To dump to `/path/to/dumpdir/mydump` on Devnet shutdown, run:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-on exit --dump-path /path/to/dumpdir/mydump
 ```

--- a/website/versioned_docs/version-0.3.0/running/cli.md
+++ b/website/versioned_docs/version-0.3.0/running/cli.md
@@ -17,7 +17,7 @@ $ starknet-devnet --help
 Or if using dockerized Devnet:
 
 ```
-$ docker run --rm shardlabs/starknet-devnet-rs --help
+$ docker run --rm starknetfoundation/starknet-devnet-rs --help
 ```
 
 ## Environment variables
@@ -47,7 +47,7 @@ $ docker run \
     -e <VAR1>=<VALUE> \
     -e <VAR2>=<VALUE> \
     ... \
-    shardlabs/starknet-devnet-rs
+    starknetfoundation/starknet-devnet-rs
 ```
 
 ## Load configuration from a file
@@ -85,5 +85,5 @@ ACCOUNTS=3
 Then run:
 
 ```
-$ docker run --env-file .my-env-file shardlabs/starknet-devnet-rs
+$ docker run --env-file .my-env-file starknetfoundation/starknet-devnet-rs
 ```

--- a/website/versioned_docs/version-0.3.0/running/docker.md
+++ b/website/versioned_docs/version-0.3.0/running/docker.md
@@ -4,10 +4,10 @@ sidebar_position: 2.2
 
 # Run with Docker
 
-Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/shardlabs/starknet-devnet-rs/)). To download the `latest` image, run:
+Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/starknetfoundation/starknet-devnet-rs/)). To download the `latest` image, run:
 
 ```text
-$ docker pull shardlabs/starknet-devnet-rs
+$ docker pull starknetfoundation/starknet-devnet-rs
 ```
 
 Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm64).
@@ -15,7 +15,7 @@ Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm6
 Running a container is done like this (see [port publishing](#container-port-publishing) for more info):
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs [OPTIONS]
 ```
 
 ## Docker image tags
@@ -23,7 +23,7 @@ $ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
 All of the versions published on crates.io for starknet-devnet are available as docker images, which can be used via:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<CRATES_IO_VERSION>
+$ docker pull starknetfoundation/starknet-devnet-rs:<CRATES_IO_VERSION>
 ```
 
 :::note
@@ -37,7 +37,7 @@ The `latest` docker image tag corresponds to the last published version on crate
 Commits to the `main` branch of this repository are mostly available as images tagged with their commit hash (the full 40-lowercase-hex-digits SHA1 digest):
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<COMMIT_HASH>
+$ docker pull starknetfoundation/starknet-devnet-rs:<COMMIT_HASH>
 ```
 
 If a fix has been merged into the `main` branch of Devnet's code repository, you can access it before its inclusion in an official release. Just inspect the [`main` commit list](https://github.com/starknet-io/starknet-devnet/commits/main) and copy the full SHA digest of the commit containing the fix (or preferably the latest commit) which has a green check ✔️ symbol next to the commit date (which indicates the image indeed exists). Some revisions may not have a corresponding Docker image, but these are not supposed to be bugfixes.
@@ -47,8 +47,8 @@ If a fix has been merged into the `main` branch of Devnet's code repository, you
 By appending the `-seed0` suffix, you can use images which [predeploy funded accounts](../predeployed) with `--seed 0`, thus always predeploying the same set of accounts:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<VERSION>-seed0
-$ docker pull shardlabs/starknet-devnet-rs:latest-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:<VERSION>-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:latest-seed0
 ```
 
 ## Container port publishing
@@ -58,7 +58,7 @@ $ docker pull shardlabs/starknet-devnet-rs:latest-seed0
 If on a Linux host machine, you can use [`--network host`](https://docs.docker.com/network/host/). This way, the port used internally by the container is also available on your host machine. The `--port` option can be used (as well as other CLI options).
 
 ```text
-$ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
+$ docker run --network host starknetfoundation/starknet-devnet-rs [--port <PORT>]
 ```
 
 ### Mac and Windows
@@ -66,13 +66,13 @@ $ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
 If not on Linux, you need to publish the container's internally used port to a desired `<PORT>` on your host machine. The internal port is `5050` by default (probably not your concern, but can be overridden with `--port`).
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 E.g. if you want to use your host machine's `127.0.0.1:5050`, you need to run:
 
 ```text
-$ docker run -p 127.0.0.1:5050:5050 shardlabs/starknet-devnet-rs
+$ docker run -p 127.0.0.1:5050:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 You may ignore any address-related output logged on container startup (e.g. `Starknet Devnet listening on 0.0.0.0:5050`). What you will use is what you specified with the `-p` argument.
@@ -85,7 +85,7 @@ Due to internal needs, images with arch suffix are built and pushed to Docker Hu
 
 This is what happens under the hood on `main`:
 
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-amd`
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-arm`
-- create and push joint docker manifest called `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-amd`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-arm`
+- create and push joint docker manifest called `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>`
   - same for `latest`

--- a/website/versioned_docs/version-0.3.0/server-config.md
+++ b/website/versioned_docs/version-0.3.0/server-config.md
@@ -21,7 +21,7 @@ $ RUST_LOG=<LEVEL> starknet-devnet
 or if using dockerized Devnet:
 
 ```
-$ docker run -e RUST_LOG=<LEVEL> shardlabs/starknet-devnet-rs
+$ docker run -e RUST_LOG=<LEVEL> starknetfoundation/starknet-devnet-rs
 ```
 
 By default, logging of request and response data is turned off.

--- a/website/versioned_docs/version-0.4.0/dump-load-restart.md
+++ b/website/versioned_docs/version-0.4.0/dump-load-restart.md
@@ -142,7 +142,7 @@ If there is `mydump` inside `/path/to/dumpdir`, you can load it with:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-path /path/to/dumpdir/mydump
 ```
 
@@ -152,6 +152,6 @@ To dump to `/path/to/dumpdir/mydump` on Devnet shutdown, run:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-on exit --dump-path /path/to/dumpdir/mydump
 ```

--- a/website/versioned_docs/version-0.4.0/running/cli.md
+++ b/website/versioned_docs/version-0.4.0/running/cli.md
@@ -17,7 +17,7 @@ $ starknet-devnet --help
 Or if using dockerized Devnet:
 
 ```
-$ docker run --rm shardlabs/starknet-devnet-rs --help
+$ docker run --rm starknetfoundation/starknet-devnet-rs --help
 ```
 
 ## Environment variables
@@ -47,7 +47,7 @@ $ docker run \
     -e <VAR1>=<VALUE> \
     -e <VAR2>=<VALUE> \
     ... \
-    shardlabs/starknet-devnet-rs
+    starknetfoundation/starknet-devnet-rs
 ```
 
 ## Load configuration from a file
@@ -85,5 +85,5 @@ ACCOUNTS=3
 Then run:
 
 ```
-$ docker run --env-file .my-env-file shardlabs/starknet-devnet-rs
+$ docker run --env-file .my-env-file starknetfoundation/starknet-devnet-rs
 ```

--- a/website/versioned_docs/version-0.4.0/running/docker.md
+++ b/website/versioned_docs/version-0.4.0/running/docker.md
@@ -4,10 +4,10 @@ sidebar_position: 2.2
 
 # Run with Docker
 
-Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/shardlabs/starknet-devnet-rs/)). To download the `latest` image, run:
+Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/starknetfoundation/starknet-devnet-rs/)). To download the `latest` image, run:
 
 ```text
-$ docker pull shardlabs/starknet-devnet-rs
+$ docker pull starknetfoundation/starknet-devnet-rs
 ```
 
 Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm64).
@@ -15,7 +15,7 @@ Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm6
 Running a container is done like this (see [port publishing](#container-port-publishing) for more info):
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs [OPTIONS]
 ```
 
 ## Docker image tags
@@ -23,7 +23,7 @@ $ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
 All of the versions published on crates.io for starknet-devnet are available as docker images, which can be used via:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<CRATES_IO_VERSION>
+$ docker pull starknetfoundation/starknet-devnet-rs:<CRATES_IO_VERSION>
 ```
 
 :::note
@@ -37,7 +37,7 @@ The `latest` docker image tag corresponds to the last published version on crate
 Commits to the `main` branch of this repository are mostly available as images tagged with their commit hash (the full 40-lowercase-hex-digits SHA1 digest):
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<COMMIT_HASH>
+$ docker pull starknetfoundation/starknet-devnet-rs:<COMMIT_HASH>
 ```
 
 If a fix has been merged into the `main` branch of Devnet's code repository, you can access it before its inclusion in an official release. Just inspect the [`main` commit list](https://github.com/starknet-io/starknet-devnet/commits/main) and copy the full SHA digest of the commit containing the fix (or preferably the latest commit) which has a green check ✔️ symbol next to the commit date (which indicates the image indeed exists). Some revisions may not have a corresponding Docker image, but these are not supposed to be bugfixes.
@@ -47,8 +47,8 @@ If a fix has been merged into the `main` branch of Devnet's code repository, you
 By appending the `-seed0` suffix, you can use images which [predeploy funded accounts](../predeployed) with `--seed 0`, thus always predeploying the same set of accounts:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<VERSION>-seed0
-$ docker pull shardlabs/starknet-devnet-rs:latest-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:<VERSION>-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:latest-seed0
 ```
 
 ## Container port publishing
@@ -58,7 +58,7 @@ $ docker pull shardlabs/starknet-devnet-rs:latest-seed0
 If on a Linux host machine, you can use [`--network host`](https://docs.docker.com/network/host/). This way, the port used internally by the container is also available on your host machine. The `--port` option can be used (as well as other CLI options).
 
 ```text
-$ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
+$ docker run --network host starknetfoundation/starknet-devnet-rs [--port <PORT>]
 ```
 
 ### Mac and Windows
@@ -66,13 +66,13 @@ $ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
 If not on Linux, you need to publish the container's internally used port to a desired `<PORT>` on your host machine. The internal port is `5050` by default (probably not your concern, but can be overridden with `--port`).
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 E.g. if you want to use your host machine's `127.0.0.1:5050`, you need to run:
 
 ```text
-$ docker run -p 127.0.0.1:5050:5050 shardlabs/starknet-devnet-rs
+$ docker run -p 127.0.0.1:5050:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 You may ignore any address-related output logged on container startup (e.g. `Starknet Devnet listening on 0.0.0.0:5050`). What you will use is what you specified with the `-p` argument.
@@ -85,7 +85,7 @@ Due to internal needs, images with arch suffix are built and pushed to Docker Hu
 
 This is what happens under the hood on `main`:
 
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-amd`
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-arm`
-- create and push joint docker manifest called `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-amd`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-arm`
+- create and push joint docker manifest called `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>`
   - same for `latest`

--- a/website/versioned_docs/version-0.4.0/server-config.md
+++ b/website/versioned_docs/version-0.4.0/server-config.md
@@ -21,7 +21,7 @@ $ RUST_LOG=<LEVEL> starknet-devnet
 or if using dockerized Devnet:
 
 ```
-$ docker run -e RUST_LOG=<LEVEL> shardlabs/starknet-devnet-rs
+$ docker run -e RUST_LOG=<LEVEL> starknetfoundation/starknet-devnet-rs
 ```
 
 By default, logging of request and response data is turned off.

--- a/website/versioned_docs/version-0.4.1/dump-load-restart.md
+++ b/website/versioned_docs/version-0.4.1/dump-load-restart.md
@@ -142,7 +142,7 @@ If there is `mydump` inside `/path/to/dumpdir`, you can load it with:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-path /path/to/dumpdir/mydump
 ```
 
@@ -152,6 +152,6 @@ To dump to `/path/to/dumpdir/mydump` on Devnet shutdown, run:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-on exit --dump-path /path/to/dumpdir/mydump
 ```

--- a/website/versioned_docs/version-0.4.1/running/cli.md
+++ b/website/versioned_docs/version-0.4.1/running/cli.md
@@ -17,7 +17,7 @@ $ starknet-devnet --help
 Or if using dockerized Devnet:
 
 ```
-$ docker run --rm shardlabs/starknet-devnet-rs --help
+$ docker run --rm starknetfoundation/starknet-devnet-rs --help
 ```
 
 ## Environment variables
@@ -47,7 +47,7 @@ $ docker run \
     -e <VAR1>=<VALUE> \
     -e <VAR2>=<VALUE> \
     ... \
-    shardlabs/starknet-devnet-rs
+    starknetfoundation/starknet-devnet-rs
 ```
 
 ## Load configuration from a file
@@ -85,5 +85,5 @@ ACCOUNTS=3
 Then run:
 
 ```
-$ docker run --env-file .my-env-file shardlabs/starknet-devnet-rs
+$ docker run --env-file .my-env-file starknetfoundation/starknet-devnet-rs
 ```

--- a/website/versioned_docs/version-0.4.1/running/docker.md
+++ b/website/versioned_docs/version-0.4.1/running/docker.md
@@ -4,10 +4,10 @@ sidebar_position: 2.2
 
 # Run with Docker
 
-Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/shardlabs/starknet-devnet-rs/)). To download the `latest` image, run:
+Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/starknetfoundation/starknet-devnet-rs/)). To download the `latest` image, run:
 
 ```text
-$ docker pull shardlabs/starknet-devnet-rs
+$ docker pull starknetfoundation/starknet-devnet-rs
 ```
 
 Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm64).
@@ -15,7 +15,7 @@ Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm6
 Running a container is done like this (see [port publishing](#container-port-publishing) for more info):
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs [OPTIONS]
 ```
 
 ## Docker image tags
@@ -23,7 +23,7 @@ $ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
 All of the versions published on crates.io for starknet-devnet are available as docker images, which can be used via:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<CRATES_IO_VERSION>
+$ docker pull starknetfoundation/starknet-devnet-rs:<CRATES_IO_VERSION>
 ```
 
 :::note
@@ -37,7 +37,7 @@ The `latest` docker image tag corresponds to the last published version on crate
 Commits to the `main` branch of this repository are mostly available as images tagged with their commit hash (the full 40-lowercase-hex-digits SHA1 digest):
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<COMMIT_HASH>
+$ docker pull starknetfoundation/starknet-devnet-rs:<COMMIT_HASH>
 ```
 
 If a fix has been merged into the `main` branch of Devnet's code repository, you can access it before its inclusion in an official release. Just inspect the [`main` commit list](https://github.com/starknet-io/starknet-devnet/commits/main) and copy the full SHA digest of the commit containing the fix (or preferably the latest commit) which has a green check ✔️ symbol next to the commit date (which indicates the image indeed exists). Some revisions may not have a corresponding Docker image, but these are not supposed to be bugfixes.
@@ -47,8 +47,8 @@ If a fix has been merged into the `main` branch of Devnet's code repository, you
 By appending the `-seed0` suffix, you can use images which [predeploy funded accounts](../predeployed) with `--seed 0`, thus always predeploying the same set of accounts:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<VERSION>-seed0
-$ docker pull shardlabs/starknet-devnet-rs:latest-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:<VERSION>-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:latest-seed0
 ```
 
 ## Container port publishing
@@ -58,7 +58,7 @@ $ docker pull shardlabs/starknet-devnet-rs:latest-seed0
 If on a Linux host machine, you can use [`--network host`](https://docs.docker.com/network/host/). This way, the port used internally by the container is also available on your host machine. The `--port` option can be used (as well as other CLI options).
 
 ```text
-$ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
+$ docker run --network host starknetfoundation/starknet-devnet-rs [--port <PORT>]
 ```
 
 ### Mac and Windows
@@ -66,13 +66,13 @@ $ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
 If not on Linux, you need to publish the container's internally used port to a desired `<PORT>` on your host machine. The internal port is `5050` by default (probably not your concern, but can be overridden with `--port`).
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 E.g. if you want to use your host machine's `127.0.0.1:5050`, you need to run:
 
 ```text
-$ docker run -p 127.0.0.1:5050:5050 shardlabs/starknet-devnet-rs
+$ docker run -p 127.0.0.1:5050:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 You may ignore any address-related output logged on container startup (e.g. `Starknet Devnet listening on 0.0.0.0:5050`). What you will use is what you specified with the `-p` argument.
@@ -85,7 +85,7 @@ Due to internal needs, images with arch suffix are built and pushed to Docker Hu
 
 This is what happens under the hood on `main`:
 
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-amd`
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-arm`
-- create and push joint docker manifest called `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-amd`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-arm`
+- create and push joint docker manifest called `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>`
   - same for `latest`

--- a/website/versioned_docs/version-0.4.1/server-config.md
+++ b/website/versioned_docs/version-0.4.1/server-config.md
@@ -21,7 +21,7 @@ $ RUST_LOG=<LEVEL> starknet-devnet
 or if using dockerized Devnet:
 
 ```
-$ docker run -e RUST_LOG=<LEVEL> shardlabs/starknet-devnet-rs
+$ docker run -e RUST_LOG=<LEVEL> starknetfoundation/starknet-devnet-rs
 ```
 
 By default, logging of request and response data is turned off.

--- a/website/versioned_docs/version-0.4.2/dump-load-restart.md
+++ b/website/versioned_docs/version-0.4.2/dump-load-restart.md
@@ -142,7 +142,7 @@ If there is `mydump` inside `/path/to/dumpdir`, you can load it with:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-path /path/to/dumpdir/mydump
 ```
 
@@ -152,6 +152,6 @@ To dump to `/path/to/dumpdir/mydump` on Devnet shutdown, run:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-on exit --dump-path /path/to/dumpdir/mydump
 ```

--- a/website/versioned_docs/version-0.4.2/running/cli.md
+++ b/website/versioned_docs/version-0.4.2/running/cli.md
@@ -17,7 +17,7 @@ $ starknet-devnet --help
 Or if using dockerized Devnet:
 
 ```
-$ docker run --rm shardlabs/starknet-devnet-rs --help
+$ docker run --rm starknetfoundation/starknet-devnet-rs --help
 ```
 
 ## Environment variables
@@ -47,7 +47,7 @@ $ docker run \
     -e <VAR1>=<VALUE> \
     -e <VAR2>=<VALUE> \
     ... \
-    shardlabs/starknet-devnet-rs
+    starknetfoundation/starknet-devnet-rs
 ```
 
 ## Load configuration from a file
@@ -85,5 +85,5 @@ ACCOUNTS=3
 Then run:
 
 ```
-$ docker run --env-file .my-env-file shardlabs/starknet-devnet-rs
+$ docker run --env-file .my-env-file starknetfoundation/starknet-devnet-rs
 ```

--- a/website/versioned_docs/version-0.4.2/running/docker.md
+++ b/website/versioned_docs/version-0.4.2/running/docker.md
@@ -4,10 +4,10 @@ sidebar_position: 2.2
 
 # Run with Docker
 
-Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/shardlabs/starknet-devnet-rs/)). To download the `latest` image, run:
+Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/starknetfoundation/starknet-devnet-rs/)). To download the `latest` image, run:
 
 ```text
-$ docker pull shardlabs/starknet-devnet-rs
+$ docker pull starknetfoundation/starknet-devnet-rs
 ```
 
 Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm64).
@@ -15,7 +15,7 @@ Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm6
 Running a container is done like this (see [port publishing](#container-port-publishing) for more info):
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs [OPTIONS]
 ```
 
 ## Docker image tags
@@ -23,7 +23,7 @@ $ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
 All of the versions published on crates.io for starknet-devnet are available as docker images, which can be used via:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<CRATES_IO_VERSION>
+$ docker pull starknetfoundation/starknet-devnet-rs:<CRATES_IO_VERSION>
 ```
 
 :::note
@@ -37,7 +37,7 @@ The `latest` docker image tag corresponds to the last published version on crate
 Commits to the `main` branch of this repository are mostly available as images tagged with their commit hash (the full 40-lowercase-hex-digits SHA1 digest):
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<COMMIT_HASH>
+$ docker pull starknetfoundation/starknet-devnet-rs:<COMMIT_HASH>
 ```
 
 If a fix has been merged into the `main` branch of Devnet's code repository, you can access it before its inclusion in an official release. Just inspect the [`main` commit list](https://github.com/starknet-io/starknet-devnet/commits/main) and copy the full SHA digest of the commit containing the fix (or preferably the latest commit) which has a green check ✔️ symbol next to the commit date (which indicates the image indeed exists). Some revisions may not have a corresponding Docker image, but these are not supposed to be bugfixes.
@@ -47,8 +47,8 @@ If a fix has been merged into the `main` branch of Devnet's code repository, you
 By appending the `-seed0` suffix, you can use images which [predeploy funded accounts](../predeployed) with `--seed 0`, thus always predeploying the same set of accounts:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<VERSION>-seed0
-$ docker pull shardlabs/starknet-devnet-rs:latest-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:<VERSION>-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:latest-seed0
 ```
 
 ## Container port publishing
@@ -58,7 +58,7 @@ $ docker pull shardlabs/starknet-devnet-rs:latest-seed0
 If on a Linux host machine, you can use [`--network host`](https://docs.docker.com/network/host/). This way, the port used internally by the container is also available on your host machine. The `--port` option can be used (as well as other CLI options).
 
 ```text
-$ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
+$ docker run --network host starknetfoundation/starknet-devnet-rs [--port <PORT>]
 ```
 
 ### Mac and Windows
@@ -66,13 +66,13 @@ $ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
 If not on Linux, you need to publish the container's internally used port to a desired `<PORT>` on your host machine. The internal port is `5050` by default (probably not your concern, but can be overridden with `--port`).
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 E.g. if you want to use your host machine's `127.0.0.1:5050`, you need to run:
 
 ```text
-$ docker run -p 127.0.0.1:5050:5050 shardlabs/starknet-devnet-rs
+$ docker run -p 127.0.0.1:5050:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 You may ignore any address-related output logged on container startup (e.g. `Starknet Devnet listening on 0.0.0.0:5050`). What you will use is what you specified with the `-p` argument.
@@ -85,7 +85,7 @@ Due to internal needs, images with arch suffix are built and pushed to Docker Hu
 
 This is what happens under the hood on `main`:
 
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-amd`
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-arm`
-- create and push joint docker manifest called `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-amd`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-arm`
+- create and push joint docker manifest called `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>`
   - same for `latest`

--- a/website/versioned_docs/version-0.4.2/server-config.md
+++ b/website/versioned_docs/version-0.4.2/server-config.md
@@ -21,7 +21,7 @@ $ RUST_LOG=<LEVEL> starknet-devnet
 or if using dockerized Devnet:
 
 ```
-$ docker run -e RUST_LOG=<LEVEL> shardlabs/starknet-devnet-rs
+$ docker run -e RUST_LOG=<LEVEL> starknetfoundation/starknet-devnet-rs
 ```
 
 By default, logging of request and response data is turned off.

--- a/website/versioned_docs/version-0.4.3/dump-load-restart.md
+++ b/website/versioned_docs/version-0.4.3/dump-load-restart.md
@@ -142,7 +142,7 @@ If there is `mydump` inside `/path/to/dumpdir`, you can load it with:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-path /path/to/dumpdir/mydump
 ```
 
@@ -152,6 +152,6 @@ To dump to `/path/to/dumpdir/mydump` on Devnet shutdown, run:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-on exit --dump-path /path/to/dumpdir/mydump
 ```

--- a/website/versioned_docs/version-0.4.3/running/cli.md
+++ b/website/versioned_docs/version-0.4.3/running/cli.md
@@ -17,7 +17,7 @@ $ starknet-devnet --help
 Or if using dockerized Devnet:
 
 ```
-$ docker run --rm shardlabs/starknet-devnet-rs --help
+$ docker run --rm starknetfoundation/starknet-devnet-rs --help
 ```
 
 ## Environment variables
@@ -47,7 +47,7 @@ $ docker run \
     -e <VAR1>=<VALUE> \
     -e <VAR2>=<VALUE> \
     ... \
-    shardlabs/starknet-devnet-rs
+    starknetfoundation/starknet-devnet-rs
 ```
 
 ## Load configuration from a file
@@ -85,5 +85,5 @@ ACCOUNTS=3
 Then run:
 
 ```
-$ docker run --env-file .my-env-file shardlabs/starknet-devnet-rs
+$ docker run --env-file .my-env-file starknetfoundation/starknet-devnet-rs
 ```

--- a/website/versioned_docs/version-0.4.3/running/docker.md
+++ b/website/versioned_docs/version-0.4.3/running/docker.md
@@ -4,10 +4,10 @@ sidebar_position: 2.2
 
 # Run with Docker
 
-Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/shardlabs/starknet-devnet-rs/)). To download the `latest` image, run:
+Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/starknetfoundation/starknet-devnet-rs/)). To download the `latest` image, run:
 
 ```text
-$ docker pull shardlabs/starknet-devnet-rs
+$ docker pull starknetfoundation/starknet-devnet-rs
 ```
 
 Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm64).
@@ -15,7 +15,7 @@ Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm6
 Running a container is done like this (see [port publishing](#container-port-publishing) for more info):
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs [OPTIONS]
 ```
 
 ## Docker image tags
@@ -23,7 +23,7 @@ $ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
 All of the versions published on crates.io for starknet-devnet are available as docker images, which can be used via:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<CRATES_IO_VERSION>
+$ docker pull starknetfoundation/starknet-devnet-rs:<CRATES_IO_VERSION>
 ```
 
 :::note
@@ -37,7 +37,7 @@ The `latest` docker image tag corresponds to the last published version on crate
 Commits to the `main` branch of this repository are mostly available as images tagged with their commit hash (the full 40-lowercase-hex-digits SHA1 digest):
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<COMMIT_HASH>
+$ docker pull starknetfoundation/starknet-devnet-rs:<COMMIT_HASH>
 ```
 
 If a fix has been merged into the `main` branch of Devnet's code repository, you can access it before its inclusion in an official release. Just inspect the [`main` commit list](https://github.com/starknet-io/starknet-devnet/commits/main) and copy the full SHA digest of the commit containing the fix (or preferably the latest commit) which has a green check ✔️ symbol next to the commit date (which indicates the image indeed exists). Some revisions may not have a corresponding Docker image, but these are not supposed to be bugfixes.
@@ -47,8 +47,8 @@ If a fix has been merged into the `main` branch of Devnet's code repository, you
 By appending the `-seed0` suffix, you can use images which [predeploy funded accounts](../predeployed) with `--seed 0`, thus always predeploying the same set of accounts:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<VERSION>-seed0
-$ docker pull shardlabs/starknet-devnet-rs:latest-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:<VERSION>-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:latest-seed0
 ```
 
 ## Container port publishing
@@ -58,7 +58,7 @@ $ docker pull shardlabs/starknet-devnet-rs:latest-seed0
 If on a Linux host machine, you can use [`--network host`](https://docs.docker.com/network/host/). This way, the port used internally by the container is also available on your host machine. The `--port` option can be used (as well as other CLI options).
 
 ```text
-$ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
+$ docker run --network host starknetfoundation/starknet-devnet-rs [--port <PORT>]
 ```
 
 ### Mac and Windows
@@ -66,13 +66,13 @@ $ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
 If not on Linux, you need to publish the container's internally used port to a desired `<PORT>` on your host machine. The internal port is `5050` by default (probably not your concern, but can be overridden with `--port`).
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 E.g. if you want to use your host machine's `127.0.0.1:5050`, you need to run:
 
 ```text
-$ docker run -p 127.0.0.1:5050:5050 shardlabs/starknet-devnet-rs
+$ docker run -p 127.0.0.1:5050:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 You may ignore any address-related output logged on container startup (e.g. `Starknet Devnet listening on 0.0.0.0:5050`). What you will use is what you specified with the `-p` argument.
@@ -85,7 +85,7 @@ Due to internal needs, images with arch suffix are built and pushed to Docker Hu
 
 This is what happens under the hood on `main`:
 
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-amd`
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-arm`
-- create and push joint docker manifest called `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-amd`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-arm`
+- create and push joint docker manifest called `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>`
   - same for `latest`

--- a/website/versioned_docs/version-0.4.3/server-config.md
+++ b/website/versioned_docs/version-0.4.3/server-config.md
@@ -21,7 +21,7 @@ $ RUST_LOG=<LEVEL> starknet-devnet
 or if using dockerized Devnet:
 
 ```
-$ docker run -e RUST_LOG=<LEVEL> shardlabs/starknet-devnet-rs
+$ docker run -e RUST_LOG=<LEVEL> starknetfoundation/starknet-devnet-rs
 ```
 
 By default, logging of request and response data is turned off.

--- a/website/versioned_docs/version-0.5.0/dump-load-restart.md
+++ b/website/versioned_docs/version-0.5.0/dump-load-restart.md
@@ -125,7 +125,7 @@ If there is `mydump` inside `/path/to/dumpdir`, you can load it with:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-path /path/to/dumpdir/mydump
 ```
 
@@ -135,6 +135,6 @@ To dump to `/path/to/dumpdir/mydump` on Devnet shutdown, run:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-on exit --dump-path /path/to/dumpdir/mydump
 ```

--- a/website/versioned_docs/version-0.5.0/running/cli.md
+++ b/website/versioned_docs/version-0.5.0/running/cli.md
@@ -17,7 +17,7 @@ $ starknet-devnet --help
 Or if using dockerized Devnet:
 
 ```
-$ docker run --rm shardlabs/starknet-devnet-rs --help
+$ docker run --rm starknetfoundation/starknet-devnet-rs --help
 ```
 
 ## Environment variables
@@ -47,7 +47,7 @@ $ docker run \
     -e <VAR1>=<VALUE> \
     -e <VAR2>=<VALUE> \
     ... \
-    shardlabs/starknet-devnet-rs
+    starknetfoundation/starknet-devnet-rs
 ```
 
 ## Load configuration from a file
@@ -85,5 +85,5 @@ ACCOUNTS=3
 Then run:
 
 ```
-$ docker run --env-file .my-env-file shardlabs/starknet-devnet-rs
+$ docker run --env-file .my-env-file starknetfoundation/starknet-devnet-rs
 ```

--- a/website/versioned_docs/version-0.5.0/running/docker.md
+++ b/website/versioned_docs/version-0.5.0/running/docker.md
@@ -4,10 +4,10 @@ sidebar_position: 2.2
 
 # Run with Docker
 
-Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/shardlabs/starknet-devnet-rs/)). To download the `latest` image, run:
+Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/starknetfoundation/starknet-devnet-rs/)). To download the `latest` image, run:
 
 ```text
-$ docker pull shardlabs/starknet-devnet-rs
+$ docker pull starknetfoundation/starknet-devnet-rs
 ```
 
 Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm64).
@@ -15,7 +15,7 @@ Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm6
 Running a container is done like this (see [port publishing](#container-port-publishing) for more info):
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs [OPTIONS]
 ```
 
 ## Docker image tags
@@ -23,7 +23,7 @@ $ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
 All of the versions published on crates.io for starknet-devnet are available as docker images, which can be used via:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<CRATES_IO_VERSION>
+$ docker pull starknetfoundation/starknet-devnet-rs:<CRATES_IO_VERSION>
 ```
 
 :::note
@@ -37,7 +37,7 @@ The `latest` docker image tag corresponds to the last published version on crate
 Commits to the `main` branch of this repository are mostly available as images tagged with their commit hash (the full 40-lowercase-hex-digits SHA1 digest):
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<COMMIT_HASH>
+$ docker pull starknetfoundation/starknet-devnet-rs:<COMMIT_HASH>
 ```
 
 If a fix has been merged into the `main` branch of Devnet's code repository, you can access it before its inclusion in an official release. Just inspect the [`main` commit list](https://github.com/starknet-io/starknet-devnet/commits/main) and copy the full SHA digest of the commit containing the fix (or preferably the latest commit) which has a green check ✔️ symbol next to the commit date (which indicates the image indeed exists). Some revisions may not have a corresponding Docker image, but these are not supposed to be bugfixes.
@@ -47,8 +47,8 @@ If a fix has been merged into the `main` branch of Devnet's code repository, you
 By appending the `-seed0` suffix, you can use images which [predeploy funded accounts](../predeployed) with `--seed 0`, thus always predeploying the same set of accounts:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<VERSION>-seed0
-$ docker pull shardlabs/starknet-devnet-rs:latest-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:<VERSION>-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:latest-seed0
 ```
 
 ## Container port publishing
@@ -58,7 +58,7 @@ $ docker pull shardlabs/starknet-devnet-rs:latest-seed0
 If on a Linux host machine, you can use [`--network host`](https://docs.docker.com/network/host/). This way, the port used internally by the container is also available on your host machine. The `--port` option can be used (as well as other CLI options).
 
 ```text
-$ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
+$ docker run --network host starknetfoundation/starknet-devnet-rs [--port <PORT>]
 ```
 
 ### Mac and Windows
@@ -66,13 +66,13 @@ $ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
 If not on Linux, you need to publish the container's internally used port to a desired `<PORT>` on your host machine. The internal port is `5050` by default (probably not your concern, but can be overridden with `--port`).
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 E.g. if you want to use your host machine's `127.0.0.1:5050`, you need to run:
 
 ```text
-$ docker run -p 127.0.0.1:5050:5050 shardlabs/starknet-devnet-rs
+$ docker run -p 127.0.0.1:5050:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 You may ignore any address-related output logged on container startup (e.g. `Starknet Devnet listening on 0.0.0.0:5050`). What you will use is what you specified with the `-p` argument.
@@ -85,7 +85,7 @@ Due to internal needs, images with arch suffix are built and pushed to Docker Hu
 
 This is what happens under the hood on `main`:
 
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-amd`
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-arm`
-- create and push joint docker manifest called `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-amd`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-arm`
+- create and push joint docker manifest called `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>`
   - same for `latest`

--- a/website/versioned_docs/version-0.5.0/server-config.md
+++ b/website/versioned_docs/version-0.5.0/server-config.md
@@ -21,7 +21,7 @@ $ RUST_LOG=<LEVEL> starknet-devnet
 or if using dockerized Devnet:
 
 ```
-$ docker run -e RUST_LOG=<LEVEL> shardlabs/starknet-devnet-rs
+$ docker run -e RUST_LOG=<LEVEL> starknetfoundation/starknet-devnet-rs
 ```
 
 By default, logging of request and response data is turned off.

--- a/website/versioned_docs/version-0.5.1/dump-load-restart.md
+++ b/website/versioned_docs/version-0.5.1/dump-load-restart.md
@@ -125,7 +125,7 @@ If there is `mydump` inside `/path/to/dumpdir`, you can load it with:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-path /path/to/dumpdir/mydump
 ```
 
@@ -135,6 +135,6 @@ To dump to `/path/to/dumpdir/mydump` on Devnet shutdown, run:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-on exit --dump-path /path/to/dumpdir/mydump
 ```

--- a/website/versioned_docs/version-0.5.1/running/cli.md
+++ b/website/versioned_docs/version-0.5.1/running/cli.md
@@ -17,7 +17,7 @@ $ starknet-devnet --help
 Or if using dockerized Devnet:
 
 ```
-$ docker run --rm shardlabs/starknet-devnet-rs --help
+$ docker run --rm starknetfoundation/starknet-devnet-rs --help
 ```
 
 ## Environment variables
@@ -47,7 +47,7 @@ $ docker run \
     -e <VAR1>=<VALUE> \
     -e <VAR2>=<VALUE> \
     ... \
-    shardlabs/starknet-devnet-rs
+    starknetfoundation/starknet-devnet-rs
 ```
 
 ## Load configuration from a file
@@ -85,5 +85,5 @@ ACCOUNTS=3
 Then run:
 
 ```
-$ docker run --env-file .my-env-file shardlabs/starknet-devnet-rs
+$ docker run --env-file .my-env-file starknetfoundation/starknet-devnet-rs
 ```

--- a/website/versioned_docs/version-0.5.1/running/docker.md
+++ b/website/versioned_docs/version-0.5.1/running/docker.md
@@ -4,10 +4,10 @@ sidebar_position: 2.2
 
 # Run with Docker
 
-Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/shardlabs/starknet-devnet-rs/)). To download the `latest` image, run:
+Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/starknetfoundation/starknet-devnet-rs/)). To download the `latest` image, run:
 
 ```text
-$ docker pull shardlabs/starknet-devnet-rs
+$ docker pull starknetfoundation/starknet-devnet-rs
 ```
 
 Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm64).
@@ -15,7 +15,7 @@ Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm6
 Running a container is done like this (see [port publishing](#container-port-publishing) for more info):
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs [OPTIONS]
 ```
 
 ## Docker image tags
@@ -23,7 +23,7 @@ $ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
 All of the versions published on crates.io for starknet-devnet are available as docker images, which can be used via:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<CRATES_IO_VERSION>
+$ docker pull starknetfoundation/starknet-devnet-rs:<CRATES_IO_VERSION>
 ```
 
 :::note
@@ -37,7 +37,7 @@ The `latest` docker image tag corresponds to the last published version on crate
 Commits to the `main` branch of this repository are mostly available as images tagged with their commit hash (the full 40-lowercase-hex-digits SHA1 digest):
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<COMMIT_HASH>
+$ docker pull starknetfoundation/starknet-devnet-rs:<COMMIT_HASH>
 ```
 
 If a fix has been merged into the `main` branch of Devnet's code repository, you can access it before its inclusion in an official release. Just inspect the [`main` commit list](https://github.com/starknet-io/starknet-devnet/commits/main) and copy the full SHA digest of the commit containing the fix (or preferably the latest commit) which has a green check ✔️ symbol next to the commit date (which indicates the image indeed exists). Some revisions may not have a corresponding Docker image, but these are not supposed to be bugfixes.
@@ -47,8 +47,8 @@ If a fix has been merged into the `main` branch of Devnet's code repository, you
 By appending the `-seed0` suffix, you can use images which [predeploy funded accounts](../predeployed) with `--seed 0`, thus always predeploying the same set of accounts:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<VERSION>-seed0
-$ docker pull shardlabs/starknet-devnet-rs:latest-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:<VERSION>-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:latest-seed0
 ```
 
 ## Container port publishing
@@ -58,7 +58,7 @@ $ docker pull shardlabs/starknet-devnet-rs:latest-seed0
 If on a Linux host machine, you can use [`--network host`](https://docs.docker.com/network/host/). This way, the port used internally by the container is also available on your host machine. The `--port` option can be used (as well as other CLI options).
 
 ```text
-$ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
+$ docker run --network host starknetfoundation/starknet-devnet-rs [--port <PORT>]
 ```
 
 ### Mac and Windows
@@ -66,13 +66,13 @@ $ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
 If not on Linux, you need to publish the container's internally used port to a desired `<PORT>` on your host machine. The internal port is `5050` by default (probably not your concern, but can be overridden with `--port`).
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 E.g. if you want to use your host machine's `127.0.0.1:5050`, you need to run:
 
 ```text
-$ docker run -p 127.0.0.1:5050:5050 shardlabs/starknet-devnet-rs
+$ docker run -p 127.0.0.1:5050:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 You may ignore any address-related output logged on container startup (e.g. `Starknet Devnet listening on 0.0.0.0:5050`). What you will use is what you specified with the `-p` argument.
@@ -85,7 +85,7 @@ Due to internal needs, images with arch suffix are built and pushed to Docker Hu
 
 This is what happens under the hood on `main`:
 
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-amd`
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-arm`
-- create and push joint docker manifest called `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-amd`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-arm`
+- create and push joint docker manifest called `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>`
   - same for `latest`

--- a/website/versioned_docs/version-0.5.1/server-config.md
+++ b/website/versioned_docs/version-0.5.1/server-config.md
@@ -21,7 +21,7 @@ $ RUST_LOG=<LEVEL> starknet-devnet
 or if using dockerized Devnet:
 
 ```
-$ docker run -e RUST_LOG=<LEVEL> shardlabs/starknet-devnet-rs
+$ docker run -e RUST_LOG=<LEVEL> starknetfoundation/starknet-devnet-rs
 ```
 
 By default, logging of request and response data is turned off.

--- a/website/versioned_docs/version-0.6.0/dump-load-restart.md
+++ b/website/versioned_docs/version-0.6.0/dump-load-restart.md
@@ -129,7 +129,7 @@ If there is `mydump` inside `/path/to/dumpdir`, you can load it with:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-path /path/to/dumpdir/mydump
 ```
 
@@ -139,6 +139,6 @@ To dump to `/path/to/dumpdir/mydump` on Devnet shutdown, run:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-on exit --dump-path /path/to/dumpdir/mydump
 ```

--- a/website/versioned_docs/version-0.6.0/running/cli.md
+++ b/website/versioned_docs/version-0.6.0/running/cli.md
@@ -17,7 +17,7 @@ $ starknet-devnet --help
 Or if using dockerized Devnet:
 
 ```
-$ docker run --rm shardlabs/starknet-devnet-rs --help
+$ docker run --rm starknetfoundation/starknet-devnet-rs --help
 ```
 
 ## Environment variables
@@ -47,7 +47,7 @@ $ docker run \
     -e <VAR1>=<VALUE> \
     -e <VAR2>=<VALUE> \
     ... \
-    shardlabs/starknet-devnet-rs
+    starknetfoundation/starknet-devnet-rs
 ```
 
 ## Load configuration from a file
@@ -85,5 +85,5 @@ ACCOUNTS=3
 Then run:
 
 ```
-$ docker run --env-file .my-env-file shardlabs/starknet-devnet-rs
+$ docker run --env-file .my-env-file starknetfoundation/starknet-devnet-rs
 ```

--- a/website/versioned_docs/version-0.6.0/running/docker.md
+++ b/website/versioned_docs/version-0.6.0/running/docker.md
@@ -4,10 +4,10 @@ sidebar_position: 2.2
 
 # Run with Docker
 
-Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/shardlabs/starknet-devnet-rs/)). To download the `latest` image, run:
+Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/starknetfoundation/starknet-devnet-rs/)). To download the `latest` image, run:
 
 ```text
-$ docker pull shardlabs/starknet-devnet-rs
+$ docker pull starknetfoundation/starknet-devnet-rs
 ```
 
 Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm64).
@@ -15,7 +15,7 @@ Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm6
 Running a container is done like this (see [port publishing](#container-port-publishing) for more info):
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs [OPTIONS]
 ```
 
 ## Docker image tags
@@ -23,7 +23,7 @@ $ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
 All of the versions published on crates.io for starknet-devnet are available as docker images, which can be used via:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<CRATES_IO_VERSION>
+$ docker pull starknetfoundation/starknet-devnet-rs:<CRATES_IO_VERSION>
 ```
 
 :::note
@@ -37,7 +37,7 @@ The `latest` docker image tag corresponds to the last published version on crate
 Commits to the `main` branch of this repository are mostly available as images tagged with their commit hash (the full 40-lowercase-hex-digits SHA1 digest):
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<COMMIT_HASH>
+$ docker pull starknetfoundation/starknet-devnet-rs:<COMMIT_HASH>
 ```
 
 If a fix has been merged into the `main` branch of Devnet's code repository, you can access it before its inclusion in an official release. Just inspect the [`main` commit list](https://github.com/starknet-io/starknet-devnet/commits/main) and copy the full SHA digest of the commit containing the fix (or preferably the latest commit) which has a green check ✔️ symbol next to the commit date (which indicates the image indeed exists). Some revisions may not have a corresponding Docker image, but these are not supposed to be bugfixes.
@@ -47,8 +47,8 @@ If a fix has been merged into the `main` branch of Devnet's code repository, you
 By appending the `-seed0` suffix, you can use images which [predeploy funded accounts](../predeployed) with `--seed 0`, thus always predeploying the same set of accounts:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<VERSION>-seed0
-$ docker pull shardlabs/starknet-devnet-rs:latest-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:<VERSION>-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:latest-seed0
 ```
 
 ## Container port publishing
@@ -58,7 +58,7 @@ $ docker pull shardlabs/starknet-devnet-rs:latest-seed0
 If on a Linux host machine, you can use [`--network host`](https://docs.docker.com/network/host/). This way, the port used internally by the container is also available on your host machine. The `--port` option can be used (as well as other CLI options).
 
 ```text
-$ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
+$ docker run --network host starknetfoundation/starknet-devnet-rs [--port <PORT>]
 ```
 
 ### Mac and Windows
@@ -66,13 +66,13 @@ $ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
 If not on Linux, you need to publish the container's internally used port to a desired `<PORT>` on your host machine. The internal port is `5050` by default (probably not your concern, but can be overridden with `--port`).
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 E.g. if you want to use your host machine's `127.0.0.1:5050`, you need to run:
 
 ```text
-$ docker run -p 127.0.0.1:5050:5050 shardlabs/starknet-devnet-rs
+$ docker run -p 127.0.0.1:5050:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 You may ignore any address-related output logged on container startup (e.g. `Starknet Devnet listening on 0.0.0.0:5050`). What you will use is what you specified with the `-p` argument.
@@ -85,7 +85,7 @@ Due to internal needs, images with arch suffix are built and pushed to Docker Hu
 
 This is what happens under the hood on `main`:
 
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-amd`
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-arm`
-- create and push joint docker manifest called `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-amd`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-arm`
+- create and push joint docker manifest called `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>`
   - same for `latest`

--- a/website/versioned_docs/version-0.6.0/server-config.md
+++ b/website/versioned_docs/version-0.6.0/server-config.md
@@ -21,7 +21,7 @@ $ RUST_LOG=<LEVEL> starknet-devnet
 or if using dockerized Devnet:
 
 ```
-$ docker run -e RUST_LOG=<LEVEL> shardlabs/starknet-devnet-rs
+$ docker run -e RUST_LOG=<LEVEL> starknetfoundation/starknet-devnet-rs
 ```
 
 By default, logging of request and response data is turned off.

--- a/website/versioned_docs/version-0.6.1/dump-load-restart.md
+++ b/website/versioned_docs/version-0.6.1/dump-load-restart.md
@@ -129,7 +129,7 @@ If there is `mydump` inside `/path/to/dumpdir`, you can load it with:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-path /path/to/dumpdir/mydump
 ```
 
@@ -139,6 +139,6 @@ To dump to `/path/to/dumpdir/mydump` on Devnet shutdown, run:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-on exit --dump-path /path/to/dumpdir/mydump
 ```

--- a/website/versioned_docs/version-0.6.1/running/cli.md
+++ b/website/versioned_docs/version-0.6.1/running/cli.md
@@ -17,7 +17,7 @@ $ starknet-devnet --help
 Or if using dockerized Devnet:
 
 ```
-$ docker run --rm shardlabs/starknet-devnet-rs --help
+$ docker run --rm starknetfoundation/starknet-devnet-rs --help
 ```
 
 ## Environment variables
@@ -47,7 +47,7 @@ $ docker run \
     -e <VAR1>=<VALUE> \
     -e <VAR2>=<VALUE> \
     ... \
-    shardlabs/starknet-devnet-rs
+    starknetfoundation/starknet-devnet-rs
 ```
 
 ## Load configuration from a file
@@ -85,5 +85,5 @@ ACCOUNTS=3
 Then run:
 
 ```
-$ docker run --env-file .my-env-file shardlabs/starknet-devnet-rs
+$ docker run --env-file .my-env-file starknetfoundation/starknet-devnet-rs
 ```

--- a/website/versioned_docs/version-0.6.1/running/docker.md
+++ b/website/versioned_docs/version-0.6.1/running/docker.md
@@ -4,10 +4,10 @@ sidebar_position: 2.2
 
 # Run with Docker
 
-Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/shardlabs/starknet-devnet-rs/)). To download the `latest` image, run:
+Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/starknetfoundation/starknet-devnet-rs/)). To download the `latest` image, run:
 
 ```text
-$ docker pull shardlabs/starknet-devnet-rs
+$ docker pull starknetfoundation/starknet-devnet-rs
 ```
 
 Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm64).
@@ -15,7 +15,7 @@ Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm6
 Running a container is done like this (see [port publishing](#container-port-publishing) for more info):
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs [OPTIONS]
 ```
 
 ## Docker image tags
@@ -23,7 +23,7 @@ $ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
 All of the versions published on crates.io for starknet-devnet are available as docker images, which can be used via:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<CRATES_IO_VERSION>
+$ docker pull starknetfoundation/starknet-devnet-rs:<CRATES_IO_VERSION>
 ```
 
 :::note
@@ -37,7 +37,7 @@ The `latest` docker image tag corresponds to the last published version on crate
 Commits to the `main` branch of this repository are mostly available as images tagged with their commit hash (the full 40-lowercase-hex-digits SHA1 digest):
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<COMMIT_HASH>
+$ docker pull starknetfoundation/starknet-devnet-rs:<COMMIT_HASH>
 ```
 
 If a fix has been merged into the `main` branch of Devnet's code repository, you can access it before its inclusion in an official release. Just inspect the [`main` commit list](https://github.com/starknet-io/starknet-devnet/commits/main) and copy the full SHA digest of the commit containing the fix (or preferably the latest commit) which has a green check ✔️ symbol next to the commit date (which indicates the image indeed exists). Some revisions may not have a corresponding Docker image, but these are not supposed to be bugfixes.
@@ -47,8 +47,8 @@ If a fix has been merged into the `main` branch of Devnet's code repository, you
 By appending the `-seed0` suffix, you can use images which [predeploy funded accounts](../predeployed) with `--seed 0`, thus always predeploying the same set of accounts:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<VERSION>-seed0
-$ docker pull shardlabs/starknet-devnet-rs:latest-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:<VERSION>-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:latest-seed0
 ```
 
 ## Container port publishing
@@ -58,7 +58,7 @@ $ docker pull shardlabs/starknet-devnet-rs:latest-seed0
 If on a Linux host machine, you can use [`--network host`](https://docs.docker.com/network/host/). This way, the port used internally by the container is also available on your host machine. The `--port` option can be used (as well as other CLI options).
 
 ```text
-$ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
+$ docker run --network host starknetfoundation/starknet-devnet-rs [--port <PORT>]
 ```
 
 ### Mac and Windows
@@ -66,13 +66,13 @@ $ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
 If not on Linux, you need to publish the container's internally used port to a desired `<PORT>` on your host machine. The internal port is `5050` by default (probably not your concern, but can be overridden with `--port`).
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 E.g. if you want to use your host machine's `127.0.0.1:5050`, you need to run:
 
 ```text
-$ docker run -p 127.0.0.1:5050:5050 shardlabs/starknet-devnet-rs
+$ docker run -p 127.0.0.1:5050:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 You may ignore any address-related output logged on container startup (e.g. `Starknet Devnet listening on 0.0.0.0:5050`). What you will use is what you specified with the `-p` argument.
@@ -85,7 +85,7 @@ Due to internal needs, images with arch suffix are built and pushed to Docker Hu
 
 This is what happens under the hood on `main`:
 
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-amd`
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-arm`
-- create and push joint docker manifest called `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-amd`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-arm`
+- create and push joint docker manifest called `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>`
   - same for `latest`

--- a/website/versioned_docs/version-0.6.1/server-config.md
+++ b/website/versioned_docs/version-0.6.1/server-config.md
@@ -21,7 +21,7 @@ $ RUST_LOG=<LEVEL> starknet-devnet
 or if using dockerized Devnet:
 
 ```
-$ docker run -e RUST_LOG=<LEVEL> shardlabs/starknet-devnet-rs
+$ docker run -e RUST_LOG=<LEVEL> starknetfoundation/starknet-devnet-rs
 ```
 
 By default, logging of request and response data is turned off.

--- a/website/versioned_docs/version-0.7.0/dump-load-restart.md
+++ b/website/versioned_docs/version-0.7.0/dump-load-restart.md
@@ -129,7 +129,7 @@ If there is `mydump` inside `/path/to/dumpdir`, you can load it with:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-path /path/to/dumpdir/mydump
 ```
 
@@ -139,6 +139,6 @@ To dump to `/path/to/dumpdir/mydump` on Devnet shutdown, run:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-on exit --dump-path /path/to/dumpdir/mydump
 ```

--- a/website/versioned_docs/version-0.7.0/running/cli.md
+++ b/website/versioned_docs/version-0.7.0/running/cli.md
@@ -17,7 +17,7 @@ $ starknet-devnet --help
 Or if using dockerized Devnet:
 
 ```
-$ docker run --rm shardlabs/starknet-devnet-rs --help
+$ docker run --rm starknetfoundation/starknet-devnet-rs --help
 ```
 
 ## Environment variables
@@ -47,7 +47,7 @@ $ docker run \
     -e <VAR1>=<VALUE> \
     -e <VAR2>=<VALUE> \
     ... \
-    shardlabs/starknet-devnet-rs
+    starknetfoundation/starknet-devnet-rs
 ```
 
 ## Load configuration from a file
@@ -85,5 +85,5 @@ ACCOUNTS=3
 Then run:
 
 ```
-$ docker run --env-file .my-env-file shardlabs/starknet-devnet-rs
+$ docker run --env-file .my-env-file starknetfoundation/starknet-devnet-rs
 ```

--- a/website/versioned_docs/version-0.7.0/running/docker.md
+++ b/website/versioned_docs/version-0.7.0/running/docker.md
@@ -4,10 +4,10 @@ sidebar_position: 2.2
 
 # Run with Docker
 
-Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/shardlabs/starknet-devnet-rs/)). To download the `latest` image, run:
+Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/starknetfoundation/starknet-devnet-rs/)). To download the `latest` image, run:
 
 ```text
-$ docker pull shardlabs/starknet-devnet-rs
+$ docker pull starknetfoundation/starknet-devnet-rs
 ```
 
 Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm64).
@@ -15,7 +15,7 @@ Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm6
 Running a container is done like this (see [port publishing](#container-port-publishing) for more info):
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs [OPTIONS]
 ```
 
 ## Docker image tags
@@ -23,7 +23,7 @@ $ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
 All of the versions published on crates.io for starknet-devnet are available as docker images, which can be used via:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<CRATES_IO_VERSION>
+$ docker pull starknetfoundation/starknet-devnet-rs:<CRATES_IO_VERSION>
 ```
 
 :::note
@@ -37,7 +37,7 @@ The `latest` docker image tag corresponds to the last published version on crate
 Commits to the `main` branch of this repository are mostly available as images tagged with their commit hash (the full 40-lowercase-hex-digits SHA1 digest):
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<COMMIT_HASH>
+$ docker pull starknetfoundation/starknet-devnet-rs:<COMMIT_HASH>
 ```
 
 If a fix has been merged into the `main` branch of Devnet's code repository, you can access it before its inclusion in an official release. Just inspect the [`main` commit list](https://github.com/starknet-io/starknet-devnet/commits/main) and copy the full SHA digest of the commit containing the fix (or preferably the latest commit) which has a green check ✔️ symbol next to the commit date (which indicates the image indeed exists). Some revisions may not have a corresponding Docker image, but these are not supposed to be bugfixes.
@@ -47,8 +47,8 @@ If a fix has been merged into the `main` branch of Devnet's code repository, you
 By appending the `-seed0` suffix, you can use images which [predeploy funded accounts](../predeployed) with `--seed 0`, thus always predeploying the same set of accounts:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<VERSION>-seed0
-$ docker pull shardlabs/starknet-devnet-rs:latest-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:<VERSION>-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:latest-seed0
 ```
 
 ## Container port publishing
@@ -58,7 +58,7 @@ $ docker pull shardlabs/starknet-devnet-rs:latest-seed0
 If on a Linux host machine, you can use [`--network host`](https://docs.docker.com/network/host/). This way, the port used internally by the container is also available on your host machine. The `--port` option can be used (as well as other CLI options).
 
 ```text
-$ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
+$ docker run --network host starknetfoundation/starknet-devnet-rs [--port <PORT>]
 ```
 
 ### Mac and Windows
@@ -66,13 +66,13 @@ $ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
 If not on Linux, you need to publish the container's internally used port to a desired `<PORT>` on your host machine. The internal port is `5050` by default (probably not your concern, but can be overridden with `--port`).
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 E.g. if you want to use your host machine's `127.0.0.1:5050`, you need to run:
 
 ```text
-$ docker run -p 127.0.0.1:5050:5050 shardlabs/starknet-devnet-rs
+$ docker run -p 127.0.0.1:5050:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 You may ignore any address-related output logged on container startup (e.g. `Starknet Devnet listening on 0.0.0.0:5050`). What you will use is what you specified with the `-p` argument.
@@ -85,7 +85,7 @@ Due to internal needs, images with arch suffix are built and pushed to Docker Hu
 
 This is what happens under the hood on `main`:
 
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-amd`
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-arm`
-- create and push joint docker manifest called `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-amd`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-arm`
+- create and push joint docker manifest called `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>`
   - same for `latest`

--- a/website/versioned_docs/version-0.7.0/server-config.md
+++ b/website/versioned_docs/version-0.7.0/server-config.md
@@ -21,7 +21,7 @@ $ RUST_LOG=<LEVEL> starknet-devnet
 or if using dockerized Devnet:
 
 ```
-$ docker run -e RUST_LOG=<LEVEL> shardlabs/starknet-devnet-rs
+$ docker run -e RUST_LOG=<LEVEL> starknetfoundation/starknet-devnet-rs
 ```
 
 By default, logging of request and response data is turned off.

--- a/website/versioned_docs/version-0.7.1/dump-load-restart.md
+++ b/website/versioned_docs/version-0.7.1/dump-load-restart.md
@@ -129,7 +129,7 @@ If there is `mydump` inside `/path/to/dumpdir`, you can load it with:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-path /path/to/dumpdir/mydump
 ```
 
@@ -139,6 +139,6 @@ To dump to `/path/to/dumpdir/mydump` on Devnet shutdown, run:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-on exit --dump-path /path/to/dumpdir/mydump
 ```

--- a/website/versioned_docs/version-0.7.1/running/cli.md
+++ b/website/versioned_docs/version-0.7.1/running/cli.md
@@ -17,7 +17,7 @@ $ starknet-devnet --help
 Or if using dockerized Devnet:
 
 ```
-$ docker run --rm shardlabs/starknet-devnet-rs --help
+$ docker run --rm starknetfoundation/starknet-devnet-rs --help
 ```
 
 ## Environment variables
@@ -47,7 +47,7 @@ $ docker run \
     -e <VAR1>=<VALUE> \
     -e <VAR2>=<VALUE> \
     ... \
-    shardlabs/starknet-devnet-rs
+    starknetfoundation/starknet-devnet-rs
 ```
 
 ## Load configuration from a file
@@ -85,5 +85,5 @@ ACCOUNTS=3
 Then run:
 
 ```
-$ docker run --env-file .my-env-file shardlabs/starknet-devnet-rs
+$ docker run --env-file .my-env-file starknetfoundation/starknet-devnet-rs
 ```

--- a/website/versioned_docs/version-0.7.1/running/docker.md
+++ b/website/versioned_docs/version-0.7.1/running/docker.md
@@ -4,10 +4,10 @@ sidebar_position: 2.2
 
 # Run with Docker
 
-Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/shardlabs/starknet-devnet-rs/)). To download the `latest` image, run:
+Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/starknetfoundation/starknet-devnet-rs/)). To download the `latest` image, run:
 
 ```text
-$ docker pull shardlabs/starknet-devnet-rs
+$ docker pull starknetfoundation/starknet-devnet-rs
 ```
 
 Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm64).
@@ -15,7 +15,7 @@ Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm6
 Running a container is done like this (see [port publishing](#container-port-publishing) for more info):
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs [OPTIONS]
 ```
 
 ## Docker image tags
@@ -23,7 +23,7 @@ $ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
 All of the versions published on crates.io for starknet-devnet are available as docker images, which can be used via:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<CRATES_IO_VERSION>
+$ docker pull starknetfoundation/starknet-devnet-rs:<CRATES_IO_VERSION>
 ```
 
 :::note
@@ -37,7 +37,7 @@ The `latest` docker image tag corresponds to the last published version on crate
 Commits to the `main` branch of this repository are mostly available as images tagged with their commit hash (the full 40-lowercase-hex-digits SHA1 digest):
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<COMMIT_HASH>
+$ docker pull starknetfoundation/starknet-devnet-rs:<COMMIT_HASH>
 ```
 
 If a fix has been merged into the `main` branch of Devnet's code repository, you can access it before its inclusion in an official release. Just inspect the [`main` commit list](https://github.com/starknet-io/starknet-devnet/commits/main) and copy the full SHA digest of the commit containing the fix (or preferably the latest commit) which has a green check ✔️ symbol next to the commit date (which indicates the image indeed exists). Some revisions may not have a corresponding Docker image, but these are not supposed to be bugfixes.
@@ -47,8 +47,8 @@ If a fix has been merged into the `main` branch of Devnet's code repository, you
 By appending the `-seed0` suffix, you can use images which [predeploy funded accounts](../predeployed) with `--seed 0`, thus always predeploying the same set of accounts:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<VERSION>-seed0
-$ docker pull shardlabs/starknet-devnet-rs:latest-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:<VERSION>-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:latest-seed0
 ```
 
 ## Container port publishing
@@ -58,7 +58,7 @@ $ docker pull shardlabs/starknet-devnet-rs:latest-seed0
 If on a Linux host machine, you can use [`--network host`](https://docs.docker.com/network/host/). This way, the port used internally by the container is also available on your host machine. The `--port` option can be used (as well as other CLI options).
 
 ```text
-$ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
+$ docker run --network host starknetfoundation/starknet-devnet-rs [--port <PORT>]
 ```
 
 ### Mac and Windows
@@ -66,13 +66,13 @@ $ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
 If not on Linux, you need to publish the container's internally used port to a desired `<PORT>` on your host machine. The internal port is `5050` by default (probably not your concern, but can be overridden with `--port`).
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 E.g. if you want to use your host machine's `127.0.0.1:5050`, you need to run:
 
 ```text
-$ docker run -p 127.0.0.1:5050:5050 shardlabs/starknet-devnet-rs
+$ docker run -p 127.0.0.1:5050:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 You may ignore any address-related output logged on container startup (e.g. `Starknet Devnet listening on 0.0.0.0:5050`). What you will use is what you specified with the `-p` argument.
@@ -85,7 +85,7 @@ Due to internal needs, images with arch suffix are built and pushed to Docker Hu
 
 This is what happens under the hood on `main`:
 
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-amd`
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-arm`
-- create and push joint docker manifest called `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-amd`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-arm`
+- create and push joint docker manifest called `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>`
   - same for `latest`

--- a/website/versioned_docs/version-0.7.1/server-config.md
+++ b/website/versioned_docs/version-0.7.1/server-config.md
@@ -21,7 +21,7 @@ $ RUST_LOG=<LEVEL> starknet-devnet
 or if using dockerized Devnet:
 
 ```
-$ docker run -e RUST_LOG=<LEVEL> shardlabs/starknet-devnet-rs
+$ docker run -e RUST_LOG=<LEVEL> starknetfoundation/starknet-devnet-rs
 ```
 
 By default, logging of request and response data is turned off.

--- a/website/versioned_docs/version-0.7.2/dump-load-restart.md
+++ b/website/versioned_docs/version-0.7.2/dump-load-restart.md
@@ -129,7 +129,7 @@ If there is `mydump` inside `/path/to/dumpdir`, you can load it with:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-path /path/to/dumpdir/mydump
 ```
 
@@ -139,6 +139,6 @@ To dump to `/path/to/dumpdir/mydump` on Devnet shutdown, run:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-on exit --dump-path /path/to/dumpdir/mydump
 ```

--- a/website/versioned_docs/version-0.7.2/metrics.md
+++ b/website/versioned_docs/version-0.7.2/metrics.md
@@ -25,7 +25,7 @@ $ METRICS_HOST=127.0.0.1 METRICS_PORT=8080 starknet-devnet
 If running with Docker:
 
 ```bash
-$ docker run -e METRICS_HOST=0.0.0.0 -e METRICS_PORT=9090 -p 9090:9090 shardlabs/starknet-devnet-rs
+$ docker run -e METRICS_HOST=0.0.0.0 -e METRICS_PORT=9090 -p 9090:9090 starknetfoundation/starknet-devnet-rs
 ```
 
 ## Accessing Metrics

--- a/website/versioned_docs/version-0.7.2/running/cli.md
+++ b/website/versioned_docs/version-0.7.2/running/cli.md
@@ -17,7 +17,7 @@ $ starknet-devnet --help
 Or if using dockerized Devnet:
 
 ```
-$ docker run --rm shardlabs/starknet-devnet-rs --help
+$ docker run --rm starknetfoundation/starknet-devnet-rs --help
 ```
 
 ## Environment variables
@@ -47,7 +47,7 @@ $ docker run \
     -e <VAR1>=<VALUE> \
     -e <VAR2>=<VALUE> \
     ... \
-    shardlabs/starknet-devnet-rs
+    starknetfoundation/starknet-devnet-rs
 ```
 
 ## Load configuration from a file
@@ -85,5 +85,5 @@ ACCOUNTS=3
 Then run:
 
 ```
-$ docker run --env-file .my-env-file shardlabs/starknet-devnet-rs
+$ docker run --env-file .my-env-file starknetfoundation/starknet-devnet-rs
 ```

--- a/website/versioned_docs/version-0.7.2/running/docker.md
+++ b/website/versioned_docs/version-0.7.2/running/docker.md
@@ -4,10 +4,10 @@ sidebar_position: 2.2
 
 # Run with Docker
 
-Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/shardlabs/starknet-devnet-rs/)). To download the `latest` image, run:
+Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/starknetfoundation/starknet-devnet-rs/)). To download the `latest` image, run:
 
 ```text
-$ docker pull shardlabs/starknet-devnet-rs
+$ docker pull starknetfoundation/starknet-devnet-rs
 ```
 
 Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm64).
@@ -15,7 +15,7 @@ Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm6
 Running a container is done like this (see [port publishing](#container-port-publishing) for more info):
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs [OPTIONS]
 ```
 
 ## Docker image tags
@@ -23,7 +23,7 @@ $ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
 All of the versions published on crates.io for starknet-devnet are available as docker images, which can be used via:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<CRATES_IO_VERSION>
+$ docker pull starknetfoundation/starknet-devnet-rs:<CRATES_IO_VERSION>
 ```
 
 :::note
@@ -37,7 +37,7 @@ The `latest` docker image tag corresponds to the last published version on crate
 Commits to the `main` branch of this repository are mostly available as images tagged with their commit hash (the full 40-lowercase-hex-digits SHA1 digest):
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<COMMIT_HASH>
+$ docker pull starknetfoundation/starknet-devnet-rs:<COMMIT_HASH>
 ```
 
 If a fix has been merged into the `main` branch of Devnet's code repository, you can access it before its inclusion in an official release. Just inspect the [`main` commit list](https://github.com/starknet-io/starknet-devnet/commits/main) and copy the full SHA digest of the commit containing the fix (or preferably the latest commit) which has a green check ✔️ symbol next to the commit date (which indicates the image indeed exists). Some revisions may not have a corresponding Docker image, but these are not supposed to be bugfixes.
@@ -47,8 +47,8 @@ If a fix has been merged into the `main` branch of Devnet's code repository, you
 By appending the `-seed0` suffix, you can use images which [predeploy funded accounts](../predeployed) with `--seed 0`, thus always predeploying the same set of accounts:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<VERSION>-seed0
-$ docker pull shardlabs/starknet-devnet-rs:latest-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:<VERSION>-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:latest-seed0
 ```
 
 ## Container port publishing
@@ -58,7 +58,7 @@ $ docker pull shardlabs/starknet-devnet-rs:latest-seed0
 If on a Linux host machine, you can use [`--network host`](https://docs.docker.com/network/host/). This way, the port used internally by the container is also available on your host machine. The `--port` option can be used (as well as other CLI options).
 
 ```text
-$ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
+$ docker run --network host starknetfoundation/starknet-devnet-rs [--port <PORT>]
 ```
 
 ### Mac and Windows
@@ -66,13 +66,13 @@ $ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
 If not on Linux, you need to publish the container's internally used port to a desired `<PORT>` on your host machine. The internal port is `5050` by default (probably not your concern, but can be overridden with `--port`).
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 E.g. if you want to use your host machine's `127.0.0.1:5050`, you need to run:
 
 ```text
-$ docker run -p 127.0.0.1:5050:5050 shardlabs/starknet-devnet-rs
+$ docker run -p 127.0.0.1:5050:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 You may ignore any address-related output logged on container startup (e.g. `Starknet Devnet listening on 0.0.0.0:5050`). What you will use is what you specified with the `-p` argument.
@@ -85,7 +85,7 @@ Due to internal needs, images with arch suffix are built and pushed to Docker Hu
 
 This is what happens under the hood on `main`:
 
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-amd`
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-arm`
-- create and push joint docker manifest called `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-amd`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-arm`
+- create and push joint docker manifest called `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>`
   - same for `latest`

--- a/website/versioned_docs/version-0.7.2/server-config.md
+++ b/website/versioned_docs/version-0.7.2/server-config.md
@@ -21,7 +21,7 @@ $ RUST_LOG=<LEVEL> starknet-devnet
 or if using dockerized Devnet:
 
 ```
-$ docker run -e RUST_LOG=<LEVEL> shardlabs/starknet-devnet-rs
+$ docker run -e RUST_LOG=<LEVEL> starknetfoundation/starknet-devnet-rs
 ```
 
 By default, logging of request and response data is turned off.

--- a/website/versioned_docs/version-0.8.0/dump-load-restart.md
+++ b/website/versioned_docs/version-0.8.0/dump-load-restart.md
@@ -129,7 +129,7 @@ If there is `mydump` inside `/path/to/dumpdir`, you can load it with:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-path /path/to/dumpdir/mydump
 ```
 
@@ -139,6 +139,6 @@ To dump to `/path/to/dumpdir/mydump` on Devnet shutdown, run:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-on exit --dump-path /path/to/dumpdir/mydump
 ```

--- a/website/versioned_docs/version-0.8.0/metrics.md
+++ b/website/versioned_docs/version-0.8.0/metrics.md
@@ -25,7 +25,7 @@ $ METRICS_HOST=127.0.0.1 METRICS_PORT=8080 starknet-devnet
 If running with Docker:
 
 ```bash
-$ docker run -e METRICS_HOST=0.0.0.0 -e METRICS_PORT=9090 -p 9090:9090 shardlabs/starknet-devnet-rs
+$ docker run -e METRICS_HOST=0.0.0.0 -e METRICS_PORT=9090 -p 9090:9090 starknetfoundation/starknet-devnet-rs
 ```
 
 ## Accessing Metrics

--- a/website/versioned_docs/version-0.8.0/proofs.md
+++ b/website/versioned_docs/version-0.8.0/proofs.md
@@ -55,7 +55,7 @@ PROOF_MODE=devnet starknet-devnet
 ```bash
 docker run --rm -p 5050:5050 \
   -e PROOF_MODE=devnet \
-  shardlabs/starknet-devnet-rs
+  starknetfoundation/starknet-devnet-rs
 ```
 
 ## RPC: `starknet_proveTransaction`

--- a/website/versioned_docs/version-0.8.0/running/cli.md
+++ b/website/versioned_docs/version-0.8.0/running/cli.md
@@ -17,7 +17,7 @@ $ starknet-devnet --help
 Or if using dockerized Devnet:
 
 ```
-$ docker run --rm shardlabs/starknet-devnet-rs --help
+$ docker run --rm starknetfoundation/starknet-devnet-rs --help
 ```
 
 ## Environment variables
@@ -47,7 +47,7 @@ $ docker run \
     -e <VAR1>=<VALUE> \
     -e <VAR2>=<VALUE> \
     ... \
-    shardlabs/starknet-devnet-rs
+    starknetfoundation/starknet-devnet-rs
 ```
 
 ## Load configuration from a file
@@ -85,7 +85,7 @@ ACCOUNTS=3
 Then run:
 
 ```
-$ docker run --env-file .my-env-file shardlabs/starknet-devnet-rs
+$ docker run --env-file .my-env-file starknetfoundation/starknet-devnet-rs
 ```
 
 ## Proof-related configuration

--- a/website/versioned_docs/version-0.8.0/running/docker.md
+++ b/website/versioned_docs/version-0.8.0/running/docker.md
@@ -4,10 +4,10 @@ sidebar_position: 2.2
 
 # Run with Docker
 
-Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/shardlabs/starknet-devnet-rs/)). To download the `latest` image, run:
+Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/starknetfoundation/starknet-devnet-rs/)). To download the `latest` image, run:
 
 ```text
-$ docker pull shardlabs/starknet-devnet-rs
+$ docker pull starknetfoundation/starknet-devnet-rs
 ```
 
 Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm64).
@@ -15,7 +15,7 @@ Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm6
 Running a container is done like this (see [port publishing](#container-port-publishing) for more info):
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs [OPTIONS]
 ```
 
 ## Docker image tags
@@ -23,7 +23,7 @@ $ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
 All of the versions published on crates.io for starknet-devnet are available as docker images, which can be used via:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<CRATES_IO_VERSION>
+$ docker pull starknetfoundation/starknet-devnet-rs:<CRATES_IO_VERSION>
 ```
 
 :::note
@@ -37,7 +37,7 @@ The `latest` docker image tag corresponds to the last published version on crate
 Commits to the `main` branch of this repository are mostly available as images tagged with their commit hash (the full 40-lowercase-hex-digits SHA1 digest):
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<COMMIT_HASH>
+$ docker pull starknetfoundation/starknet-devnet-rs:<COMMIT_HASH>
 ```
 
 If a fix has been merged into the `main` branch of Devnet's code repository, you can access it before its inclusion in an official release. Just inspect the [`main` commit list](https://github.com/starknet-io/starknet-devnet/commits/main) and copy the full SHA digest of the commit containing the fix (or preferably the latest commit) which has a green check ✔️ symbol next to the commit date (which indicates the image indeed exists). Some revisions may not have a corresponding Docker image, but these are not supposed to be bugfixes.
@@ -47,8 +47,8 @@ If a fix has been merged into the `main` branch of Devnet's code repository, you
 By appending the `-seed0` suffix, you can use images which [predeploy funded accounts](../predeployed) with `--seed 0`, thus always predeploying the same set of accounts:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<VERSION>-seed0
-$ docker pull shardlabs/starknet-devnet-rs:latest-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:<VERSION>-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:latest-seed0
 ```
 
 ## Container port publishing
@@ -58,7 +58,7 @@ $ docker pull shardlabs/starknet-devnet-rs:latest-seed0
 If on a Linux host machine, you can use [`--network host`](https://docs.docker.com/network/host/). This way, the port used internally by the container is also available on your host machine. The `--port` option can be used (as well as other CLI options).
 
 ```text
-$ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
+$ docker run --network host starknetfoundation/starknet-devnet-rs [--port <PORT>]
 ```
 
 ### Mac and Windows
@@ -66,13 +66,13 @@ $ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
 If not on Linux, you need to publish the container's internally used port to a desired `<PORT>` on your host machine. The internal port is `5050` by default (probably not your concern, but can be overridden with `--port`).
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 E.g. if you want to use your host machine's `127.0.0.1:5050`, you need to run:
 
 ```text
-$ docker run -p 127.0.0.1:5050:5050 shardlabs/starknet-devnet-rs
+$ docker run -p 127.0.0.1:5050:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 You may ignore any address-related output logged on container startup (e.g. `Starknet Devnet listening on 0.0.0.0:5050`). What you will use is what you specified with the `-p` argument.
@@ -85,7 +85,7 @@ Due to internal needs, images with arch suffix are built and pushed to Docker Hu
 
 This is what happens under the hood on `main`:
 
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-amd`
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-arm`
-- create and push joint docker manifest called `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-amd`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-arm`
+- create and push joint docker manifest called `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>`
   - same for `latest`

--- a/website/versioned_docs/version-0.8.0/server-config.md
+++ b/website/versioned_docs/version-0.8.0/server-config.md
@@ -21,7 +21,7 @@ $ RUST_LOG=<LEVEL> starknet-devnet
 or if using dockerized Devnet:
 
 ```
-$ docker run -e RUST_LOG=<LEVEL> shardlabs/starknet-devnet-rs
+$ docker run -e RUST_LOG=<LEVEL> starknetfoundation/starknet-devnet-rs
 ```
 
 By default, logging of request and response data is turned off.

--- a/website/versioned_docs/version-0.8.1/dump-load-restart.md
+++ b/website/versioned_docs/version-0.8.1/dump-load-restart.md
@@ -129,7 +129,7 @@ If there is `mydump` inside `/path/to/dumpdir`, you can load it with:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-path /path/to/dumpdir/mydump
 ```
 
@@ -139,6 +139,6 @@ To dump to `/path/to/dumpdir/mydump` on Devnet shutdown, run:
 docker run \
   -p 127.0.0.1:5050:5050 \
   --mount type=bind,source=/path/to/dumpdir,target=/path/to/dumpdir \
-  shardlabs/starknet-devnet-rs \
+  starknetfoundation/starknet-devnet-rs \
   --dump-on exit --dump-path /path/to/dumpdir/mydump
 ```

--- a/website/versioned_docs/version-0.8.1/metrics.md
+++ b/website/versioned_docs/version-0.8.1/metrics.md
@@ -25,7 +25,7 @@ $ METRICS_HOST=127.0.0.1 METRICS_PORT=8080 starknet-devnet
 If running with Docker:
 
 ```bash
-$ docker run -e METRICS_HOST=0.0.0.0 -e METRICS_PORT=9090 -p 9090:9090 shardlabs/starknet-devnet-rs
+$ docker run -e METRICS_HOST=0.0.0.0 -e METRICS_PORT=9090 -p 9090:9090 starknetfoundation/starknet-devnet-rs
 ```
 
 ## Accessing Metrics

--- a/website/versioned_docs/version-0.8.1/proofs.md
+++ b/website/versioned_docs/version-0.8.1/proofs.md
@@ -55,7 +55,7 @@ PROOF_MODE=devnet starknet-devnet
 ```bash
 docker run --rm -p 5050:5050 \
   -e PROOF_MODE=devnet \
-  shardlabs/starknet-devnet-rs
+  starknetfoundation/starknet-devnet-rs
 ```
 
 ## RPC: `starknet_proveTransaction`

--- a/website/versioned_docs/version-0.8.1/running/cli.md
+++ b/website/versioned_docs/version-0.8.1/running/cli.md
@@ -17,7 +17,7 @@ $ starknet-devnet --help
 Or if using dockerized Devnet:
 
 ```
-$ docker run --rm shardlabs/starknet-devnet-rs --help
+$ docker run --rm starknetfoundation/starknet-devnet-rs --help
 ```
 
 ## Environment variables
@@ -47,7 +47,7 @@ $ docker run \
     -e <VAR1>=<VALUE> \
     -e <VAR2>=<VALUE> \
     ... \
-    shardlabs/starknet-devnet-rs
+    starknetfoundation/starknet-devnet-rs
 ```
 
 ## Load configuration from a file
@@ -85,7 +85,7 @@ ACCOUNTS=3
 Then run:
 
 ```
-$ docker run --env-file .my-env-file shardlabs/starknet-devnet-rs
+$ docker run --env-file .my-env-file starknetfoundation/starknet-devnet-rs
 ```
 
 ## Proof-related configuration

--- a/website/versioned_docs/version-0.8.1/running/docker.md
+++ b/website/versioned_docs/version-0.8.1/running/docker.md
@@ -4,10 +4,10 @@ sidebar_position: 2.2
 
 # Run with Docker
 
-Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/shardlabs/starknet-devnet-rs/)). To download the `latest` image, run:
+Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/starknetfoundation/starknet-devnet-rs/)). To download the `latest` image, run:
 
 ```text
-$ docker pull shardlabs/starknet-devnet-rs
+$ docker pull starknetfoundation/starknet-devnet-rs
 ```
 
 Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm64).
@@ -15,7 +15,7 @@ Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm6
 Running a container is done like this (see [port publishing](#container-port-publishing) for more info):
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs [OPTIONS]
 ```
 
 ## Docker image tags
@@ -23,7 +23,7 @@ $ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs [OPTIONS]
 All of the versions published on crates.io for starknet-devnet are available as docker images, which can be used via:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<CRATES_IO_VERSION>
+$ docker pull starknetfoundation/starknet-devnet-rs:<CRATES_IO_VERSION>
 ```
 
 :::note
@@ -37,7 +37,7 @@ The `latest` docker image tag corresponds to the last published version on crate
 Commits to the `main` branch of this repository are mostly available as images tagged with their commit hash (the full 40-lowercase-hex-digits SHA1 digest):
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<COMMIT_HASH>
+$ docker pull starknetfoundation/starknet-devnet-rs:<COMMIT_HASH>
 ```
 
 If a fix has been merged into the `main` branch of Devnet's code repository, you can access it before its inclusion in an official release. Just inspect the [`main` commit list](https://github.com/starknet-io/starknet-devnet/commits/main) and copy the full SHA digest of the commit containing the fix (or preferably the latest commit) which has a green check ✔️ symbol next to the commit date (which indicates the image indeed exists). Some revisions may not have a corresponding Docker image, but these are not supposed to be bugfixes.
@@ -47,8 +47,8 @@ If a fix has been merged into the `main` branch of Devnet's code repository, you
 By appending the `-seed0` suffix, you can use images which [predeploy funded accounts](../predeployed) with `--seed 0`, thus always predeploying the same set of accounts:
 
 ```
-$ docker pull shardlabs/starknet-devnet-rs:<VERSION>-seed0
-$ docker pull shardlabs/starknet-devnet-rs:latest-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:<VERSION>-seed0
+$ docker pull starknetfoundation/starknet-devnet-rs:latest-seed0
 ```
 
 ## Container port publishing
@@ -58,7 +58,7 @@ $ docker pull shardlabs/starknet-devnet-rs:latest-seed0
 If on a Linux host machine, you can use [`--network host`](https://docs.docker.com/network/host/). This way, the port used internally by the container is also available on your host machine. The `--port` option can be used (as well as other CLI options).
 
 ```text
-$ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
+$ docker run --network host starknetfoundation/starknet-devnet-rs [--port <PORT>]
 ```
 
 ### Mac and Windows
@@ -66,13 +66,13 @@ $ docker run --network host shardlabs/starknet-devnet-rs [--port <PORT>]
 If not on Linux, you need to publish the container's internally used port to a desired `<PORT>` on your host machine. The internal port is `5050` by default (probably not your concern, but can be overridden with `--port`).
 
 ```text
-$ docker run -p [HOST:]<PORT>:5050 shardlabs/starknet-devnet-rs
+$ docker run -p [HOST:]<PORT>:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 E.g. if you want to use your host machine's `127.0.0.1:5050`, you need to run:
 
 ```text
-$ docker run -p 127.0.0.1:5050:5050 shardlabs/starknet-devnet-rs
+$ docker run -p 127.0.0.1:5050:5050 starknetfoundation/starknet-devnet-rs
 ```
 
 You may ignore any address-related output logged on container startup (e.g. `Starknet Devnet listening on 0.0.0.0:5050`). What you will use is what you specified with the `-p` argument.
@@ -85,7 +85,7 @@ Due to internal needs, images with arch suffix are built and pushed to Docker Hu
 
 This is what happens under the hood on `main`:
 
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-amd`
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-arm`
-- create and push joint docker manifest called `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-amd`
+- build `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>-arm`
+- create and push joint docker manifest called `starknetfoundation/starknet-devnet-rs-<COMMIT_SHA1>`
   - same for `latest`

--- a/website/versioned_docs/version-0.8.1/server-config.md
+++ b/website/versioned_docs/version-0.8.1/server-config.md
@@ -21,7 +21,7 @@ $ RUST_LOG=<LEVEL> starknet-devnet
 or if using dockerized Devnet:
 
 ```
-$ docker run -e RUST_LOG=<LEVEL> shardlabs/starknet-devnet-rs
+$ docker run -e RUST_LOG=<LEVEL> starknetfoundation/starknet-devnet-rs
 ```
 
 By default, logging of request and response data is turned off.


### PR DESCRIPTION
## Usage related changes

- Docker images are now pushed to **both** `shardlabs/starknet-devnet-rs` and `starknetfoundation/starknet-devnet-rs` on Docker Hub.
- All documentation now references `starknetfoundation/starknet-devnet-rs` as the canonical image.

## Development related changes

- `.github/actions/load-config/action.yml`: Added `docker_namespace_secondary` output for `starknetfoundation`.
- `.github/workflows/build-and-publish.yml`: Updated tag generation and image push steps to include both namespaces using the same credentials.

## Checklist:

- [x] Checked out the [contribution guidelines](https://github.com/starknet-io/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/starknet-io/starknet-devnet/issues) resolvable by this PR
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/starknet-io/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)