### PR TITLE
feat: log when web UI explorer is enabled on startup

### DIFF
--- a/crates/starknet-devnet/src/main.rs
+++ b/crates/starknet-devnet/src/main.rs
@@ -346,6 +346,7 @@ async fn main() -> Result<(), anyhow::Error> {
     );
 
     let api = Api::new(starknet, server_config);
+    let ui_enabled = api.server_config.ui_enabled;
     let json_rpc_handler = JsonRpcHandler::new(api.clone());
     if let Some(dump_path) = &starknet_config.dump_path {
         // Try to load events from the path. Since the same CLI parameter is used for dump and load
@@ -365,6 +366,9 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let server = serve_http_json_rpc(listener, &api.server_config, json_rpc_handler).await;
     info!("Starknet Devnet listening on {}", address);
+    if ui_enabled {
+        info!("Web UI explorer enabled at http://{}/ui", address);
+    }
 
     #[cfg(unix)]
     if let Ok(socket_path) = std::env::var("UNIX_SOCKET") {


### PR DESCRIPTION
## Usage related changes

When `--ui` flag is passed, Devnet now logs the web UI explorer URL on startup:

```
INFO: Starknet Devnet listening on 127.0.0.1:5050
INFO: Web UI explorer enabled at http://127.0.0.1:5050/ui
```

## Development related changes

- Captures `ui_enabled` from `server_config` before the config is moved into `Api::new`
- Logs with `info!` alongside the existing listening address log

## Checklist:

- [x] Performed code self-review
- [x] Compiles cleanly (`cargo check -p starknet-devnet`)
- [x] Clippy passes (`./scripts/clippy_check.sh`)