### PR TITLE
ci: native multi-arch Docker builds with cargo-chef

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -148,194 +148,295 @@ jobs:
         run: tar -czvf ${{ matrix.artifact-name }}.tar.gz --directory target/${{ matrix.target }}/release starknet-devnet
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact-name }}
           path: ${{ matrix.artifact-name }}.tar.gz
           retention-days: 14
 
-  build-docker:
-    name: Build Docker Images
+  prepare-docker-tags:
+    name: Prepare Docker Tags
     needs: prepare
-    runs-on: self-hosted
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-22.04
+    outputs:
+      registry: ${{ steps.tags.outputs.registry }}
+      sha_standard_tag: ${{ steps.tags.outputs.sha_standard_tag }}
+      standard_tags: ${{ steps.tags.outputs.standard_tags }}
+      seed0_tags: ${{ steps.tags.outputs.seed0_tags }}
+      standard_secondary_tags: ${{ steps.tags.outputs.standard_secondary_tags }}
+      seed0_secondary_tags: ${{ steps.tags.outputs.seed0_secondary_tags }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        
+
       - name: Load common configuration
         id: config
         uses: ./.github/actions/load-config
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64,amd64
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      
-      - name: Prepare SHA tags
-        id: sha_tags
+      - name: Prepare all Docker tags
+        id: tags
         run: |
           DOCKER_REGISTRY="${{ steps.config.outputs.docker_registry }}"
           DOCKER_NAMESPACE="${{ steps.config.outputs.docker_namespace }}"
           DOCKER_NAMESPACE_SECONDARY="${{ steps.config.outputs.docker_namespace_secondary }}"
           IMAGE_NAME="${{ steps.config.outputs.image_name }}"
           SHA="${{ needs.prepare.outputs.sha }}"
-          
-          SHA_TAG="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$IMAGE_NAME:sha-$SHA"
-          SHA_SEED0_TAG="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$IMAGE_NAME:sha-$SHA-seed0"
-          SHA_TAG_SECONDARY="$DOCKER_REGISTRY/$DOCKER_NAMESPACE_SECONDARY/$IMAGE_NAME:sha-$SHA"
-          SHA_SEED0_TAG_SECONDARY="$DOCKER_REGISTRY/$DOCKER_NAMESPACE_SECONDARY/$IMAGE_NAME:sha-$SHA-seed0"
-          
-          echo "sha_tag=$SHA_TAG" >> $GITHUB_OUTPUT
-          echo "sha_seed0_tag=$SHA_SEED0_TAG" >> $GITHUB_OUTPUT
-          echo "sha_tag_secondary=$SHA_TAG_SECONDARY" >> $GITHUB_OUTPUT
-          echo "sha_seed0_tag_secondary=$SHA_SEED0_TAG_SECONDARY" >> $GITHUB_OUTPUT
-
-      - name: Prepare version tags
-        id: version_tags
-        if: ${{ needs.prepare.outputs.version_changed == 'true' }}
-        run: |
-          DOCKER_REGISTRY="${{ steps.config.outputs.docker_registry }}"
-          DOCKER_NAMESPACE="${{ steps.config.outputs.docker_namespace }}"
-          DOCKER_NAMESPACE_SECONDARY="${{ steps.config.outputs.docker_namespace_secondary }}"
-          IMAGE_NAME="${{ steps.config.outputs.image_name }}"
           VERSION="${{ needs.prepare.outputs.version }}"
-          
-          VERSION_TAG="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$IMAGE_NAME:$VERSION"
-          VERSION_SEED0_TAG="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$IMAGE_NAME:$VERSION-seed0"
-          VERSION_TAG_SECONDARY="$DOCKER_REGISTRY/$DOCKER_NAMESPACE_SECONDARY/$IMAGE_NAME:$VERSION"
-          VERSION_SEED0_TAG_SECONDARY="$DOCKER_REGISTRY/$DOCKER_NAMESPACE_SECONDARY/$IMAGE_NAME:$VERSION-seed0"
-          
-          echo "version_tag=$VERSION_TAG" >> $GITHUB_OUTPUT
-          echo "version_seed0_tag=$VERSION_SEED0_TAG" >> $GITHUB_OUTPUT
-          echo "version_tag_secondary=$VERSION_TAG_SECONDARY" >> $GITHUB_OUTPUT
-          echo "version_seed0_tag_secondary=$VERSION_SEED0_TAG_SECONDARY" >> $GITHUB_OUTPUT
-      
-      - name: Prepare latest tags
-        id: latest_tags
-        if: ${{ needs.prepare.outputs.version_changed == 'true' && needs.prepare.outputs.is_rc == 'false' }}
-        run: |
-          DOCKER_REGISTRY="${{ steps.config.outputs.docker_registry }}"
-          DOCKER_NAMESPACE="${{ steps.config.outputs.docker_namespace }}"
-          DOCKER_NAMESPACE_SECONDARY="${{ steps.config.outputs.docker_namespace_secondary }}"
-          IMAGE_NAME="${{ steps.config.outputs.image_name }}"
-          
-          LATEST_TAG="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$IMAGE_NAME:latest"
-          LATEST_SEED0_TAG="$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$IMAGE_NAME:latest-seed0"
-          LATEST_TAG_SECONDARY="$DOCKER_REGISTRY/$DOCKER_NAMESPACE_SECONDARY/$IMAGE_NAME:latest"
-          LATEST_SEED0_TAG_SECONDARY="$DOCKER_REGISTRY/$DOCKER_NAMESPACE_SECONDARY/$IMAGE_NAME:latest-seed0"
-          
-          echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
-          echo "latest_seed0_tag=$LATEST_SEED0_TAG" >> $GITHUB_OUTPUT
-          echo "latest_tag_secondary=$LATEST_TAG_SECONDARY" >> $GITHUB_OUTPUT
-          echo "latest_seed0_tag_secondary=$LATEST_SEED0_TAG_SECONDARY" >> $GITHUB_OUTPUT
-          
-      - name: Combine tags for standard image
-        id: combined_tags
-        run: |
-          TAGS=("${{ steps.sha_tags.outputs.sha_tag }}")
-          TAGS+=("${{ steps.sha_tags.outputs.sha_tag_secondary }}")
-          
-          if [[ -n "${{ steps.version_tags.outputs.version_tag }}" ]]; then
-            TAGS+=("${{ steps.version_tags.outputs.version_tag }}")
-            TAGS+=("${{ steps.version_tags.outputs.version_tag_secondary }}")
-          fi
-          
-          if [[ -n "${{ steps.latest_tags.outputs.latest_tag }}" ]]; then
-            TAGS+=("${{ steps.latest_tags.outputs.latest_tag }}")
-            TAGS+=("${{ steps.latest_tags.outputs.latest_tag_secondary }}")
-          fi
-          
-          echo "tags=$(IFS=,; echo "${TAGS[*]}")" >> $GITHUB_OUTPUT
 
-      - name: Combine tags for seed0 image
-        id: combined_seed0_tags
-        run: |
-          SEED0_TAGS=("${{ steps.sha_tags.outputs.sha_seed0_tag }}")
-          SEED0_TAGS+=("${{ steps.sha_tags.outputs.sha_seed0_tag_secondary }}")
-          
-          if [[ -n "${{ steps.version_tags.outputs.version_seed0_tag }}" ]]; then
-            SEED0_TAGS+=("${{ steps.version_tags.outputs.version_seed0_tag }}")
-            SEED0_TAGS+=("${{ steps.version_tags.outputs.version_seed0_tag_secondary }}")
-          fi
-          
-          if [[ -n "${{ steps.latest_tags.outputs.latest_seed0_tag }}" ]]; then
-            SEED0_TAGS+=("${{ steps.latest_tags.outputs.latest_seed0_tag }}")
-            SEED0_TAGS+=("${{ steps.latest_tags.outputs.latest_seed0_tag_secondary }}")
-          fi
-          
-          echo "tags=$(IFS=,; echo "${SEED0_TAGS[*]}")" >> $GITHUB_OUTPUT
+          STD_PRIMARY=()
+          STD_SECONDARY=()
+          SEED0_PRIMARY=()
+          SEED0_SECONDARY=()
 
-      - name: Build and publish standard Docker image
-        id: build_standard
+          STD_PRIMARY+=("$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$IMAGE_NAME:sha-$SHA")
+          STD_SECONDARY+=("$DOCKER_REGISTRY/$DOCKER_NAMESPACE_SECONDARY/$IMAGE_NAME:sha-$SHA")
+          SEED0_PRIMARY+=("$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$IMAGE_NAME:sha-$SHA-seed0")
+          SEED0_SECONDARY+=("$DOCKER_REGISTRY/$DOCKER_NAMESPACE_SECONDARY/$IMAGE_NAME:sha-$SHA-seed0")
+
+          if [[ "${{ needs.prepare.outputs.version_changed }}" == "true" ]]; then
+            STD_PRIMARY+=("$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$IMAGE_NAME:$VERSION")
+            STD_SECONDARY+=("$DOCKER_REGISTRY/$DOCKER_NAMESPACE_SECONDARY/$IMAGE_NAME:$VERSION")
+            SEED0_PRIMARY+=("$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$IMAGE_NAME:$VERSION-seed0")
+            SEED0_SECONDARY+=("$DOCKER_REGISTRY/$DOCKER_NAMESPACE_SECONDARY/$IMAGE_NAME:$VERSION-seed0")
+          fi
+
+          if [[ "${{ needs.prepare.outputs.version_changed }}" == "true" && "${{ needs.prepare.outputs.is_rc }}" == "false" ]]; then
+            STD_PRIMARY+=("$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$IMAGE_NAME:latest")
+            STD_SECONDARY+=("$DOCKER_REGISTRY/$DOCKER_NAMESPACE_SECONDARY/$IMAGE_NAME:latest")
+            SEED0_PRIMARY+=("$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$IMAGE_NAME:latest-seed0")
+            SEED0_SECONDARY+=("$DOCKER_REGISTRY/$DOCKER_NAMESPACE_SECONDARY/$IMAGE_NAME:latest-seed0")
+          fi
+
+          echo "registry=$DOCKER_REGISTRY" >> "$GITHUB_OUTPUT"
+          echo "sha_standard_tag=$DOCKER_REGISTRY/$DOCKER_NAMESPACE/$IMAGE_NAME:sha-$SHA" >> "$GITHUB_OUTPUT"
+          echo "standard_tags=$(IFS=,; echo "${STD_PRIMARY[*]}")" >> "$GITHUB_OUTPUT"
+          echo "seed0_tags=$(IFS=,; echo "${SEED0_PRIMARY[*]}")" >> "$GITHUB_OUTPUT"
+          echo "standard_secondary_tags=$(IFS=,; echo "${STD_SECONDARY[*]}")" >> "$GITHUB_OUTPUT"
+          echo "seed0_secondary_tags=$(IFS=,; echo "${SEED0_SECONDARY[*]}")" >> "$GITHUB_OUTPUT"
+
+  build-docker:
+    name: Build Docker (${{ matrix.platform }})
+    needs: prepare-docker-tags
+    if: github.ref == 'refs/heads/main'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-22.04
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-22.04-arm
+            arch: arm64
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push per-arch image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
-          tags: ${{ steps.combined_tags.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          tags: ${{ needs.prepare-docker-tags.outputs.sha_standard_tag }}-${{ matrix.arch }}
+          cache-from: type=gha,scope=docker-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.arch }}
           provenance: true
           sbom: true
 
-      - name: Build and publish seed0 Docker image
-        id: build_seed0
+  build-docker-seed0:
+    name: Build Docker Seed0 (${{ matrix.platform }})
+    needs: [prepare-docker-tags, build-docker]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-22.04
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-22.04-arm
+            arch: arm64
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Compute seed0 per-arch tag
+        id: seed0_tag
+        run: |
+          IFS=',' read -ra SEED0 <<< "${{ needs.prepare-docker-tags.outputs.seed0_tags }}"
+          echo "tag=${SEED0[0]}-${{ matrix.arch }}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push per-arch seed0 image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./seed0.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
-          tags: ${{ steps.combined_seed0_tags.outputs.tags }}
+          tags: ${{ steps.seed0_tag.outputs.tag }}
           build-args: |
-            BASE_IMAGE=${{ steps.config.outputs.docker_registry }}/${{ steps.config.outputs.docker_namespace }}/${{ steps.config.outputs.image_name }}:sha-${{ needs.prepare.outputs.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            BASE_IMAGE=${{ needs.prepare-docker-tags.outputs.sha_standard_tag }}-${{ matrix.arch }}
+          cache-from: type=gha,scope=docker-seed0-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=docker-seed0-${{ matrix.arch }}
           provenance: true
           sbom: true
-          
-      - name: Summarize published images
+
+  merge-docker-manifests:
+    name: Merge Multi-Arch Docker Manifests
+    needs: [prepare-docker-tags, build-docker-seed0]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Create multi-arch manifests
+        run: |
+          BASE="${{ needs.prepare-docker-tags.outputs.sha_standard_tag }}"
+          IFS=',' read -ra TAGS <<< "${{ needs.prepare-docker-tags.outputs.standard_tags }}"
+          for tag in "${TAGS[@]}"; do
+            docker buildx imagetools create -t "$tag" "${BASE}-amd64" "${BASE}-arm64"
+          done
+
+      - name: Create multi-arch manifests for seed0 image
+        run: |
+          IFS=',' read -ra SEED0_ALL <<< "${{ needs.prepare-docker-tags.outputs.seed0_tags }}"
+          SEED0_BASE="${SEED0_ALL[0]}"
+          for tag in "${SEED0_ALL[@]}"; do
+            docker buildx imagetools create -t "$tag" "${SEED0_BASE}-amd64" "${SEED0_BASE}-arm64"
+          done
+
+      - name: Summarize primary published images
         run: |
           echo "# Docker images published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "## Standard image tags:" >> $GITHUB_STEP_SUMMARY
-          
-          echo "- \`${{ steps.sha_tags.outputs.sha_tag }}\`" >> $GITHUB_STEP_SUMMARY
-          
-          if [[ -n "${{ steps.version_tags.outputs.version_tag }}" ]]; then
-            echo "- \`${{ steps.version_tags.outputs.version_tag }}\`" >> $GITHUB_STEP_SUMMARY
-          fi
-          if [[ -n "${{ steps.latest_tags.outputs.latest_tag }}" ]]; then
-            echo "- \`${{ steps.latest_tags.outputs.latest_tag }}\`" >> $GITHUB_STEP_SUMMARY
-          fi
-          
+          echo "## Docker image tags:" >> $GITHUB_STEP_SUMMARY
+          IFS=',' read -ra STD_TAGS <<< "${{ needs.prepare-docker-tags.outputs.standard_tags }}"
+          for tag in "${STD_TAGS[@]}"; do echo "- \`$tag\`" >> $GITHUB_STEP_SUMMARY; done
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "## Seed0 image tags:" >> $GITHUB_STEP_SUMMARY
-          
-          echo "- \`${{ steps.sha_tags.outputs.sha_seed0_tag }}\`" >> $GITHUB_STEP_SUMMARY
-          
-          if [[ -n "${{ steps.version_tags.outputs.version_seed0_tag }}" ]]; then
-            echo "- \`${{ steps.version_tags.outputs.version_seed0_tag }}\`" >> $GITHUB_STEP_SUMMARY
+          IFS=',' read -ra SEED0_TAGS <<< "${{ needs.prepare-docker-tags.outputs.seed0_tags }}"
+          for tag in "${SEED0_TAGS[@]}"; do echo "- \`$tag\`" >> $GITHUB_STEP_SUMMARY; done
+
+  tag-secondary-images:
+    name: Tag Docker Images - Secondary Namespace
+    needs: [prepare-docker-tags, merge-docker-manifests]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.1.0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4.2.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Tag secondary manifests from primary manifests
+        run: |
+          publish_secondary() {
+            local primary_csv="$1"
+            local secondary_csv="$2"
+            IFS=',' read -ra PRIMARY <<< "$primary_csv"
+            IFS=',' read -ra SECONDARY <<< "$secondary_csv"
+
+            for i in "${!PRIMARY[@]}"; do
+              docker buildx imagetools create -t "${SECONDARY[$i]}" "${PRIMARY[$i]}"
+            done
+          }
+
+          publish_secondary "${{ needs.prepare-docker-tags.outputs.standard_tags }}" "${{ needs.prepare-docker-tags.outputs.standard_secondary_tags }}"
+          publish_secondary "${{ needs.prepare-docker-tags.outputs.seed0_tags }}" "${{ needs.prepare-docker-tags.outputs.seed0_secondary_tags }}"
+
+  cleanup-docker-intermediate-tags:
+    name: Cleanup Docker Intermediate Tags
+    needs: [prepare-docker-tags, tag-secondary-images]
+    if: github.ref == 'refs/heads/main' && (needs.prepare-docker-tags.outputs.registry == 'docker.io' || needs.prepare-docker-tags.outputs.registry == 'index.docker.io' || needs.prepare-docker-tags.outputs.registry == 'registry-1.docker.io')
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Load common configuration
+        id: config
+        uses: ./.github/actions/load-config
+
+      - name: Remove per-arch intermediate tags from Docker Hub
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          repo="${{ steps.config.outputs.docker_namespace }}/${{ steps.config.outputs.image_name }}"
+
+          # Obtain JWT token for Docker Hub API
+          TOKEN=$(curl -fsS -H "Content-Type: application/json" \
+            -X POST -d "{\"username\":\"${DOCKER_USERNAME}\",\"password\":\"${DOCKER_PASSWORD}\"}" \
+            https://hub.docker.com/v2/users/login/ | jq -r .token)
+
+          if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
+            echo "::warning::Failed to obtain Docker Hub JWT token, skipping cleanup"
+            exit 0
           fi
-          if [[ -n "${{ steps.latest_tags.outputs.latest_seed0_tag }}" ]]; then
-            echo "- \`${{ steps.latest_tags.outputs.latest_seed0_tag }}\`" >> $GITHUB_STEP_SUMMARY
-          fi
+
+          delete_tag() {
+            local tag="$1"
+            local delete_url="https://hub.docker.com/v2/repositories/${repo}/tags/${tag}/"
+            if ! curl -fsS -H "Authorization: Bearer ${TOKEN}" -X DELETE "$delete_url"; then
+              echo "::warning::Could not delete tag $tag"
+            fi
+          }
+
+          # Clean up per-arch tags
+          STD_BASE="${{ needs.prepare-docker-tags.outputs.sha_standard_tag }}"
+          STD_BASE_TAG="${STD_BASE##*:}"
+          delete_tag "${STD_BASE_TAG}-amd64"
+          delete_tag "${STD_BASE_TAG}-arm64"
+
+          # Clean up per-arch tags for seed0 image
+          IFS=',' read -ra SEED0_ALL <<< "${{ needs.prepare-docker-tags.outputs.seed0_tags }}"
+          SEED0_BASE_TAG="${SEED0_ALL[0]##*:}"
+          delete_tag "${SEED0_BASE_TAG}-amd64"
+          delete_tag "${SEED0_BASE_TAG}-arm64"
 
   publish:
     name: Publish to crates.io and GitHub releases
-    needs: [prepare, build-binaries, build-docker]
+    needs: [prepare, build-binaries, tag-secondary-images]
     if: needs.prepare.outputs.version_changed == 'true' && github.ref == 'refs/heads/main'
-    runs-on: self-hosted
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -350,16 +451,18 @@ jobs:
           toolchain: ${{ steps.config.outputs.rust_stable_version }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
+      - name: Download binary artifacts
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
+          pattern: starknet-devnet-*
+          merge-multiple: false
           
       - name: Publish to crates.io
         if: ${{ !inputs.skip_crates_io }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -100,7 +100,7 @@ jobs:
           toolchain: ${{ steps.config.outputs.rust_stable_version }}
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1.1.0
+        uses: foundry-rs/foundry-toolchain@v1.8
         with:
           version: nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -100,7 +100,7 @@ jobs:
           toolchain: ${{ steps.config.outputs.rust_stable_version }}
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1.8
+        uses: foundry-rs/foundry-toolchain@v1.8.0
         with:
           version: nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,21 @@
-FROM rust:1.92-alpine3.22 AS builder
+FROM rust:1.92-alpine3.22 AS chef
+
+RUN apk add --no-cache pkgconfig make musl-dev openssl-dev perl && \
+    cargo install cargo-chef --locked
+
+WORKDIR /app
+
+FROM chef AS planner
 
 COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-RUN apk update && \
-    apk add --no-cache pkgconfig make musl-dev openssl-dev perl
+FROM chef AS builder
 
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
+COPY . .
 RUN cargo build --bin starknet-devnet --release
 
 FROM alpine:3.22
@@ -15,7 +26,7 @@ RUN apk add --no-cache tini ca-certificates
 
 RUN addgroup -S devnet && adduser -S devnet -G devnet
 
-COPY --from=builder /target/release/starknet-devnet /usr/local/bin/starknet-devnet
+COPY --from=builder /app/target/release/starknet-devnet /usr/local/bin/starknet-devnet
 
 USER devnet
 


### PR DESCRIPTION
## Usage related changes

No user-facing changes. Docker images are built and published identically.

## Development related changes

- **Native multi-arch Docker builds**: Replaced QEMU-based cross-compilation with native builds on `ubuntu-22.04` (amd64) and `ubuntu-22.04-arm` (arm64), significantly reducing build times.
- **cargo-chef**: Dockerfile now uses a 3-stage cargo-chef pattern (chef → planner → builder) for optimal dependency layer caching.
- **Split Docker pipeline**: The monolithic Docker job is now split into sequential stages: `build-docker` → `build-docker-seed0` → `merge-docker-manifests` → `tag-secondary-images` → `cleanup-docker-intermediate-tags`.
- **GHA layer cache**: Per-architecture scoped caches with `mode=max` for maximum layer reuse.
- **Decoupled secondary namespace tagging**: Secondary namespace images are tagged via `imagetools create` after primary manifests are merged, rather than during build.
- **JWT auth for cleanup**: Intermediate per-arch tag cleanup uses proper JWT token authentication for Docker Hub API.
- **foundry-toolchain bump**: Updated from v1.1.0 to v1.8 in build-and-test workflow.

Closes #922
Closes #925

## Checklist:

- [x] Checked out the [contribution guidelines](https://github.com/starknet-io/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
- [ ] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/starknet-io/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] Updated the tests if needed; all passing - [execution info](https://github.com/starknet-io/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)