### PR TITLE
feat: harden Docker image and CI pipeline

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -255,7 +255,7 @@ jobs:
 
       - name: Build and publish standard Docker image
         id: build_standard
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -264,10 +264,12 @@ jobs:
           tags: ${{ steps.combined_tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true
 
       - name: Build and publish seed0 Docker image
         id: build_seed0
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./seed0.Dockerfile
@@ -278,6 +280,8 @@ jobs:
             BASE_IMAGE=${{ steps.config.outputs.docker_registry }}/${{ steps.config.outputs.docker_namespace }}/${{ steps.config.outputs.image_name }}:sha-${{ needs.prepare.outputs.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true
           
       - name: Summarize published images
         run: |
@@ -355,7 +359,7 @@ jobs:
           npm run deploy
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           name: v${{ needs.prepare.outputs.version }}
           tag_name: v${{ needs.prepare.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,11 @@ FROM alpine:3.22
 # Use ca-certificates to allow forking from URLs using https scheme
 RUN apk add --no-cache tini ca-certificates
 
+RUN addgroup -S devnet && adduser -S devnet -G devnet
+
 COPY --from=builder /target/release/starknet-devnet /usr/local/bin/starknet-devnet
+
+USER devnet
 
 # The default port; exposing is beneficial if using Docker GUI
 EXPOSE 5050


### PR DESCRIPTION
## Usage related changes

- Docker image now runs as a non-root user (`devnet`), improving container security posture.
- Docker images now include provenance attestations and SBOM, enabling supply chain verification.

## Development related changes

- Bumped `docker/build-push-action` from v5 to v7
- Bumped `softprops/action-gh-release` from v1 to v3
- Added `provenance: true` and `sbom: true` to both Docker buildx steps

## Checklist:

- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)